### PR TITLE
Fix hamburger icon color

### DIFF
--- a/sunny_sales_web/src/components/HamburgerMenu.css
+++ b/sunny_sales_web/src/components/HamburgerMenu.css
@@ -21,7 +21,7 @@
   display: block;
   height: 3px;
   width: 100%;
-  background: #333;
+  background: #f9c200;
   margin: 4px 0;
   border-radius: 2px;
   transition: all 0.3s ease;


### PR DESCRIPTION
## Summary
- colorize the hamburger bars with same yellow as the header

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6866ab5cf2e0832e8cb66906988a3d08