### PR TITLE
Fix vendor dashboard hamburger visibility

### DIFF
--- a/sunny_sales_web/src/components/HamburgerMenu.css
+++ b/sunny_sales_web/src/components/HamburgerMenu.css
@@ -11,15 +11,18 @@
   display: flex;
   flex-direction: column;
   justify-content: center;
-  background: none;
-  border: none;
+  align-items: center;
+  gap: 4px;
+  background: rgba(255, 255, 255, 0.9);
+  border: 1px solid #000;
+  border-radius: 4px;
   cursor: pointer;
   padding: 0;
 }
 
 /* Override global button:hover rule so the icon stays visible */
 .burger:hover {
-  background: none !important;
+  background: rgba(255, 255, 255, 0.9) !important;
 }
 
 .burger span {


### PR DESCRIPTION
## Summary
- tweak hamburger menu styles so the three bars remain visible on vendor dashboard

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6866bac4a8b8832eb8e9d0469491cbd4