### PR TITLE
Update profile button to redirect to dashboard when logged in

### DIFF
--- a/sunny_sales_web/src/App.jsx
+++ b/sunny_sales_web/src/App.jsx
@@ -22,6 +22,9 @@ import LoginSelection from './pages/LoginSelection';
 import './index.css'; // (em português) Importa os estilos globais
 
 export default function App() {
+  const isLoggedIn = localStorage.getItem('user') || localStorage.getItem('client');
+  const profileLink = isLoggedIn ? '/dashboard' : '/login-selection';
+
   return (
     <Router>
       {/* (em português) Barra de navegação */}
@@ -33,7 +36,7 @@ export default function App() {
           <Link style={styles.navLink} to="/login">Login Cliente</Link>
           <Link style={styles.navLink} to="/register">Registar Cliente</Link>
         </nav>
-        <Link to="/login-selection" style={styles.profileIcon} aria-label="Login">
+        <Link to={profileLink} style={styles.profileIcon} aria-label="Login">
           👤
         </Link>
       </header>


### PR DESCRIPTION
## Summary
- enhance the web header to send logged users directly to their dashboard

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686658ef7110832e9a63b5cacf7af0ef