### PR TITLE
Update header and add product filters

### DIFF
--- a/sunny_sales_web/src/App.jsx
+++ b/sunny_sales_web/src/App.jsx
@@ -24,9 +24,15 @@ export default function App() {
   return (
     <Router>
       {/* (em português) Barra de navegação */}
-      <div style={styles.navbar}>
-        <Link style={styles.link} to="/">Sunny Sales</Link>
-      </div>
+      <header style={styles.navbar}>
+        <Link style={styles.logo} to="/">Sunny Sales</Link>
+        <nav style={styles.navLinks}>
+          <Link style={styles.navLink} to="/vendor-login">Login Vendedor</Link>
+          <Link style={styles.navLink} to="/vendor-register">Registar Vendedor</Link>
+          <Link style={styles.navLink} to="/login">Login Cliente</Link>
+          <Link style={styles.navLink} to="/register">Registar Cliente</Link>
+        </nav>
+      </header>
 
       {/* (em português) Container central da aplicação */}
       <div className="container">
@@ -62,14 +68,23 @@ const styles = {
   navbar: {
     display: 'flex',
     justifyContent: 'space-between',
-    padding: '1rem 2rem',
+    padding: '1.5rem 2rem',
     backgroundColor: '#f9c200',
     alignItems: 'center',
   },
-  link: {
-    marginLeft: '1rem',
+  logo: {
     textDecoration: 'none',
-    color: 'black',
+    color: 'white',
+    fontWeight: 'bold',
+    fontSize: '2.5rem',
+  },
+  navLinks: {
+    display: 'flex',
+    gap: '1rem',
+  },
+  navLink: {
+    textDecoration: 'none',
+    color: 'white',
     fontWeight: 'bold',
   },
 };

--- a/sunny_sales_web/src/index.css
+++ b/sunny_sales_web/src/index.css
@@ -17,12 +17,13 @@ header {
   justify-content: space-between;
   align-items: center;
   background: linear-gradient(to right, #ffe072, #ffde8a);
-  padding: 1rem 2rem;
+  padding: 1.5rem 2rem;
 }
 
 header h1 {
   margin: 0;
-  font-size: 2rem;
+  font-size: 2.5rem;
+  color: white;
 }
 
 .btn-top {

--- a/sunny_sales_web/src/pages/ModernMapLayout.css
+++ b/sunny_sales_web/src/pages/ModernMapLayout.css
@@ -34,6 +34,17 @@
   font-size: 0.95rem;
 }
 
+.product-filters {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-bottom: 20px;
+}
+
+.product-filters label {
+  font-size: 0.9rem;
+}
+
 .section {
   margin-bottom: 20px;
 }

--- a/sunny_sales_web/src/pages/ModernMapLayout.jsx
+++ b/sunny_sales_web/src/pages/ModernMapLayout.jsx
@@ -9,6 +9,8 @@ import './ModernMapLayout.css';
 export default function ModernMapLayout() {
   const [vendors, setVendors] = useState([]);
   const [search, setSearch] = useState('');
+  const PRODUCTS = ['Bolas de Berlim', 'Acessórios', 'Gelados'];
+  const [selectedProducts, setSelectedProducts] = useState([...PRODUCTS]);
   const [selected, setSelected] = useState(null);
   const mapRef = useRef(null);
 
@@ -32,8 +34,10 @@ export default function ModernMapLayout() {
 
   const activeVendors = vendors.filter((v) => v.current_lat && v.current_lng);
 
-  const filteredActive = activeVendors.filter((v) =>
-    v.name?.toLowerCase().includes(search.toLowerCase())
+  const filteredActive = activeVendors.filter(
+    (v) =>
+      v.name?.toLowerCase().includes(search.toLowerCase()) &&
+      (selectedProducts.length === 0 || selectedProducts.includes(v.product))
   );
 
   const focusVendor = (v) => {
@@ -55,6 +59,37 @@ export default function ModernMapLayout() {
           value={search}
           onChange={(e) => setSearch(e.target.value)}
         />
+
+        <div className="product-filters">
+          <label>
+            <input
+              type="checkbox"
+              checked={selectedProducts.length === PRODUCTS.length}
+              onChange={() =>
+                setSelectedProducts((prev) =>
+                  prev.length === PRODUCTS.length ? [] : [...PRODUCTS]
+                )
+              }
+            />{' '}
+            Todos
+          </label>
+          {PRODUCTS.map((p) => (
+            <label key={p}>
+              <input
+                type="checkbox"
+                checked={selectedProducts.includes(p)}
+                onChange={() =>
+                  setSelectedProducts((prev) =>
+                    prev.includes(p)
+                      ? prev.filter((v) => v !== p)
+                      : [...prev, p]
+                  )
+                }
+              />{' '}
+              {p}
+            </label>
+          ))}
+        </div>
 
         <div className="section">
           <h3 className="section-title">Ativos</h3>
@@ -108,7 +143,7 @@ export default function ModernMapLayout() {
         <MapContainer
           center={[38.7169, -9.1399]}
           zoom={13}
-          style={{ height: '100%', width: '100%' }}
+          style={{ height: '66vh', width: '100%' }}
           whenCreated={(map) => {
             mapRef.current = map;
           }}


### PR DESCRIPTION
## Summary
- enlarge header style
- add vendor/client login/register links
- shrink map display
- show product filters on map sidebar

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68654cd5785c832ebb2276747e7dd1da