### PR TITLE
Fix trailing slash regex in MapScreen

### DIFF
--- a/mobile/screens/MapScreen.js
+++ b/mobile/screens/MapScreen.js
@@ -166,7 +166,7 @@ export default function MapScreen({ navigation }) {
           markers={[
             ...filteredVendors.map((v) => {
               const photo = v.profile_photo
-                ? `${BASE_URL.replace(/\\/$/, '')}/${v.profile_photo}`
+                ? `${BASE_URL.replace(/\/$/, '')}/${v.profile_photo}`
                 : null;
               return {
                 latitude: v.current_lat,


### PR DESCRIPTION
## Summary
- correct regular expression when building profile photo URLs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68553f9cc1cc832eb33302d0c10d25e0