### PR TITLE
Clear vendor location on stop

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -271,6 +271,12 @@ def test_routes_flow(client):
     assert route["distance_m"] >= 0
     assert len(route["points"]) >= 2
 
+    # vendor location should be cleared after stopping route
+    resp = client.get("/vendors/")
+    assert resp.status_code == 200
+    vendor = next(v for v in resp.json() if v["id"] == vendor_id)
+    assert vendor["current_lat"] is None and vendor["current_lng"] is None
+
     # list routes
     resp = client.get(
         f"/vendors/{vendor_id}/routes",


### PR DESCRIPTION
## Summary
- clear vendor coordinates when route stops so map removes them
- broadcast the null location via websocket
- test clearing of vendor location after stopping route

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68553676065c832ea259513e13142a47