### PR TITLE
Fix dashboard menus

### DIFF
--- a/mobile/screens/DashboardScreen.js
+++ b/mobile/screens/DashboardScreen.js
@@ -499,18 +499,22 @@ const styles = StyleSheet.create({
     justifyContent: 'space-between', 
     width: '100%' 
   },
-  mapButton: { 
-    position: 'absolute', 
-    top: 16, 
-    right: 16 
+  mapButton: {
+    position: 'absolute',
+    top: 16,
+    right: 16,
+    zIndex: 101,
+    elevation: 10
   },
   mapIcon: { 
     fontSize: 36 
   },
-  menuButton: { 
-    position: 'absolute', 
-    top: 16, 
-    left: 16 
+  menuButton: {
+    position: 'absolute',
+    top: 16,
+    left: 16,
+    zIndex: 101,
+    elevation: 10
   },
   menuIcon: { 
     fontSize: 36 

--- a/mobile/screens/MapScreen.js
+++ b/mobile/screens/MapScreen.js
@@ -85,6 +85,7 @@ export default function MapScreen({ navigation }) {
 
   // loadVendor
   const loadVendor = async () => {
+    let ret = null;
     try {
       // stored
       const stored = await AsyncStorage.getItem("user");
@@ -92,6 +93,7 @@ export default function MapScreen({ navigation }) {
         // v
         const v = JSON.parse(stored);
         setVendorUser(v);
+        ret = v;
         // share
         const share = await isLocationSharing();
         if (share) {
@@ -108,7 +110,9 @@ export default function MapScreen({ navigation }) {
     } catch (err) {
       console.log("Erro ao carregar vendedor:", err);
       setVendorUser(null);
+      return null;
     }
+    return ret;
   };
 
   // loadClient
@@ -117,7 +121,9 @@ export default function MapScreen({ navigation }) {
       // stored
       const stored = await AsyncStorage.getItem("client");
       if (stored) {
-        setClientUser(JSON.parse(stored));
+        const c = JSON.parse(stored);
+        setClientUser(c);
+        return c;
       } else {
         setClientUser(null);
       }
@@ -125,6 +131,7 @@ export default function MapScreen({ navigation }) {
       console.log("Erro ao carregar cliente:", err);
       setClientUser(null);
     }
+    return null;
   };
 
   // loadFavorites
@@ -309,9 +316,10 @@ export default function MapScreen({ navigation }) {
 
       <TouchableOpacity
         style={styles.vendorIcon}
-        onPress={() =>
-          navigation.navigate(vendorUser ? "Dashboard" : "VendorLogin")
-        }
+        onPress={async () => {
+          const v = await loadVendor();
+          navigation.navigate(v ? "Dashboard" : "VendorLogin");
+        }}
         accessibilityRole="button"
         accessibilityLabel="Iniciar sessão de Vendedor"
         accessible
@@ -476,7 +484,10 @@ export default function MapScreen({ navigation }) {
           <Button
             mode="contained"
             style={styles.button}
-            onPress={() => navigation.navigate("ClientDashboard")}
+            onPress={async () => {
+              const c = await loadClient();
+              navigation.navigate(c ? "ClientDashboard" : "ClientLogin");
+            }}
           >
             <Text>Perfil</Text>
           </Button>


### PR DESCRIPTION
## Summary
- ensure vendor/client are reloaded when tapping profile buttons
- elevate map and menu buttons in vendor dashboard so they are clickable

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6866984181c4832ea6ce2a40b95baf2f