### PR TITLE
Fix map route

### DIFF
--- a/sunny_sales_web/src/App.jsx
+++ b/sunny_sales_web/src/App.jsx
@@ -33,7 +33,7 @@ return (
   </div>
 
   <Routes>
-    <Route path="/" element={<h2 style={styles.home}>Bem-vindo à Sunny Sales!</h2>} />
+    <Route path="/" element={<MapScreen />} />
     <Route path="/about" element={<About />} />
     <Route path="/settings" element={<AccountSettings />} />
     <Route path="/login" element={<ClientLogin />} />


### PR DESCRIPTION
## Summary
- set the main page to show the map

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68626da73788832e9d652768b29a59a6