### PR TITLE
Adjust web map screen and vendor dashboard

### DIFF
--- a/sunny_sales_web/src/App.jsx
+++ b/sunny_sales_web/src/App.jsx
@@ -25,11 +25,7 @@ export default function App() {
     <Router>
       {/* (em português) Barra de navegação */}
       <div style={styles.navbar}>
-        <Link style={styles.link} to="/">🏖️ Sunny Sales</Link>
-        <div>
-          <Link style={styles.link} to="/about">Sobre</Link>
-          <Link style={styles.link} to="/settings">Definições</Link>
-        </div>
+        <Link style={styles.link} to="/">Sunny Sales</Link>
       </div>
 
       {/* (em português) Container central da aplicação */}

--- a/sunny_sales_web/src/pages/MapScreen.jsx
+++ b/sunny_sales_web/src/pages/MapScreen.jsx
@@ -92,7 +92,7 @@ export default function MapScreenWeb() {
 
   return (
     <div style={{ padding: '1rem', position: 'relative' }}>
-      <h2>🌞 Localização dos Vendedores</h2>
+      <h2>Localização dos Vendedores</h2>
 
       <div style={{ marginBottom: '1rem' }}>
         <select
@@ -155,11 +155,13 @@ export default function MapScreenWeb() {
         </MapContainer>
       </div>
 
+      <button style={styles.locateButton} onClick={locateUser}>📍</button>
+
       <button
         style={styles.vendorIcon}
         onClick={() => navigate(vendorUser ? '/dashboard' : '/vendor-login')}
       >
-        🧑‍💼
+        👤
       </button>
 
       <div style={styles.buttonsContainer}>
@@ -189,6 +191,16 @@ const styles = {
   vendorIcon: {
     position: 'absolute',
     top: 10,
+    right: 10,
+    backgroundColor: '#fff',
+    border: '1px solid #ccc',
+    borderRadius: '50%',
+    padding: '0.5rem',
+    cursor: 'pointer',
+  },
+  locateButton: {
+    position: 'absolute',
+    bottom: 80,
     right: 10,
     backgroundColor: '#fff',
     border: '1px solid #ccc',

--- a/sunny_sales_web/src/pages/VendorDashboard.jsx
+++ b/sunny_sales_web/src/pages/VendorDashboard.jsx
@@ -1,9 +1,14 @@
 import React, { useEffect, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { BASE_URL } from '../config';
+import axios from 'axios';
+
+let watchId = null;
 
 export default function VendorDashboard() {
   const [vendor, setVendor] = useState(null);
+  const [sharing, setSharing] = useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
   const navigate = useNavigate();
 
   // carrega dados do vendedor guardados no localStorage
@@ -12,6 +17,8 @@ export default function VendorDashboard() {
     if (stored) {
       setVendor(JSON.parse(stored));
     }
+    const share = localStorage.getItem('sharingLocation') === 'true';
+    setSharing(share);
   }, []);
 
   const logout = () => {
@@ -20,8 +27,60 @@ export default function VendorDashboard() {
     navigate('/vendor-login');
   };
 
+  const startSharing = async () => {
+    if (!vendor) return;
+    const token = localStorage.getItem('token');
+    if (!token) return;
+    try {
+      await axios.post(`${BASE_URL}/vendors/${vendor.id}/routes/start`, null, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      watchId = navigator.geolocation.watchPosition(
+        async (pos) => {
+          try {
+            await axios.put(
+              `${BASE_URL}/vendors/${vendor.id}/location`,
+              { lat: pos.coords.latitude, lng: pos.coords.longitude },
+              { headers: { Authorization: `Bearer ${token}` } }
+            );
+          } catch (err) {
+            console.log('Erro ao enviar localização:', err);
+          }
+        },
+        (err) => console.log('Erro localização:', err),
+        { enableHighAccuracy: true }
+      );
+      localStorage.setItem('sharingLocation', 'true');
+      setSharing(true);
+    } catch (err) {
+      console.log('Erro ao ativar localização:', err);
+    }
+  };
+
+  const stopSharing = async () => {
+    if (watchId) {
+      navigator.geolocation.clearWatch(watchId);
+      watchId = null;
+    }
+    if (vendor) {
+      const token = localStorage.getItem('token');
+      if (token) {
+        try {
+          await axios.post(`${BASE_URL}/vendors/${vendor.id}/routes/stop`, null, {
+            headers: { Authorization: `Bearer ${token}` },
+          });
+        } catch (err) {
+          console.log('Erro ao parar localização:', err);
+        }
+      }
+    }
+    localStorage.setItem('sharingLocation', 'false');
+    setSharing(false);
+  };
+
   return (
     <div style={styles.container}>
+      <button style={styles.menuButton} onClick={() => setMenuOpen(!menuOpen)}>☰</button>
       <h2 style={styles.title}>Painel do Vendedor</h2>
       {vendor && (
         <>
@@ -33,20 +92,33 @@ export default function VendorDashboard() {
             />
           )}
           <p><strong>Nome:</strong> {vendor.name}</p>
+          <p><strong>Email:</strong> {vendor.email}</p>
           <p><strong>Produto:</strong> {vendor.product}</p>
-          {vendor.subscription_active && (
-            <p style={styles.subActive}>Subscrição ativa</p>
-          )}
+          <p>
+            <strong>Cor do Pin:</strong>
+            <span style={{ ...styles.pinPreview, backgroundColor: vendor.pin_color || '#FFB6C1' }} />
+          </p>
+          <p>
+            <strong>Subscrição:</strong>{' '}
+            {vendor.subscription_active ? 'ativa' : 'inativa'}
+          </p>
         </>
       )}
 
-      <div style={styles.links}>
-        <Link style={styles.link} to="/routes">Trajetos</Link>
-        <Link style={styles.link} to="/paid-weeks">Semanas Pagas</Link>
-        <Link style={styles.link} to="/stats">Estatísticas</Link>
-        <Link style={styles.link} to="/account">Conta</Link>
-      </div>
+      <button style={styles.shareButton} onClick={sharing ? stopSharing : startSharing}>
+        {sharing ? 'Desativar Localização' : 'Ativar Localização'}
+      </button>
+
       <button style={styles.logout} onClick={logout}>Sair</button>
+
+      {menuOpen && (
+        <div style={styles.menu} onClick={() => setMenuOpen(false)}>
+          <Link style={styles.link} to="/routes">Trajetos</Link>
+          <Link style={styles.link} to="/paid-weeks">Semanas Pagas</Link>
+          <Link style={styles.link} to="/stats">Estatísticas</Link>
+          <Link style={styles.link} to="/account">Conta</Link>
+        </div>
+      )}
     </div>
   );
 }
@@ -68,12 +140,6 @@ const styles = {
     objectFit: 'cover',
     marginBottom: '1rem',
   },
-  links: {
-    display: 'flex',
-    flexDirection: 'column',
-    gap: '0.5rem',
-    margin: '1rem 0',
-  },
   link: {
     textDecoration: 'none',
     color: '#0077cc',
@@ -89,5 +155,44 @@ const styles = {
     borderRadius: '8px',
     backgroundColor: '#f9c200',
     cursor: 'pointer',
+  },
+  shareButton: {
+    marginTop: '1rem',
+    padding: '0.5rem 1rem',
+    border: 'none',
+    borderRadius: '8px',
+    backgroundColor: '#f9c200',
+    cursor: 'pointer',
+  },
+  menuButton: {
+    position: 'absolute',
+    top: 16,
+    left: 16,
+    backgroundColor: '#fff',
+    border: '1px solid #ccc',
+    borderRadius: '50%',
+    padding: '0.5rem',
+    cursor: 'pointer',
+  },
+  menu: {
+    position: 'absolute',
+    top: 60,
+    left: 16,
+    right: 16,
+    backgroundColor: '#fff',
+    border: '1px solid #ccc',
+    borderRadius: '8px',
+    padding: '1rem',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '0.5rem',
+  },
+  pinPreview: {
+    display: 'inline-block',
+    width: 16,
+    height: 16,
+    borderRadius: '50%',
+    marginLeft: 8,
+    verticalAlign: 'middle',
   },
 };


### PR DESCRIPTION
## Summary
- simplify header navigation
- clean up MapScreen visuals and add location zoom button
- redesign vendor dashboard with hamburger menu and location sharing controls

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686294ab9754832e8c57146b2ca9e149