### PR TITLE
Add modern map layout page

### DIFF
--- a/sunny_sales_web/src/App.jsx
+++ b/sunny_sales_web/src/App.jsx
@@ -18,6 +18,7 @@ import TermsScreen from './pages/TermsScreen';
 import VendorDetailScreen from './pages/VendorDetailScreen';
 import Invoices from './pages/Invoices';
 import Dashboard from './pages/Dashboard';
+import ModernMapLayout from './pages/ModernMapLayout';
 import './index.css'; // (em português) Importa os estilos globais
 
 export default function App() {
@@ -42,6 +43,7 @@ export default function App() {
           <Route path="/paid-weeks" element={<PaidWeeksScreen />} />
           <Route path="/invoices" element={<Invoices />} />
           <Route path="/map" element={<MapScreen />} />
+          <Route path="/modern-map" element={<ModernMapLayout />} />
           <Route path="/vendor-register" element={<VendorRegister />} />
           <Route path="/route-detail" element={<RouteDetail />} />
           <Route path="/routes" element={<RoutesScreen />} />

--- a/sunny_sales_web/src/pages/ModernMapLayout.css
+++ b/sunny_sales_web/src/pages/ModernMapLayout.css
@@ -1,0 +1,179 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap');
+
+/* Layout geral dividindo sidebar e mapa */
+.layout {
+  display: flex;
+  height: 100vh;
+  background: #f0f4f8;
+  font-family: 'Inter', sans-serif;
+}
+
+/* Sidebar fixa à esquerda */
+.sidebar {
+  width: 280px;
+  padding: 16px;
+  background: #ffffff;
+  border-right: 1px solid #dee2e6;
+  box-sizing: border-box;
+  overflow-y: auto;
+}
+
+.sidebar-title {
+  margin-top: 0;
+  margin-bottom: 20px;
+  font-size: 1.5rem;
+  color: #212529;
+}
+
+.search-input {
+  width: 100%;
+  padding: 0.5rem;
+  border: 1px solid #dee2e6;
+  border-radius: 8px;
+  margin-bottom: 20px;
+  font-size: 0.95rem;
+}
+
+.section {
+  margin-bottom: 20px;
+}
+
+.section-title {
+  font-size: 1rem;
+  margin: 0 0 8px 0;
+  color: #212529;
+}
+
+.vendor-list {
+  list-style: none;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.vendor-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  cursor: pointer;
+}
+
+.vendor-info {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.avatar {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  object-fit: cover;
+}
+
+.vendor-name {
+  color: #212529;
+  font-size: 0.95rem;
+}
+
+.vendor-time {
+  font-size: 0.8rem;
+  color: #6c757d;
+}
+
+/* Área do mapa */
+.map-area {
+  flex: 1;
+  position: relative;
+}
+
+#map {
+  height: 100%;
+  width: 100%;
+  background: #e6eef5;
+}
+
+/* Cartão flutuante do vendedor */
+.vendor-card {
+  position: absolute;
+  bottom: 20px;
+  right: 20px;
+  width: 260px;
+  padding: 1rem;
+  background: #ffffff;
+  border: 1px solid #dee2e6;
+  border-radius: 16px;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+}
+
+.card-header {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.card-photo {
+  width: 80px;
+  height: 80px;
+  border-radius: 50%;
+  object-fit: cover;
+}
+
+.badge {
+  background: #28a745;
+  color: #fff;
+  font-size: 0.8rem;
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+
+.card-name {
+  margin: 0 0 4px 0;
+  font-weight: bold;
+  color: #212529;
+}
+
+.card-id {
+  margin: 0 0 8px 0;
+  color: #6c757d;
+  font-size: 0.8rem;
+}
+
+.card-stats {
+  margin: 0 0 1rem 0;
+  font-size: 0.95rem;
+  color: #212529;
+}
+
+.map-btn {
+  background: #00c48c;
+  color: #fff;
+  border: none;
+  padding: 0.5rem 1rem;
+  width: 100%;
+  cursor: pointer;
+  border-radius: 8px;
+  font-weight: bold;
+}
+
+.map-btn:hover {
+  background: #00a97d;
+}
+
+/* Responsivo */
+@media (max-width: 768px) {
+  .layout {
+    flex-direction: column;
+  }
+  .sidebar {
+    width: 100%;
+    height: auto;
+  }
+  .vendor-card {
+    left: 50%;
+    right: auto;
+    transform: translateX(-50%);
+  }
+}

--- a/sunny_sales_web/src/pages/ModernMapLayout.jsx
+++ b/sunny_sales_web/src/pages/ModernMapLayout.jsx
@@ -1,0 +1,165 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { MapContainer, TileLayer, Marker, Popup } from 'react-leaflet';
+import L from 'leaflet';
+import axios from 'axios';
+import { BASE_URL } from '../config';
+import './ModernMapLayout.css';
+
+// Componente principal que implementa o layout moderno com sidebar, mapa e cartão flutuante
+export default function ModernMapLayout() {
+  const [vendors, setVendors] = useState([]);
+  const [search, setSearch] = useState('');
+  const [selected, setSelected] = useState(null);
+  const mapRef = useRef(null);
+
+  // Carrega vendedores do backend
+  const fetchVendors = async () => {
+    try {
+      const res = await axios.get(`${BASE_URL}/vendors/`);
+      setVendors(res.data);
+    } catch (err) {
+      console.error('Erro ao carregar vendedores:', err);
+    }
+  };
+
+  useEffect(() => {
+    fetchVendors();
+  }, []);
+
+  // Lista de favoritos guardada no localStorage
+  const favoriteIds = JSON.parse(localStorage.getItem('favorites') || '[]');
+  const favorites = vendors.filter((v) => favoriteIds.includes(v.id));
+
+  const activeVendors = vendors.filter((v) => v.current_lat && v.current_lng);
+
+  const filteredActive = activeVendors.filter((v) =>
+    v.name?.toLowerCase().includes(search.toLowerCase())
+  );
+
+  const focusVendor = (v) => {
+    setSelected(v);
+    if (mapRef.current) {
+      mapRef.current.setView([v.current_lat, v.current_lng], 16);
+    }
+  };
+
+  return (
+    <div className="layout">
+      {/* Sidebar lateral esquerda */}
+      <aside className="sidebar">
+        <h2 className="sidebar-title">Vendedores</h2>
+        <input
+          className="search-input"
+          type="text"
+          placeholder="Filtrar..."
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+        />
+
+        <div className="section">
+          <h3 className="section-title">Ativos</h3>
+          <ul className="vendor-list">
+            {filteredActive.map((v) => (
+              <li key={v.id} className="vendor-item" onClick={() => focusVendor(v)}>
+                <div className="vendor-info">
+                  {v.profile_photo ? (
+                    <img
+                      src={`${BASE_URL}/${v.profile_photo}`}
+                      alt={v.name}
+                      className="avatar"
+                    />
+                  ) : (
+                    <div className="avatar" style={{ background: v.pin_color || '#ccc' }} />
+                  )}
+                  <span className="vendor-name">{v.name}</span>
+                </div>
+                <span className="vendor-time">~{v.approx_time || '--'}m</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        <div className="section">
+          <h3 className="section-title">Favoritos</h3>
+          <ul className="vendor-list">
+            {favorites.map((v) => (
+              <li key={v.id} className="vendor-item" onClick={() => focusVendor(v)}>
+                <div className="vendor-info">
+                  {v.profile_photo ? (
+                    <img
+                      src={`${BASE_URL}/${v.profile_photo}`}
+                      alt={v.name}
+                      className="avatar"
+                    />
+                  ) : (
+                    <div className="avatar" style={{ background: v.pin_color || '#ccc' }} />
+                  )}
+                  <span className="vendor-name">{v.name}</span>
+                </div>
+                <span className="vendor-time">★</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </aside>
+
+      {/* Área principal do mapa */}
+      <main className="map-area">
+        <MapContainer
+          center={[38.7169, -9.1399]}
+          zoom={13}
+          style={{ height: '100%', width: '100%' }}
+          whenCreated={(map) => {
+            mapRef.current = map;
+          }}
+        >
+          <TileLayer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" />
+          {activeVendors.map((v) => (
+            <Marker
+              key={v.id}
+              position={[v.current_lat, v.current_lng]}
+              icon={L.divIcon({
+                className: 'vendor-pin',
+                html: `<div style="background:${v.pin_color || '#FFB6C1'};width:16px;height:16px;border-radius:50%;"></div>`,
+              })}
+              eventHandlers={{
+                click: () => focusVendor(v),
+              }}
+            >
+              <Popup>{v.name}</Popup>
+            </Marker>
+          ))}
+        </MapContainer>
+
+        {selected && (
+          <div className="vendor-card">
+            <div className="card-header">
+              {selected.profile_photo ? (
+                <img
+                  src={`${BASE_URL}/${selected.profile_photo}`}
+                  alt={selected.name}
+                  className="card-photo"
+                />
+              ) : (
+                <div
+                  className="card-photo"
+                  style={{ background: selected.pin_color || '#ccc' }}
+                />
+              )}
+              <span className="badge">Ativo</span>
+            </div>
+            <h4 className="card-name">{selected.name}</h4>
+            <p className="card-id">#{selected.id}</p>
+            <p className="card-stats">
+              📍 {selected.locations_count || 0} &nbsp; ⭐{' '}
+              {selected.rating_average ? selected.rating_average.toFixed(1) : '--'}
+            </p>
+            <button className="map-btn" onClick={() => focusVendor(selected)}>
+              VER NO MAPA
+            </button>
+          </div>
+        )}
+      </main>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- create `ModernMapLayout` page to showcase a sidebar, map and floating vendor card
- style layout with new `ModernMapLayout.css`
- register new route `/modern-map`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686533f729b4832eb6428a430b758fa6