### PR TITLE
Add account settings page

### DIFF
--- a/mobile/App.js
+++ b/mobile/App.js
@@ -15,6 +15,7 @@ import StatsScreen from './screens/StatsScreen';
 import TermsScreen from './screens/TermsScreen';
 import PaidWeeksScreen from './screens/PaidWeeksScreen';
 import ForgotPasswordScreen from './screens/ForgotPasswordScreen';
+import AccountSettingsScreen from './screens/AccountSettingsScreen';
 import { theme } from './theme';
 import t, { loadLanguage } from './i18n';
 import LanguageScreen from './screens/LanguageScreen';
@@ -53,6 +54,7 @@ export default function App() {
           <Stack.Screen name="PaidWeeks" component={PaidWeeksScreen} options={{ title: t('paidWeeksTitle') }} />
           <Stack.Screen name="RouteDetail" component={RouteDetailScreen} options={{ title: 'Trajeto' }} />
           <Stack.Screen name="Terms" component={TermsScreen} options={{ title: 'Termos' }} />
+          <Stack.Screen name="AccountSettings" component={AccountSettingsScreen} options={{ title: t('accountSettingsTitle') }} />
           <Stack.Screen name="Language" component={LanguageScreen} options={{ title: t('languageTitle') }} />
         </Stack.Navigator>
       </NavigationContainer>

--- a/mobile/i18n.js
+++ b/mobile/i18n.js
@@ -13,6 +13,9 @@ const translations = {
     languageTitle: 'Language',
     english: 'English',
     portuguese: 'Portuguese',
+    accountSettingsTitle: 'Account Settings',
+    notificationsEnabled: 'Enable notifications',
+    notificationRadius: 'Notification radius (m)',
   },
   pt: {
     statsTitle: 'Estatísticas',
@@ -24,6 +27,9 @@ const translations = {
     languageTitle: 'Idioma',
     english: 'Inglês',
     portuguese: 'Português',
+    accountSettingsTitle: 'Definições de Conta',
+    notificationsEnabled: 'Ativar notificações',
+    notificationRadius: 'Raio para notificações (m)',
   },
 };
 

--- a/mobile/screens/AccountSettingsScreen.js
+++ b/mobile/screens/AccountSettingsScreen.js
@@ -1,0 +1,64 @@
+import React, { useEffect, useState } from 'react';
+import { View, StyleSheet } from 'react-native';
+import { Switch, Text, TextInput } from 'react-native-paper';
+import {
+  isNotificationsEnabled,
+  setNotificationsEnabled,
+  getNotificationRadius,
+  setNotificationRadius,
+} from '../settingsService';
+import { theme } from '../theme';
+import t from '../i18n';
+
+export default function AccountSettingsScreen() {
+  const [enabled, setEnabled] = useState(true);
+  const [radius, setRadius] = useState('20');
+
+  useEffect(() => {
+    const load = async () => {
+      setEnabled(await isNotificationsEnabled());
+      const r = await getNotificationRadius();
+      setRadius(String(r));
+    };
+    load();
+  }, []);
+
+  const toggleNotifications = async () => {
+    const val = !enabled;
+    setEnabled(val);
+    await setNotificationsEnabled(val);
+  };
+
+  const changeRadius = async (value) => {
+    setRadius(value);
+    const num = parseInt(value, 10);
+    if (!isNaN(num)) {
+      await setNotificationRadius(num);
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>{t('accountSettingsTitle')}</Text>
+      <View style={styles.row}>
+        <Text>{t('notificationsEnabled')}</Text>
+        <Switch value={enabled} onValueChange={toggleNotifications} />
+      </View>
+      <TextInput
+        mode="outlined"
+        style={styles.input}
+        label={t('notificationRadius')}
+        keyboardType="numeric"
+        value={radius}
+        onChangeText={changeRadius}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, padding: 16, backgroundColor: theme.colors.background },
+  title: { fontSize: 20, marginBottom: 16 },
+  row: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', marginBottom: 16 },
+  input: { marginBottom: 16 },
+});

--- a/mobile/screens/DashboardScreen.js
+++ b/mobile/screens/DashboardScreen.js
@@ -485,6 +485,9 @@ if (share) {
           <Button mode="text" onPress={() => { setMenuOpen(false); navigation.navigate('Stats'); }}>
             {t('statsTitle')}
           </Button>
+          <Button mode="text" onPress={() => { setMenuOpen(false); navigation.navigate('AccountSettings'); }}>
+            {t('accountSettingsTitle')}
+          </Button>
           <Button mode="text" onPress={() => { setMenuOpen(false); navigation.navigate('Language'); }}>
             {t('languageTitle')}
           </Button>

--- a/mobile/screens/MapScreen.js
+++ b/mobile/screens/MapScreen.js
@@ -15,6 +15,7 @@ import LeafletMap from "../LeafletMap";
 import axios from "axios";
 import { BASE_URL } from "../config";
 import { theme } from "../theme";
+import { isNotificationsEnabled, getNotificationRadius } from "../settingsService";
 import { subscribe as subscribeLocations } from "../socketService";
 import {
   startLocationSharing,
@@ -40,6 +41,8 @@ export default function MapScreen({ navigation }) {
   const [userPosition, setUserPosition] = useState(null);
   const [mapKey, setMapKey] = useState(0);
   const [zoomLevel, setZoomLevel] = useState(13);
+  const [notifEnabled, setNotifEnabled] = useState(true);
+  const [notifRadius, setNotifRadius] = useState(20);
   const mapRef = useRef(null);
   const watchRef = useRef(null);
 
@@ -201,6 +204,14 @@ export default function MapScreen({ navigation }) {
     init();
   }, []);
 
+  useEffect(() => {
+    const load = async () => {
+      setNotifEnabled(await isNotificationsEnabled());
+      setNotifRadius(await getNotificationRadius());
+    };
+    load();
+  }, []);
+
   const activeVendors = vendors.filter(
     (v) => v?.current_lat != null && v?.current_lng != null,
   );
@@ -212,8 +223,8 @@ export default function MapScreen({ navigation }) {
         v?.name?.toLowerCase().includes(searchQuery.toLowerCase())),
   );
 
-  // Enviar notificações quando um vendedor estiver a 20 metros
-  useProximityNotifications(filteredVendors, 20, favoriteIds);
+  // Enviar notificações de proximidade se estiver ativo
+  useProximityNotifications(filteredVendors, notifRadius, favoriteIds, notifEnabled);
 
   return (
     <View style={styles.container}>

--- a/mobile/settingsService.js
+++ b/mobile/settingsService.js
@@ -1,0 +1,22 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const ENABLED_KEY = 'notifications_enabled';
+const RADIUS_KEY = 'notification_radius';
+
+export async function isNotificationsEnabled() {
+  const val = await AsyncStorage.getItem(ENABLED_KEY);
+  return val !== 'false';
+}
+
+export async function setNotificationsEnabled(enabled) {
+  await AsyncStorage.setItem(ENABLED_KEY, enabled ? 'true' : 'false');
+}
+
+export async function getNotificationRadius() {
+  const val = await AsyncStorage.getItem(RADIUS_KEY);
+  return val ? parseInt(val, 10) : 20;
+}
+
+export async function setNotificationRadius(radius) {
+  await AsyncStorage.setItem(RADIUS_KEY, String(radius));
+}

--- a/mobile/useProximityNotifications.js
+++ b/mobile/useProximityNotifications.js
@@ -19,9 +19,11 @@ function distanceMeters(lat1, lon1, lat2, lon2) {
 export default function useProximityNotifications(
   vendors,
   radius = 500,
-  favoriteIds = []
+  favoriteIds = [],
+  enabled = true
 ) {
   useEffect(() => {
+    if (!enabled) return;
     let sub;
     const start = async () => {
       const { status } = await Location.requestForegroundPermissionsAsync();
@@ -64,5 +66,5 @@ export default function useProximityNotifications(
     return () => {
       sub && sub.remove();
     };
-  }, [vendors, radius, favoriteIds]);
+  }, [vendors, radius, favoriteIds, enabled]);
 }


### PR DESCRIPTION
## Summary
- add account settings screen with notification preferences
- handle notification settings in map screen
- expose new translation strings
- include new screen in navigation and menu

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685973c99d2c832e9afeb0cbb54eef9a