### PR TITLE
Add English language selection

### DIFF
--- a/mobile/App.js
+++ b/mobile/App.js
@@ -1,5 +1,5 @@
 // App.js - ponto de entrada do aplicativo React Native com navegacao
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { Provider as PaperProvider } from 'react-native-paper';
@@ -16,11 +16,20 @@ import TermsScreen from './screens/TermsScreen';
 import PaidWeeksScreen from './screens/PaidWeeksScreen';
 import ForgotPasswordScreen from './screens/ForgotPasswordScreen';
 import { theme } from './theme';
-import t from './i18n';
+import t, { loadLanguage } from './i18n';
+import LanguageScreen from './screens/LanguageScreen';
 
 const Stack = createNativeStackNavigator();
 
 export default function App() {
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    loadLanguage().then(() => setReady(true));
+  }, []);
+
+  if (!ready) return null;
+
   return (
     <PaperProvider theme={theme}>
       <NavigationContainer>
@@ -44,6 +53,7 @@ export default function App() {
           <Stack.Screen name="PaidWeeks" component={PaidWeeksScreen} options={{ title: t('paidWeeksTitle') }} />
           <Stack.Screen name="RouteDetail" component={RouteDetailScreen} options={{ title: 'Trajeto' }} />
           <Stack.Screen name="Terms" component={TermsScreen} options={{ title: 'Termos' }} />
+          <Stack.Screen name="Language" component={LanguageScreen} options={{ title: t('languageTitle') }} />
         </Stack.Navigator>
       </NavigationContainer>
     </PaperProvider>

--- a/mobile/i18n.js
+++ b/mobile/i18n.js
@@ -1,5 +1,6 @@
 import { I18n } from 'i18n-js';
 import * as Localization from 'expo-localization';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 
 const translations = {
   en: {
@@ -9,6 +10,9 @@ const translations = {
     addFavorite: 'Add to favorites',
     removeFavorite: 'Remove favorite',
     paidWeeksTitle: 'Paid weeks',
+    languageTitle: 'Language',
+    english: 'English',
+    portuguese: 'Portuguese',
   },
   pt: {
     statsTitle: 'Estatísticas',
@@ -17,11 +21,30 @@ const translations = {
     addFavorite: 'Adicionar aos favoritos',
     removeFavorite: 'Remover favorito',
     paidWeeksTitle: 'Semanas Pagas',
+    languageTitle: 'Idioma',
+    english: 'Inglês',
+    portuguese: 'Português',
   },
 };
 
 const i18n = new I18n(translations);
-i18n.locale = Localization.locale;
 i18n.enableFallback = true;
 
-export default (key) => i18n.t(key);
+export async function loadLanguage() {
+  const stored = await AsyncStorage.getItem('language');
+  i18n.locale = stored || Localization.locale;
+}
+
+export async function setLanguage(lang) {
+  i18n.locale = lang;
+  await AsyncStorage.setItem('language', lang);
+}
+
+export async function getLanguage() {
+  const stored = await AsyncStorage.getItem('language');
+  return stored || Localization.locale;
+}
+
+export default function t(key) {
+  return i18n.t(key);
+}

--- a/mobile/screens/DashboardScreen.js
+++ b/mobile/screens/DashboardScreen.js
@@ -471,6 +471,9 @@ if (share) {
           <Button mode="text" onPress={() => { setMenuOpen(false); navigation.navigate('Stats'); }}>
             {t('statsTitle')}
           </Button>
+          <Button mode="text" onPress={() => { setMenuOpen(false); navigation.navigate('Language'); }}>
+            {t('languageTitle')}
+          </Button>
           <Button mode="text" onPress={() => { setMenuOpen(false); navigation.navigate('Terms'); }}>
             Termos e Condições
           </Button>

--- a/mobile/screens/LanguageScreen.js
+++ b/mobile/screens/LanguageScreen.js
@@ -1,0 +1,32 @@
+import React, { useEffect, useState } from 'react';
+import { View, StyleSheet } from 'react-native';
+import { RadioButton, Text } from 'react-native-paper';
+import t, { setLanguage, getLanguage } from '../i18n';
+
+export default function LanguageScreen() {
+  const [lang, setLang] = useState('en');
+
+  useEffect(() => {
+    getLanguage().then(setLang);
+  }, []);
+
+  const onChange = async (value) => {
+    setLang(value);
+    await setLanguage(value);
+  };
+
+  return (
+    <View style={styles.container} accessible accessibilityLabel={t('languageTitle')}>
+      <Text style={styles.title}>{t('languageTitle')}</Text>
+      <RadioButton.Group onValueChange={onChange} value={lang}>
+        <RadioButton.Item label={t('english')} value="en" />
+        <RadioButton.Item label={t('portuguese')} value="pt" />
+      </RadioButton.Group>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, padding: 16 },
+  title: { fontSize: 20, marginBottom: 16 },
+});


### PR DESCRIPTION
## Summary
- add AsyncStorage-based language selection utilities
- load stored language in the app entry
- create new `LanguageScreen`
- expose language choice via dashboard menu

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6857e4950c2c832eb4166f439c2be048