### PR TITLE
Update vendor location every second

### DIFF
--- a/mobile/locationService.js
+++ b/mobile/locationService.js
@@ -38,7 +38,7 @@ export const startLocationSharing = async (vendorId) => {
     locationSubscription = await Location.watchPositionAsync(
       {
         accuracy: Location.Accuracy.High,
-        timeInterval: 10000,       // Atualiza a cada 10 segundos
+        timeInterval: 1000,        // Atualiza a cada 1 segundo
         distanceInterval: 10,      // Ou quando se move 10 metros
       },
       async ({ coords }) => {


### PR DESCRIPTION
## Summary
- adjust the mobile location service to send updates every second

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_685468c1f5c4832eabb352120d6b894a