### PR TITLE
Update MapScreen filter UI

### DIFF
--- a/mobile/screens/MapScreen.js
+++ b/mobile/screens/MapScreen.js
@@ -337,7 +337,25 @@ export default function MapScreen({ navigation }) {
       )}
 
       <View style={styles.filterContainer}>
-        <View style={styles.checkboxRow}>
+        <View style={styles.checkboxColumn}>
+          <TouchableOpacity
+            key="all"
+            style={styles.checkboxItem}
+            onPress={() =>
+              setSelectedProducts((prev) =>
+                prev.length === PRODUCTS.length ? [] : [...PRODUCTS],
+              )
+            }
+          >
+            <Checkbox
+              status={
+                selectedProducts.length === PRODUCTS.length
+                  ? "checked"
+                  : "unchecked"
+              }
+            />
+            <Text>Todos</Text>
+          </TouchableOpacity>
           {PRODUCTS.map((p) => (
             <TouchableOpacity
               key={p}
@@ -498,9 +516,8 @@ const styles = StyleSheet.create({
     borderRadius: 16,
     padding: 6,
   },
-  checkboxRow: {
-    flexDirection: "row",
-    justifyContent: "space-around",
+  checkboxColumn: {
+    flexDirection: "column",
     marginBottom: 4,
   },
   checkboxItem: { flexDirection: "row", alignItems: "center" },


### PR DESCRIPTION
## Summary
- modernize product filters on map screen with select-all checkbox
- arrange product filters vertically for cleaner look

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6863d6e4cb48832ea2056cebb48d2bb3