### PR TITLE
Add pop-up dashboard menu

### DIFF
--- a/sunny_sales_web/src/components/DashboardMenu.css
+++ b/sunny_sales_web/src/components/DashboardMenu.css
@@ -1,0 +1,72 @@
+.dashboard-menu {
+  position: relative;
+  display: inline-block;
+}
+
+/* Button styles from Uiverse snippet */
+.setting-btn {
+  width: 45px;
+  height: 45px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  background-color: rgb(129, 110, 216);
+  border-radius: 10px;
+  cursor: pointer;
+  border: none;
+  box-shadow: 0px 0px 0px 2px rgb(212, 209, 255);
+}
+
+.bar {
+  width: 50%;
+  height: 2px;
+  background-color: rgb(229, 229, 229);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  border-radius: 2px;
+}
+.bar::before {
+  content: '';
+  width: 2px;
+  height: 2px;
+  background-color: rgb(126, 117, 255);
+  position: absolute;
+  border-radius: 50%;
+  border: 2px solid white;
+  transition: all 0.3s;
+  box-shadow: 0px 0px 5px white;
+}
+.bar1::before {
+  transform: translateX(-4px);
+}
+.bar2::before {
+  transform: translateX(4px);
+}
+.setting-btn:hover .bar1::before {
+  transform: translateX(4px);
+}
+.setting-btn:hover .bar2::before {
+  transform: translateX(-4px);
+}
+
+/* Popup menu positioning */
+.popup-window {
+  display: none;
+  position: absolute;
+  top: 55px;
+  left: 0;
+  background: #fff;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  padding: 1rem;
+  border-radius: 10px;
+  min-width: 220px;
+  z-index: 100;
+}
+
+.popup-window.open {
+  display: block;
+}

--- a/sunny_sales_web/src/components/DashboardMenu.jsx
+++ b/sunny_sales_web/src/components/DashboardMenu.jsx
@@ -1,0 +1,23 @@
+import React, { useState } from 'react';
+import './DashboardMenu.css';
+
+export default function DashboardMenu({ children }) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className="dashboard-menu">
+      <button
+        type="button"
+        aria-label="Menu"
+        className="setting-btn"
+        onClick={() => setOpen(o => !o)}
+      >
+        <div className="bar bar1" />
+        <div className="bar bar2" />
+      </button>
+      <nav className={`popup-window${open ? ' open' : ''}`} onClick={() => setOpen(false)}>
+        {children}
+      </nav>
+    </div>
+  );
+}

--- a/sunny_sales_web/src/pages/DashboardCliente.jsx
+++ b/sunny_sales_web/src/pages/DashboardCliente.jsx
@@ -1,9 +1,10 @@
 // (em português) Dashboard do cliente na versão web com favoritos e menu lateral
 
 import React, { useEffect, useState } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import axios from 'axios';
 import { BASE_URL } from '../config';
+import DashboardMenu from '../components/DashboardMenu';
 
 export default function DashboardCliente() {
   const [client, setClient] = useState(null);
@@ -44,7 +45,7 @@ export default function DashboardCliente() {
 
   return (
     <div style={styles.wrapper}>
-      <div style={styles.menu}>
+      <DashboardMenu>
         <legend>Menu</legend>
         <ul>
           <li><button onClick={() => navigate('/settings')}>Notificações</button></li>
@@ -57,7 +58,7 @@ export default function DashboardCliente() {
             <button onClick={() => (window.location.href = 'mailto:suporte@sunnysales.com')}>Contactar Suporte</button>
           </li>
         </ul>
-      </div>
+      </DashboardMenu>
 
       <div style={styles.container}>
         <h2 style={styles.title}>Meu Perfil</h2>
@@ -99,13 +100,7 @@ export default function DashboardCliente() {
 // estilos embutidos
 const styles = {
   wrapper: {
-    display: 'flex',
-    alignItems: 'flex-start',
-  },
-  menu: {
-    width: '220px',
-    padding: '1rem',
-    borderRight: '1px solid #ccc',
+    position: 'relative',
   },
   container: {
     padding: '2rem',
@@ -155,7 +150,4 @@ const styles = {
     cursor: 'pointer',
     fontWeight: 'bold',
   },
-  menuButton: {
-    display: 'none',
-  }
 }

--- a/sunny_sales_web/src/pages/VendorDashboard.jsx
+++ b/sunny_sales_web/src/pages/VendorDashboard.jsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useState } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { BASE_URL } from '../config';
 import axios from 'axios';
+import DashboardMenu from '../components/DashboardMenu';
 
 let watchId = null;
 
@@ -108,7 +109,7 @@ export default function VendorDashboard() {
 
   return (
     <div style={styles.wrapper}>
-      <div style={styles.menu}>
+      <DashboardMenu>
         <legend>Menu</legend>
         <ul>
           <li><button onClick={paySubscription}>Pagar Semanalidade</button></li>
@@ -124,7 +125,7 @@ export default function VendorDashboard() {
           <li><button onClick={() => navigate('/terms')}>Termos e Condições</button></li>
           <li><button onClick={() => (window.location.href = 'mailto:suporte@sunnysales.com')}>Contactar Suporte</button></li>
         </ul>
-      </div>
+      </DashboardMenu>
       <div style={styles.container}>
         <h2 style={styles.title}>Painel do Vendedor</h2>
       {vendor && (
@@ -175,13 +176,7 @@ export default function VendorDashboard() {
 
 const styles = {
   wrapper: {
-    display: 'flex',
-    alignItems: 'flex-start',
-  },
-  menu: {
-    width: '220px',
-    padding: '1rem',
-    borderRight: '1px solid #ccc',
+    position: 'relative',
   },
   container: {
     padding: '2rem',
@@ -222,9 +217,6 @@ const styles = {
     backgroundColor: '#f9c200',
     cursor: 'pointer',
   },
-  menuButton: {
-    display: 'none',
-  },
   pinPreview: {
     display: 'inline-block',
     width: 16,
@@ -247,3 +239,4 @@ const styles = {
     padding: '4px 0',
   },
 };
+


### PR DESCRIPTION
## Summary
- add `DashboardMenu` component with styling from the snippet
- use `DashboardMenu` in both dashboard pages so menu appears on click

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6867021c9938832e999e5e81a6df4786