### PR TITLE
Adjust proximity notification distance

### DIFF
--- a/mobile/screens/MapScreen.js
+++ b/mobile/screens/MapScreen.js
@@ -209,7 +209,8 @@ export default function MapScreen({ navigation }) {
         v?.name?.toLowerCase().includes(searchQuery.toLowerCase())),
   );
 
-  useProximityNotifications(filteredVendors, 500, favoriteIds);
+  // Enviar notificações quando um vendedor estiver a 20 metros
+  useProximityNotifications(filteredVendors, 20, favoriteIds);
 
   return (
     <View style={styles.container}>


### PR DESCRIPTION
## Summary
- send proximity alerts when vendors are within 20 meters

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6856dbba949c832e89bf31942526f948