### PR TITLE
Update dashboards with always visible side menu

### DIFF
--- a/sunny_sales_web/src/pages/DashboardCliente.jsx
+++ b/sunny_sales_web/src/pages/DashboardCliente.jsx
@@ -2,7 +2,6 @@
 
 import React, { useEffect, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
-import HamburgerMenu from '../components/HamburgerMenu';
 import axios from 'axios';
 import { BASE_URL } from '../config';
 
@@ -44,8 +43,8 @@ export default function DashboardCliente() {
   }, []);
 
   return (
-    <div style={styles.container}>
-      <HamburgerMenu style={styles.menuButton}>
+    <div style={styles.wrapper}>
+      <div style={styles.menu}>
         <legend>Menu</legend>
         <ul>
           <li><button onClick={() => navigate('/settings')}>Notificações</button></li>
@@ -58,9 +57,10 @@ export default function DashboardCliente() {
             <button onClick={() => (window.location.href = 'mailto:suporte@sunnysales.com')}>Contactar Suporte</button>
           </li>
         </ul>
-      </HamburgerMenu>
+      </div>
 
-      <h2 style={styles.title}>Meu Perfil</h2>
+      <div style={styles.container}>
+        <h2 style={styles.title}>Meu Perfil</h2>
 
       {client?.profile_photo && (
         <img src={`${BASE_URL}/${client.profile_photo}`} style={styles.image} alt="Foto de perfil" />
@@ -91,12 +91,22 @@ export default function DashboardCliente() {
       </div>
 
       <button onClick={logout} className="btn" style={styles.logoutButton}>Sair</button>
+      </div>
     </div>
   );
 }
 
 // estilos embutidos
 const styles = {
+  wrapper: {
+    display: 'flex',
+    alignItems: 'flex-start',
+  },
+  menu: {
+    width: '220px',
+    padding: '1rem',
+    borderRight: '1px solid #ccc',
+  },
   container: {
     padding: '2rem',
     maxWidth: '600px',
@@ -146,13 +156,6 @@ const styles = {
     fontWeight: 'bold',
   },
   menuButton: {
-    position: 'absolute',
-    top: 16,
-    left: 16,
-    fontSize: '2rem',
-    background: 'none',
-    border: 'none',
-    cursor: 'pointer',
-    zIndex: 1000,
+    display: 'none',
   }
 }

--- a/sunny_sales_web/src/pages/VendorDashboard.jsx
+++ b/sunny_sales_web/src/pages/VendorDashboard.jsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
-import HamburgerMenu from '../components/HamburgerMenu';
 import { BASE_URL } from '../config';
 import axios from 'axios';
 
@@ -108,8 +107,8 @@ export default function VendorDashboard() {
   };
 
   return (
-    <div style={styles.container}>
-      <HamburgerMenu style={styles.menuButton}>
+    <div style={styles.wrapper}>
+      <div style={styles.menu}>
         <legend>Menu</legend>
         <ul>
           <li><button onClick={paySubscription}>Pagar Semanalidade</button></li>
@@ -125,8 +124,9 @@ export default function VendorDashboard() {
           <li><button onClick={() => navigate('/terms')}>Termos e Condições</button></li>
           <li><button onClick={() => (window.location.href = 'mailto:suporte@sunnysales.com')}>Contactar Suporte</button></li>
         </ul>
-      </HamburgerMenu>
-      <h2 style={styles.title}>Painel do Vendedor</h2>
+      </div>
+      <div style={styles.container}>
+        <h2 style={styles.title}>Painel do Vendedor</h2>
       {vendor && (
         <>
           {vendor.profile_photo && (
@@ -168,11 +168,21 @@ export default function VendorDashboard() {
       </button>
 
       <button className="btn" style={styles.logout} onClick={logout}>Sair</button>
+      </div>
     </div>
   );
 }
 
 const styles = {
+  wrapper: {
+    display: 'flex',
+    alignItems: 'flex-start',
+  },
+  menu: {
+    width: '220px',
+    padding: '1rem',
+    borderRight: '1px solid #ccc',
+  },
   container: {
     padding: '2rem',
     maxWidth: '600px',
@@ -213,14 +223,7 @@ const styles = {
     cursor: 'pointer',
   },
   menuButton: {
-    position: 'absolute',
-    top: 16,
-    left: 16,
-    fontSize: '2rem',
-    background: 'none',
-    border: 'none',
-    cursor: 'pointer',
-    zIndex: 1000,
+    display: 'none',
   },
   pinPreview: {
     display: 'inline-block',


### PR DESCRIPTION
## Summary
- remove `HamburgerMenu` from customer and vendor dashboards
- add static side menu on the left of each dashboard

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6866cd1504e0832e8857a1c8559bfa49