### PR TITLE
Fix 404 refresh by switching router

### DIFF
--- a/sunny_sales_web/src/App.jsx
+++ b/sunny_sales_web/src/App.jsx
@@ -1,6 +1,6 @@
 // (em português) Componente principal da aplicação Web com rotas
 
-import { BrowserRouter as Router, Routes, Route, Link } from 'react-router-dom';
+import { HashRouter as Router, Routes, Route, Link } from 'react-router-dom';
 import About from './pages/About';
 import AccountSettings from './pages/AccountSettings';
 import ClientLogin from './pages/ClientLogin';

--- a/sunny_sales_web/src/pages/About.jsx
+++ b/sunny_sales_web/src/pages/About.jsx
@@ -1,4 +1,6 @@
 // (em português) Página "Sobre e Ajuda" com estilos embutidos
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
 
 const styles = {
   container: {
@@ -32,6 +34,7 @@ const styles = {
 };
 
 export default function About() {
+  const navigate = useNavigate();
   return (
     <div style={styles.container}>
       <div style={styles.card}>
@@ -40,7 +43,7 @@ export default function About() {
         <button
           className="btn"
           style={styles.button}
-          onClick={() => (window.location.href = '/terms')}
+          onClick={() => navigate('/terms')}
         >
           📄 Termos e Condições
         </button>

--- a/sunny_sales_web/src/pages/VendorLogin.jsx
+++ b/sunny_sales_web/src/pages/VendorLogin.jsx
@@ -1,6 +1,7 @@
 // (em português) Página Web para login de vendedores
 
 import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import axios from 'axios';
 import { BASE_URL } from '../config';
 import LoadingDots from '../components/LoadingDots';
@@ -10,6 +11,7 @@ export default function VendorLogin() {
   const [password, setPassword] = useState('');
   const [error, setError] = useState(null);
   const [loading, setLoading] = useState(false);
+  const navigate = useNavigate();
 
   // (em português) Decodifica o token JWT para extrair o ID do vendedor
   const getVendorIdFromToken = (token) => {
@@ -44,7 +46,7 @@ export default function VendorLogin() {
       localStorage.removeItem('clientToken');
       localStorage.removeItem('favorites');
 
-      window.location.href = '/dashboard'; // redirecionar para o dashboard
+      navigate('/dashboard');
     } catch (err) {
       console.error(err);
       if (err.response?.data?.detail) {
@@ -91,7 +93,7 @@ export default function VendorLogin() {
         <button
           type="button"
           className="outlined-button"
-          onClick={() => (window.location.href = '/register')}
+          onClick={() => navigate('/register')}
         >
           Registar
         </button>
@@ -99,7 +101,7 @@ export default function VendorLogin() {
         <button
           type="button"
           className="outlined-button"
-          onClick={() => (window.location.href = '/forgot-password')}
+          onClick={() => navigate('/forgot-password')}
           style={{ background: 'none', border: 'none', color: '#007BFF', textDecoration: 'underline' }}
         >
           Esqueci-me da palavra-passe


### PR DESCRIPTION
## Summary
- use HashRouter so dashboard works on page reload

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6866850bb0e8832eaae7e6760f77817f