### PR TITLE
Add login selector and profile header icon

### DIFF
--- a/sunny_sales_web/src/App.jsx
+++ b/sunny_sales_web/src/App.jsx
@@ -18,6 +18,7 @@ import VendorDetailScreen from './pages/VendorDetailScreen';
 import Invoices from './pages/Invoices';
 import Dashboard from './pages/Dashboard';
 import ModernMapLayout from './pages/ModernMapLayout';
+import LoginSelection from './pages/LoginSelection';
 import './index.css'; // (em português) Importa os estilos globais
 
 export default function App() {
@@ -32,6 +33,9 @@ export default function App() {
           <Link style={styles.navLink} to="/login">Login Cliente</Link>
           <Link style={styles.navLink} to="/register">Registar Cliente</Link>
         </nav>
+        <Link to="/login-selection" style={styles.profileIcon} aria-label="Login">
+          👤
+        </Link>
       </header>
 
       {/* (em português) Container central da aplicação */}
@@ -45,6 +49,7 @@ export default function App() {
   <Route path="/register" element={<ClientRegister />} />
   <Route path="/forgot-password" element={<ForgotPassword />} />
   <Route path="/vendor-login" element={<VendorLogin />} />
+  <Route path="/login-selection" element={<LoginSelection />} />
   <Route path="/account" element={<ManageAccount />} />
   <Route path="/paid-weeks" element={<PaidWeeksScreen />} />
   <Route path="/invoices" element={<Invoices />} />
@@ -86,5 +91,11 @@ const styles = {
     textDecoration: 'none',
     color: 'white',
     fontWeight: 'bold',
+  },
+  profileIcon: {
+    textDecoration: 'none',
+    color: 'white',
+    fontSize: '2rem',
+    marginLeft: '1rem',
   },
 };

--- a/sunny_sales_web/src/pages/LoginSelection.jsx
+++ b/sunny_sales_web/src/pages/LoginSelection.jsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+
+export default function LoginSelection() {
+  const navigate = useNavigate();
+  return (
+    <div style={styles.container}>
+      <h2>Escolha o tipo de utilizador</h2>
+      <div style={styles.buttons}>
+        <button style={styles.button} onClick={() => navigate('/vendor-login')}>
+          Sou Vendedor
+        </button>
+        <button style={styles.button} onClick={() => navigate('/login')}>
+          Sou Cliente
+        </button>
+      </div>
+    </div>
+  );
+}
+
+const styles = {
+  container: {
+    padding: '2rem',
+    textAlign: 'center',
+  },
+  buttons: {
+    display: 'flex',
+    justifyContent: 'center',
+    gap: '1rem',
+    marginTop: '1rem',
+  },
+  button: {
+    padding: '0.75rem 1.5rem',
+    backgroundColor: '#f9c200',
+    border: 'none',
+    cursor: 'pointer',
+  },
+};


### PR DESCRIPTION
## Summary
- add a new `LoginSelection` page for choosing vendor or client login
- link to the new page with a profile icon in the header

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686654867f6c832ea2d4b893183167ab