### PR TITLE
Fix client pin visibility on map

### DIFF
--- a/mobile/screens/MapScreen.js
+++ b/mobile/screens/MapScreen.js
@@ -47,6 +47,7 @@ export default function MapScreen({ navigation }) {
   const [selectedVendorId, setSelectedVendorId] = useState(null);
   const [favoriteIds, setFavoriteIds] = useState([]);
   const [userPosition, setUserPosition] = useState(null);
+  const [mapKey, setMapKey] = useState(0);
   const mapRef = useRef(null);
 
   const fetchVendors = async () => {
@@ -118,6 +119,12 @@ export default function MapScreen({ navigation }) {
     return unsubscribe;
   }, []);
 
+  useEffect(() => {
+    if (userPosition) {
+      setMapKey((k) => k + 1);
+    }
+  }, [userPosition]);
+
   const locateUser = async (zoom = 18) => {
     try {
       const { status } = await Location.requestForegroundPermissionsAsync();
@@ -161,6 +168,7 @@ export default function MapScreen({ navigation }) {
         <ActivityIndicator animating size="large" style={StyleSheet.absoluteFill} />
       ) : (
         <LeafletMap
+          key={mapKey}
           ref={mapRef}
           initialPosition={initialPosition}
           markers={[


### PR DESCRIPTION
## Summary
- ensure map reloads when user location becomes available

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685549e7a4a0832eb94ba73c3dc3de2c