### PR TITLE
Increase login token lifetime

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -145,7 +145,7 @@ def _b64decode(segment: str) -> bytes:
     padded = segment + "=" * (-len(segment) % 4)
     return base64.urlsafe_b64decode(padded)
 
-def create_access_token(payload: dict, expires_sec: int = 3600) -> str:
+def create_access_token(payload: dict, expires_sec: int = 604800) -> str:
     data = payload.copy()
     data["exp"] = int(time.time()) + expires_sec
     header = {"alg": "HS256", "typ": "JWT"}


### PR DESCRIPTION
## Summary
- extend default JWT expiry to seven days

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68546b57e964832ea3d3f66a976821c6