### PR TITLE
Add resort themed map page

### DIFF
--- a/sunny_sales_web/public/resort-map.html
+++ b/sunny_sales_web/public/resort-map.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="pt">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Mapa Resort</title>
+    <link rel="stylesheet" href="resort-style.css">
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+</head>
+<body>
+    <header class="main-header">
+        <img src="logo.png" alt="Logo" class="logo">
+        <nav>
+            <ul>
+                <li><a href="#">Início</a></li>
+                <li><a href="#">Vendedores</a></li>
+                <li><a href="#">Mapa</a></li>
+                <li><a href="#">Sobre</a></li>
+            </ul>
+        </nav>
+    </header>
+
+    <img src="palm-left.svg" class="decor decor-left" alt="">
+    <img src="palm-right.svg" class="decor decor-right" alt="">
+
+    <div class="map-wrapper">
+        <div id="map"></div>
+    </div>
+
+    <script>
+        // Exemplo de inicialização do mapa (pode ser removido se já existir no projeto)
+        var map = L.map('map').setView([38.7169, -9.1399], 13);
+        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+            maxZoom: 19
+        }).addTo(map);
+    </script>
+</body>
+</html>

--- a/sunny_sales_web/public/resort-style.css
+++ b/sunny_sales_web/public/resort-style.css
@@ -1,0 +1,73 @@
+body {
+    margin: 0;
+    font-family: Arial, Helvetica, sans-serif;
+    background: #f9f3e7;
+    /* Opcional textura de areia */
+    /* background-image: url('sand-texture.png'); */
+    background-size: cover;
+}
+
+.main-header {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 60px;
+    background: rgba(255, 255, 255, 0.85);
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+    display: flex;
+    align-items: center;
+    padding: 0 1rem;
+    z-index: 1000;
+}
+
+.main-header .logo {
+    height: 40px;
+    margin-right: 1rem;
+}
+
+.main-header nav ul {
+    list-style: none;
+    display: flex;
+    gap: 1.5rem;
+    margin: 0;
+    padding: 0;
+}
+
+.main-header nav a {
+    text-decoration: none;
+    color: #333;
+    font-weight: bold;
+}
+
+.map-wrapper {
+    width: 90%;
+    margin: 80px auto 40px; /* deixa espaço para o cabeçalho */
+    height: 80vh;
+    background: #fff;
+    border-radius: 20px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+    overflow: hidden;
+    position: relative;
+}
+
+#map {
+    width: 100%;
+    height: 100%;
+}
+
+.decor {
+    position: absolute;
+    pointer-events: none;
+    z-index: 500;
+}
+
+.decor-left {
+    left: 0;
+    bottom: 0;
+}
+
+.decor-right {
+    right: 0;
+    top: 0;
+}


### PR DESCRIPTION
## Summary
- add standalone `resort-map.html` page
- provide `resort-style.css` with fixed header and map container styles

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68651ce5f610832ebdb2897e12fe19dd