### PR TITLE
Fix dashboard selection after login

### DIFF
--- a/sunny_sales_web/src/pages/ClientLogin.jsx
+++ b/sunny_sales_web/src/pages/ClientLogin.jsx
@@ -46,6 +46,11 @@ export default function ClientLogin() {
       }
 
       localStorage.setItem('client', JSON.stringify(client));
+      // remove any previous vendor session data
+      localStorage.removeItem('user');
+      localStorage.removeItem('token');
+      localStorage.removeItem('vendorId');
+      localStorage.removeItem('sharingLocation');
       navigate('/dashboard');
     } catch (err) {
       console.error(err);

--- a/sunny_sales_web/src/pages/VendorLogin.jsx
+++ b/sunny_sales_web/src/pages/VendorLogin.jsx
@@ -39,6 +39,10 @@ export default function VendorLogin() {
 
       const userRes = await axios.post(`${BASE_URL}/login`, { email, password });
       localStorage.setItem('user', JSON.stringify(userRes.data));
+      // remove any previous client session data
+      localStorage.removeItem('client');
+      localStorage.removeItem('clientToken');
+      localStorage.removeItem('favorites');
 
       window.location.href = '/dashboard'; // redirecionar para o dashboard
     } catch (err) {


### PR DESCRIPTION
## Summary
- clear old session data when logging in as client or vendor

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6866813bb910832e9f19e11d514fb517