### PR TITLE
Fix module import path

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -9,7 +9,7 @@ from passlib.context import CryptContext
 from . import models, schemas
 import stripe
 from datetime import datetime, timedelta
-from app.database import SessionLocal, engine, get_db
+from .database import SessionLocal, engine, get_db
 import os
 import shutil
 from uuid import uuid4


### PR DESCRIPTION
## Summary
- fix database import path to be package-relative

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68627577cb08832eb6378930bcd68ca6