### PR TITLE
Implement EditProfileScreen

### DIFF
--- a/mobile/App.js
+++ b/mobile/App.js
@@ -29,6 +29,7 @@ import InvoicesScreen from './screens/InvoicesScreen';
 import ForgotPasswordScreen from './screens/ForgotPasswordScreen';
 import AccountSettingsScreen from './screens/AccountSettingsScreen';
 import ManageAccountScreen from './screens/ManageAccountScreen';
+import EditProfileScreen from './screens/EditProfileScreen';
 import AboutScreen from './screens/AboutScreen';
 import { theme } from './theme';
 import t from './i18n';
@@ -83,6 +84,7 @@ export default function App() {
           <Stack.Screen name="RouteDetail" component={RouteDetailScreen} options={{ title: 'Trajeto' }} />
           <Stack.Screen name="Terms" component={TermsScreen} options={{ title: 'Termos' }} />
           <Stack.Screen name="AccountSettings" component={AccountSettingsScreen} options={{ title: t('accountSettingsTitle') }} />
+          <Stack.Screen name="EditProfileScreen" component={EditProfileScreen} options={{ title: 'Editar Perfil' }} />
           <Stack.Screen name="ManageAccount" component={ManageAccountScreen} options={{ title: 'Definições' }} />
           <Stack.Screen name="About" component={AboutScreen} options={{ title: 'Sobre/Ajuda' }} />
           </Stack.Navigator>

--- a/mobile/screens/ClientDashboardScreen.js
+++ b/mobile/screens/ClientDashboardScreen.js
@@ -196,7 +196,7 @@ export default function ClientDashboardScreen({ navigation }) {
                 title="Atualizar Dados Pessoais"
                 onPress={() => {
                   setMenuOpen(false);
-                  navigation.navigate('ManageAccount');
+                  navigation.navigate('EditProfileScreen');
                 }}
               />
               <List.Item

--- a/mobile/screens/DashboardScreen.js
+++ b/mobile/screens/DashboardScreen.js
@@ -438,7 +438,13 @@ export default function DashboardScreen({ navigation }) {
               <List.Item title="Distância Percorrida" onPress={() => { setMenuOpen(false); navigation.navigate('Stats'); }} />
             </List.Accordion>
             <List.Accordion title="Definições de Conta" expanded={accountOpen} onPress={() => setAccountOpen(!accountOpen)}>
-              <List.Item title="Atualizar Dados Pessoais" onPress={() => { setMenuOpen(false); setEditing(true); }} />
+              <List.Item
+                title="Atualizar Dados Pessoais"
+                onPress={() => {
+                  setMenuOpen(false);
+                  navigation.navigate('EditProfileScreen');
+                }}
+              />
               <List.Item title="Apagar Conta" onPress={() => { setMenuOpen(false); navigation.navigate('ManageAccount'); }} />
             </List.Accordion>
             <List.Accordion title="Sobre e Ajuda" expanded={helpOpen} onPress={() => setHelpOpen(!helpOpen)}>

--- a/mobile/screens/EditProfileScreen.js
+++ b/mobile/screens/EditProfileScreen.js
@@ -1,0 +1,156 @@
+import React, { useEffect, useState } from 'react';
+import { View, StyleSheet, Image, Platform } from 'react-native';
+import { TextInput, Button, Text } from 'react-native-paper';
+import { Picker } from '@react-native-picker/picker';
+import * as ImagePicker from 'expo-image-picker';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import axios from 'axios';
+import { BASE_URL } from '../config';
+import { theme } from '../theme';
+import BackButton from '../BackButton';
+
+export default function EditProfileScreen({ navigation }) {
+  const [vendor, setVendor] = useState(null);
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [product, setProduct] = useState('');
+  const [profilePhoto, setProfilePhoto] = useState(null);
+  const [error, setError] = useState(null);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    const loadVendor = async () => {
+      const stored = await AsyncStorage.getItem('user');
+      if (stored) {
+        const v = JSON.parse(stored);
+        setVendor(v);
+        setName(v.name || '');
+        setEmail(v.email || '');
+        setProduct(v.product || '');
+      }
+    };
+    loadVendor();
+  }, []);
+
+  const handleFileChange = (e) => {
+    if (e.target.files && e.target.files[0]) {
+      setProfilePhoto(e.target.files[0]);
+    }
+  };
+
+  const pickImage = async () => {
+    const result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: ImagePicker.MediaTypeOptions.Images,
+      allowsEditing: true,
+      quality: 1,
+    });
+    if (!result.canceled && result.assets.length > 0) {
+      setProfilePhoto(result.assets[0]);
+    }
+  };
+
+  const save = async () => {
+    if (!vendor) return;
+    setSaving(true);
+    try {
+      const data = new FormData();
+      if (name !== vendor.name) data.append('name', name);
+      if (email !== vendor.email) data.append('email', email);
+      if (product !== vendor.product) data.append('product', product);
+      if (profilePhoto) {
+        if (Platform.OS === 'web') {
+          data.append('profile_photo', profilePhoto);
+        } else {
+          data.append('profile_photo', {
+            uri: profilePhoto.uri,
+            name: 'profile.jpg',
+            type: 'image/jpeg',
+          });
+        }
+      }
+      const token = await AsyncStorage.getItem('token');
+      const res = await axios.patch(
+        `${BASE_URL}/vendors/${vendor.id}/profile`,
+        data,
+        {
+          headers: {
+            'Content-Type': 'multipart/form-data',
+            Authorization: `Bearer ${token}`,
+          },
+        },
+      );
+      await AsyncStorage.setItem('user', JSON.stringify(res.data));
+      navigation.goBack();
+    } catch {
+      setError('Erro ao atualizar perfil');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const previewUri = profilePhoto
+    ? Platform.OS === 'web'
+      ? URL.createObjectURL(profilePhoto)
+      : profilePhoto.uri
+    : vendor && vendor.profile_photo
+    ? `${BASE_URL.replace(/\/$/, '')}/${vendor.profile_photo}`
+    : null;
+
+  return (
+    <View style={styles.container}>
+      <BackButton style={styles.back} />
+      <Text style={styles.title}>Editar Perfil</Text>
+      {previewUri && (
+        <Image source={{ uri: previewUri }} style={styles.imagePreview} />
+      )}
+      {Platform.OS === 'web' ? (
+        <input type="file" onChange={handleFileChange} style={{ marginBottom: 12 }} />
+      ) : (
+        <Button mode="outlined" onPress={pickImage} style={styles.button}>
+          <Text>Escolher Foto</Text>
+        </Button>
+      )}
+      <TextInput
+        mode="outlined"
+        style={styles.input}
+        label="Nome"
+        value={name}
+        onChangeText={setName}
+      />
+      <TextInput
+        mode="outlined"
+        style={styles.input}
+        label="Email"
+        value={email}
+        onChangeText={setEmail}
+        autoCapitalize="none"
+      />
+      <Picker selectedValue={product} onValueChange={setProduct} style={styles.input}>
+        <Picker.Item label="Bolas de Berlim" value="Bolas de Berlim" />
+        <Picker.Item label="Gelados" value="Gelados" />
+        <Picker.Item label="Acessórios" value="Acessórios" />
+      </Picker>
+      {error && <Text style={styles.error}>{error}</Text>}
+      <View style={styles.row}>
+        <Button mode="contained" onPress={save} loading={saving}>
+          <Text>Guardar</Text>
+        </Button>
+        <Button mode="outlined" onPress={() => navigation.goBack()}>
+          <Text>Cancelar</Text>
+        </Button>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, padding: 16, backgroundColor: theme.colors.background },
+  title: { fontSize: 20, marginBottom: 16, textAlign: 'center' },
+  input: { marginBottom: 12 },
+  button: { marginBottom: 12 },
+  row: { flexDirection: 'row', justifyContent: 'space-between', marginTop: 12 },
+  back: { position: 'absolute', top: 16, left: 16 },
+  imagePreview: { width: 120, height: 120, borderRadius: 60, alignSelf: 'center', marginBottom: 12 },
+  error: { color: 'red', textAlign: 'center', marginBottom: 12 },
+});
+

--- a/sunny_sales_web/src/App.jsx
+++ b/sunny_sales_web/src/App.jsx
@@ -9,6 +9,7 @@ import ClientRegister from './pages/ClientRegister';
 import ForgotPassword from './pages/ForgotPassword';
 import VendorLogin from './pages/VendorLogin';
 import ManageAccount from './pages/ManageAccount';
+import EditProfileScreen from './pages/EditProfileScreen';
 import PaidWeeksScreen from './pages/PaidWeeksScreen.jsx';
 import VendorRegister from './pages/VendorRegister';
 import RouteDetail from './pages/RouteDetail';
@@ -61,6 +62,7 @@ export default function App() {
           <Route path="/vendor-login" element={<VendorLogin />} />
           <Route path="/login-selection" element={<LoginSelection />} />
           <Route path="/account" element={<ManageAccount />} />
+          <Route path="/edit-profile" element={<EditProfileScreen />} />
           <Route path="/paid-weeks" element={<PaidWeeksScreen />} />
           <Route path="/invoices" element={<Invoices />} />
           <Route path="/map" element={<ModernMapLayout />} />

--- a/sunny_sales_web/src/pages/DashboardCliente.jsx
+++ b/sunny_sales_web/src/pages/DashboardCliente.jsx
@@ -50,7 +50,7 @@ export default function DashboardCliente() {
         <ul>
           <li><button onClick={() => navigate('/settings')}>Notificações</button></li>
           <hr />
-          <li><button onClick={() => alert('Funcionalidade indisponivel')}>Atualizar Dados Pessoais</button></li>
+          <li><button onClick={() => navigate('/edit-profile')}>Atualizar Dados Pessoais</button></li>
           <li><button onClick={() => alert('Funcionalidade indisponivel')}>Apagar Conta</button></li>
           <hr />
           <li><button onClick={() => navigate('/terms')}>Termos e Condições</button></li>

--- a/sunny_sales_web/src/pages/EditProfileScreen.jsx
+++ b/sunny_sales_web/src/pages/EditProfileScreen.jsx
@@ -1,0 +1,95 @@
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+import { BASE_URL } from '../config';
+import { useNavigate } from 'react-router-dom';
+
+export default function EditProfileScreen() {
+  const navigate = useNavigate();
+  const [vendor, setVendor] = useState(null);
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [product, setProduct] = useState('');
+  const [photo, setPhoto] = useState(null);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    const stored = localStorage.getItem('user');
+    if (stored) {
+      const v = JSON.parse(stored);
+      setVendor(v);
+      setName(v.name || '');
+      setEmail(v.email || '');
+      setProduct(v.product || '');
+    }
+  }, []);
+
+  const handlePhoto = (e) => {
+    if (e.target.files && e.target.files[0]) {
+      setPhoto(e.target.files[0]);
+    }
+  };
+
+  const save = async (e) => {
+    e.preventDefault();
+    if (!vendor) return;
+    const data = new FormData();
+    if (name !== vendor.name) data.append('name', name);
+    if (email !== vendor.email) data.append('email', email);
+    if (product !== vendor.product) data.append('product', product);
+    if (photo) data.append('profile_photo', photo);
+    const token = localStorage.getItem('token');
+    try {
+      const res = await axios.patch(`${BASE_URL}/vendors/${vendor.id}/profile`, data, {
+        headers: {
+          'Content-Type': 'multipart/form-data',
+          Authorization: `Bearer ${token}`,
+        },
+      });
+      localStorage.setItem('user', JSON.stringify(res.data));
+      navigate('/dashboard');
+    } catch {
+      setError('Erro ao atualizar');
+    }
+  };
+
+  if (!vendor) return <p>Utilizador não autenticado.</p>;
+
+  return (
+    <div className="form-box">
+      <h2 className="title">Editar Perfil</h2>
+      {error && <p style={{ color: 'red' }}>{error}</p>}
+      <form onSubmit={save} className="form">
+        <div className="form-container">
+          <input
+            type="text"
+            placeholder="Nome"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            className="input"
+          />
+          <input
+            type="email"
+            placeholder="Email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className="input"
+          />
+          <select
+            value={product}
+            onChange={(e) => setProduct(e.target.value)}
+            className="input"
+          >
+            <option value="Bolas de Berlim">Bolas de Berlim</option>
+            <option value="Gelados">Gelados</option>
+            <option value="Acessórios">Acessórios</option>
+          </select>
+          <input type="file" onChange={handlePhoto} className="input" />
+        </div>
+        <div style={{ display: 'flex', gap: '1rem', marginTop: '1rem' }}>
+          <button type="submit">Guardar</button>
+          <button type="button" onClick={() => navigate('/dashboard')}>Cancelar</button>
+        </div>
+      </form>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- create mobile EditProfileScreen with form to update vendor info and profile photo
- wire EditProfileScreen into navigation and menus
- add web EditProfileScreen page and route
- update dashboard menu button to navigate to new page

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68670947bf98832eb671004db7c8c6ce