### PR TITLE
Update map style with Carto Light tiles

### DIFF
--- a/mobile/LeafletMap.js
+++ b/mobile/LeafletMap.js
@@ -64,7 +64,11 @@ const LeafletMap = forwardRef((props, ref) => {
             ${initialPosition.latitude},
             ${initialPosition.longitude}
           ], ${initialZoom});
-          L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', { maxZoom: 19 }).addTo(map);
+          L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png', {
+            attribution: '&copy; <a href="https://carto.com/">Carto</a>, &copy; <a href="https://openstreetmap.org">OpenStreetMap</a> contributors',
+            subdomains: 'abcd',
+            maxZoom: 19
+          }).addTo(map);
           var markers = ${JSON.stringify(markers)};
           var line = ${JSON.stringify(polyline)};
           markers.forEach(function(m) {

--- a/sunny_sales_web/public/resort-map.html
+++ b/sunny_sales_web/public/resort-map.html
@@ -31,7 +31,9 @@
     <script>
         // Exemplo de inicialização do mapa (pode ser removido se já existir no projeto)
         var map = L.map('map').setView([38.7169, -9.1399], 13);
-        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+        L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png', {
+            attribution: '&copy; <a href="https://carto.com/">Carto</a>, &copy; <a href="https://openstreetmap.org">OpenStreetMap</a> contributors',
+            subdomains: 'abcd',
             maxZoom: 19
         }).addTo(map);
     </script>

--- a/sunny_sales_web/src/pages/ModernMapLayout.jsx
+++ b/sunny_sales_web/src/pages/ModernMapLayout.jsx
@@ -148,7 +148,12 @@ export default function ModernMapLayout() {
             mapRef.current = map;
           }}
         >
-          <TileLayer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" />
+          <TileLayer
+            url="https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png"
+            attribution="&copy; <a href='https://carto.com/'>Carto</a>, &copy; <a href='https://openstreetmap.org'>OpenStreetMap</a> contributors"
+            subdomains="abcd"
+            maxZoom={19}
+          />
           {activeVendors.map((v) => (
             <Marker
               key={v.id}

--- a/sunny_sales_web/src/pages/RouteDetail.jsx
+++ b/sunny_sales_web/src/pages/RouteDetail.jsx
@@ -30,8 +30,10 @@ export default function RouteDetail() {
 
       <MapContainer center={initial} zoom={15} style={styles.map}>
         <TileLayer
-          url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
-          attribution="© OpenStreetMap"
+          url="https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png"
+          attribution="&copy; <a href='https://carto.com/'>Carto</a>, &copy; <a href='https://openstreetmap.org'>OpenStreetMap</a> contributors"
+          subdomains="abcd"
+          maxZoom={19}
         />
         <Polyline positions={polyline} color="blue" />
       </MapContainer>


### PR DESCRIPTION
## Summary
- switch Leaflet tile URLs to Carto Light basemap
- update Map components and HTML examples accordingly

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `npm run lint` in `sunny_sales_web` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68654fee4c34832eb777254fd0973fe0