### PR TITLE
Fix dashboard menu overlay

### DIFF
--- a/sunny_sales_web/src/components/HamburgerMenu.css
+++ b/sunny_sales_web/src/components/HamburgerMenu.css
@@ -1,0 +1,52 @@
+.popup {
+  position: relative;
+}
+
+.burger {
+  width: 32px;
+  height: 32px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  z-index: 1000;
+}
+
+.burger span {
+  display: block;
+  height: 3px;
+  background: #333;
+  margin: 4px 0;
+  transition: transform 0.3s ease;
+}
+
+.burger.open span:nth-child(1) {
+  transform: translateY(7px) rotate(45deg);
+}
+
+.burger.open span:nth-child(2) {
+  opacity: 0;
+}
+
+.burger.open span:nth-child(3) {
+  transform: translateY(-7px) rotate(-45deg);
+}
+
+.popup-window {
+  display: none;
+  position: absolute;
+  top: 40px;
+  left: 0;
+  background: #fff;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+  padding: 1rem;
+  border-radius: 8px;
+  z-index: 999;
+}
+
+.popup-window.open {
+  display: block;
+}

--- a/sunny_sales_web/src/components/HamburgerMenu.jsx
+++ b/sunny_sales_web/src/components/HamburgerMenu.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import './HamburgerMenu.css';
 
 export default function HamburgerMenu({ children, style }) {
   const [open, setOpen] = useState(false);

--- a/sunny_sales_web/src/pages/DashboardCliente.jsx
+++ b/sunny_sales_web/src/pages/DashboardCliente.jsx
@@ -153,5 +153,6 @@ const styles = {
     background: 'none',
     border: 'none',
     cursor: 'pointer',
+    zIndex: 1000,
   }
 }

--- a/sunny_sales_web/src/pages/VendorDashboard.jsx
+++ b/sunny_sales_web/src/pages/VendorDashboard.jsx
@@ -178,6 +178,7 @@ const styles = {
     maxWidth: '600px',
     margin: '0 auto',
     textAlign: 'center',
+    position: 'relative',
   },
   title: {
     marginBottom: '1rem',
@@ -219,6 +220,7 @@ const styles = {
     background: 'none',
     border: 'none',
     cursor: 'pointer',
+    zIndex: 1000,
   },
   pinPreview: {
     display: 'inline-block',


### PR DESCRIPTION
## Summary
- style hamburger menu
- import new hamburger styles
- tweak dashboard container and menu button styles

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68665e448c48832e8b97b3fa54e1df6e