### PR TITLE
Fix map zoom resetting

### DIFF
--- a/mobile/LeafletMap.js
+++ b/mobile/LeafletMap.js
@@ -7,6 +7,7 @@ const LeafletMap = forwardRef((props, ref) => {
   const {
     markers = [],
     initialPosition = { latitude: 38.736946, longitude: -9.142685 },
+    initialZoom = 13,
     polyline = [],
   } = props;
   const webviewRef = useRef(null);
@@ -59,7 +60,7 @@ const LeafletMap = forwardRef((props, ref) => {
           var map = L.map('map').setView([
             ${initialPosition.latitude},
             ${initialPosition.longitude}
-          ], 13);
+          ], ${initialZoom});
           L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', { maxZoom: 19 }).addTo(map);
           var markers = ${JSON.stringify(markers)};
           var line = ${JSON.stringify(polyline)};

--- a/mobile/screens/MapScreen.js
+++ b/mobile/screens/MapScreen.js
@@ -48,6 +48,7 @@ export default function MapScreen({ navigation }) {
   const [favoriteIds, setFavoriteIds] = useState([]);
   const [userPosition, setUserPosition] = useState(null);
   const [mapKey, setMapKey] = useState(0);
+  const [mapZoom, setMapZoom] = useState(15);
   const mapRef = useRef(null);
   const watchRef = useRef(null);
 
@@ -158,6 +159,7 @@ useEffect(() => {
 
       if (userPosition) {
         mapRef.current?.setView(userPosition.latitude, userPosition.longitude, zoom);
+        setMapZoom(zoom);
         return;
       }
 
@@ -171,7 +173,7 @@ useEffect(() => {
       setInitialPosition(coords);
       setUserPosition(coords);
       startWatch();
-      
+
 // Remount the map so the user pin becomes visible
 setMapKey((k) => k + 1);
 
@@ -180,6 +182,7 @@ setMapKey((k) => k + 1);
         () => mapRef.current?.setView(loc.coords.latitude, loc.coords.longitude, zoom),
         100
       );
+      setMapZoom(zoom);
     } catch (err) {
       console.log('Erro ao obter localização:', err);
     }
@@ -211,6 +214,7 @@ setMapKey((k) => k + 1);
           key={mapKey}
           ref={mapRef}
           initialPosition={userPosition || initialPosition}
+          initialZoom={mapZoom}
           markers={[
             ...filteredVendors.map((v) => {
               const photo = v.profile_photo


### PR DESCRIPTION
## Summary
- preserve zoom level across map reloads by passing `initialZoom`
- handle zoom updates in `MapScreen`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68557acf3330832e855ec9c64521d233