### PR TITLE
Fix hamburger lines visibility

### DIFF
--- a/sunny_sales_web/src/components/HamburgerMenu.css
+++ b/sunny_sales_web/src/components/HamburgerMenu.css
@@ -17,11 +17,16 @@
   padding: 0;
 }
 
+/* Override global button:hover rule so the icon stays visible */
+.burger:hover {
+  background: none !important;
+}
+
 .burger span {
   display: block;
   height: 3px;
   width: 100%;
-  background: #f9c200;
+  background: #000;
   margin: 4px 0;
   border-radius: 2px;
   transition: all 0.3s ease;

--- a/sunny_sales_web/src/components/HamburgerMenu.jsx
+++ b/sunny_sales_web/src/components/HamburgerMenu.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import './HamburgerMenu.css';
 
 export default function HamburgerMenu({ children, style }) {
   const [open, setOpen] = useState(false);
@@ -10,66 +11,20 @@ export default function HamburgerMenu({ children, style }) {
         type="button"
         onClick={() => setOpen(o => !o)}
         aria-label="Menu"
-        style={{
-          background: 'transparent',
-          border: 'none',
-          cursor: 'pointer',
-          padding: '10px',
-          display: 'flex',
-          flexDirection: 'column',
-          justifyContent: 'space-between',
-          height: '24px',
-          width: '30px',
-          zIndex: 1001,
-        }}
+        className={`burger${open ? ' open' : ''}`}
       >
-        <span
-          style={{
-            height: '3px',
-            background: '#000',
-            borderRadius: '2px',
-            transition: '0.3s',
-            transform: open ? 'rotate(45deg) translate(5px, 5px)' : 'none',
-          }}
-        />
-        <span
-          style={{
-            height: '3px',
-            background: '#000',
-            borderRadius: '2px',
-            transition: '0.3s',
-            opacity: open ? 0 : 1,
-          }}
-        />
-        <span
-          style={{
-            height: '3px',
-            background: '#000',
-            borderRadius: '2px',
-            transition: '0.3s',
-            transform: open ? 'rotate(-45deg) translate(5px, -5px)' : 'none',
-          }}
-        />
+        <span />
+        <span />
+        <span />
       </button>
 
       {/* Menu lateral */}
-      {open && (
-        <nav
-          style={{
-            position: 'absolute',
-            top: '40px',
-            left: 0,
-            background: '#fff',
-            borderRadius: '12px',
-            boxShadow: '0 4px 16px rgba(0,0,0,0.2)',
-            padding: '20px',
-            zIndex: 1000,
-          }}
-          onClick={() => setOpen(false)}
-        >
-          {children}
-        </nav>
-      )}
+      <nav
+        className={`popup-window${open ? ' open' : ''}`}
+        onClick={() => setOpen(false)}
+      >
+        {children}
+      </nav>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- keep hamburger button background transparent when hovered
- ensure the popup menu still opens below the button

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6866b585b044832ea0544332f27367b2