### PR TITLE
Add client notification radius option

### DIFF
--- a/mobile/screens/ClientDashboardScreen.js
+++ b/mobile/screens/ClientDashboardScreen.js
@@ -7,6 +7,7 @@ import axios from 'axios';
 import { BASE_URL } from '../config';
 import { getFavorites } from '../favoritesService';
 import { theme } from '../theme';
+import t from '../i18n';
 
 export default function ClientDashboardScreen({ navigation }) {
   const [favorites, setFavorites] = useState([]);
@@ -61,6 +62,13 @@ export default function ClientDashboardScreen({ navigation }) {
           );
         }}
       />
+      <Button
+        mode="outlined"
+        onPress={() => navigation.navigate('AccountSettings')}
+        style={styles.settings}
+      >
+        {t('accountSettingsTitle')}
+      </Button>
       <Button mode="outlined" onPress={logout} style={styles.logout}>
         Sair
       </Button>
@@ -79,5 +87,6 @@ const styles = StyleSheet.create({
     borderBottomColor: '#ccc',
   },
   image: { width: 40, height: 40, borderRadius: 20, marginRight: 8 },
+  settings: { marginTop: 20 },
   logout: { marginTop: 20 },
 });

--- a/mobile/screens/DashboardScreen.js
+++ b/mobile/screens/DashboardScreen.js
@@ -485,9 +485,6 @@ if (share) {
           <Button mode="text" onPress={() => { setMenuOpen(false); navigation.navigate('Stats'); }}>
             {t('statsTitle')}
           </Button>
-          <Button mode="text" onPress={() => { setMenuOpen(false); navigation.navigate('AccountSettings'); }}>
-            {t('accountSettingsTitle')}
-          </Button>
           <Button mode="text" onPress={() => { setMenuOpen(false); navigation.navigate('Language'); }}>
             {t('languageTitle')}
           </Button>


### PR DESCRIPTION
## Summary
- allow clients to configure notification radius in the dashboard
- remove notification radius option from vendor dashboard

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685aa5b27ac4832eaaf1738c038c30b9