### PR TITLE
Fix page width on desktop by adjusting root style

### DIFF
--- a/sunny_sales_web/src/App.css
+++ b/sunny_sales_web/src/App.css
@@ -2,8 +2,9 @@
 @import 'leaflet/dist/leaflet.css';
 
 #root {
-  max-width: 1280px;
-  margin: 0 auto;
+  /* Expande para toda a largura no desktop e adapta-se em ecrãs menores */
+  width: 100%;
+  margin: 0;
   padding: 2rem;
   text-align: center;
 }


### PR DESCRIPTION
## Summary
- update `App.css` so `#root` spans the full width

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68627dfb5838832e92e7eb740698250e