### PR TITLE
Fix location restart bug

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -131,6 +131,10 @@ def test_protected_routes(client):
     assert resp.status_code == 401
 
     # update location with auth
+    client.post(
+        f"/vendors/{vendor_id}/routes/start",
+        headers={"Authorization": f"Bearer {token}"},
+    )
     resp = client.put(
         f"/vendors/{vendor_id}/location",
         json={"lat": 1.0, "lng": 2.0},
@@ -145,6 +149,10 @@ def test_location_update_fields(client):
     confirm_latest_email(client)
     token = get_token(client)
 
+    client.post(
+        f"/vendors/{vendor_id}/routes/start",
+        headers={"Authorization": f"Bearer {token}"},
+    )
     resp = client.put(
         f"/vendors/{vendor_id}/location",
         json={"lat": 10.5, "lng": -20.3},
@@ -166,6 +174,10 @@ def test_websocket_location_broadcast(client):
     confirm_latest_email(client)
     token = get_token(client)
 
+    client.post(
+        f"/vendors/{vendor_id}/routes/start",
+        headers={"Authorization": f"Bearer {token}"},
+    )
     with client.websocket_connect("/ws/locations") as websocket:
         resp = client.put(
             f"/vendors/{vendor_id}/location",


### PR DESCRIPTION
## Summary
- require an active route to update vendor location
- adjust tests to start a route before sending location updates

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68554684f91c832e8f36bcdadb4cd519