### PR TITLE
Atualiza layout do mapa e header

### DIFF
--- a/sunny_sales_web/src/App.jsx
+++ b/sunny_sales_web/src/App.jsx
@@ -92,7 +92,7 @@ const styles = {
   },
   logo: {
     textDecoration: 'none',
-    color: 'white',
+    color: '#3c73f0',
     fontWeight: 'bold',
     fontSize: '2.5rem',
   },
@@ -102,12 +102,12 @@ const styles = {
   },
   navLink: {
     textDecoration: 'none',
-    color: 'white',
+    color: '#3c73f0',
     fontWeight: 'bold',
   },
   profileIcon: {
     textDecoration: 'none',
-    color: 'white',
+    color: '#3c73f0',
     fontSize: '2rem',
     marginLeft: '1rem',
   },

--- a/sunny_sales_web/src/index.css
+++ b/sunny_sales_web/src/index.css
@@ -21,7 +21,7 @@ header {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  background: linear-gradient(to right, var(--primary-color), #ffde8a);
+  background-color: var(--primary-color);
   padding: 1.5rem 2rem;
 }
 

--- a/sunny_sales_web/src/pages/ModernMapLayout.css
+++ b/sunny_sales_web/src/pages/ModernMapLayout.css
@@ -69,7 +69,7 @@ body {
   position: relative;
   width: 70vw;
   flex: 1;
-  height: 100vh;
+  height: 80vh;
   padding: 1rem;
   box-sizing: border-box;
 }
@@ -85,8 +85,9 @@ body {
 .vendor-card {
   z-index: 1000;
   position: absolute;
-  bottom: 20px;
-  right: 20px;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
   width: 260px;
   padding: 1rem;
   background: #ffffff;
@@ -148,6 +149,41 @@ body {
   background: #345fbd;
 }
 
+.online-vendors {
+  margin-top: 2rem;
+}
+
+.vendors-title {
+  margin-bottom: 0.5rem;
+  font-size: 1.1rem;
+}
+
+.vendor-entry {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+  cursor: pointer;
+}
+
+.vendor-avatar {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  object-fit: cover;
+}
+
+.vendor-name {
+  margin: 0;
+  font-weight: bold;
+}
+
+.vendor-rating {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #555;
+}
+
 @media (max-width: 768px) {
   .modern-layout {
     flex-direction: column;
@@ -160,6 +196,6 @@ body {
   }
   .map-area {
     width: 100vw;
-    height: calc(100vh - 300px);
+    height: calc(80vh - 300px);
   }
 }


### PR DESCRIPTION
## Summary
- remove header gradient and use solid color
- colorize header text and icon in blue
- center vendor popup on the map
- shrink map height and adjust for small screens
- show button to favorite vendor when logged in
- list online vendors under filters

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6867d56541a4832ebc46ecbd88de54e5