### PR TITLE
Update MapScreen web filters

### DIFF
--- a/mobile/screens/MapScreen.js
+++ b/mobile/screens/MapScreen.js
@@ -337,7 +337,25 @@ export default function MapScreen({ navigation }) {
       )}
 
       <View style={styles.filterContainer}>
-        <View style={styles.checkboxRow}>
+        <View style={styles.checkboxColumn}>
+          <TouchableOpacity
+            key="all"
+            style={styles.checkboxItem}
+            onPress={() =>
+              setSelectedProducts((prev) =>
+                prev.length === PRODUCTS.length ? [] : [...PRODUCTS],
+              )
+            }
+          >
+            <Checkbox
+              status={
+                selectedProducts.length === PRODUCTS.length
+                  ? "checked"
+                  : "unchecked"
+              }
+            />
+            <Text>Todos</Text>
+          </TouchableOpacity>
           {PRODUCTS.map((p) => (
             <TouchableOpacity
               key={p}
@@ -498,9 +516,8 @@ const styles = StyleSheet.create({
     borderRadius: 16,
     padding: 6,
   },
-  checkboxRow: {
-    flexDirection: "row",
-    justifyContent: "space-around",
+  checkboxColumn: {
+    flexDirection: "column",
     marginBottom: 4,
   },
   checkboxItem: { flexDirection: "row", alignItems: "center" },

--- a/sunny_sales_web/src/pages/MapScreen.css
+++ b/sunny_sales_web/src/pages/MapScreen.css
@@ -1,9 +1,9 @@
 /* (em português) Estilo da barra de filtros */
 .filter-container {
   display: flex;
-  flex-wrap: wrap;
-  gap: 1rem;
-  align-items: center;
+  flex-direction: column;
+  gap: 0.5rem;
+  align-items: flex-start;
   margin-bottom: 1rem;
 }
 

--- a/sunny_sales_web/src/pages/MapScreen.jsx
+++ b/sunny_sales_web/src/pages/MapScreen.jsx
@@ -86,6 +86,21 @@ export default function MapScreenWeb() {
       <h2>Localização dos Vendedores</h2>
 
       <div className="filter-container">
+        <label key="all" className="checkbox-container">
+          Todos
+          <input
+            type="checkbox"
+            className="custom-checkbox"
+            checked={selectedProducts.length === PRODUCTS.length}
+            onChange={() =>
+              setSelectedProducts((prev) =>
+                prev.length === PRODUCTS.length ? [] : [...PRODUCTS]
+              )
+            }
+          />
+          <span className="checkmark"></span>
+        </label>
+
         {PRODUCTS.map((p) => (
           <label key={p} className="checkbox-container">
             {p}


### PR DESCRIPTION
## Summary
- allow selecting all products on MapScreen web filter
- stack filters vertically for improved layout

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6863d6e4cb48832ea2056cebb48d2bb3