### PR TITLE
Adjust brand colors and vendor card control

### DIFF
--- a/sunny_sales_web/src/App.jsx
+++ b/sunny_sales_web/src/App.jsx
@@ -92,7 +92,7 @@ const styles = {
   },
   logo: {
     textDecoration: 'none',
-    color: '#3c73f0',
+    color: '#ffffff',
     fontWeight: 'bold',
     fontSize: '2.5rem',
   },
@@ -102,12 +102,12 @@ const styles = {
   },
   navLink: {
     textDecoration: 'none',
-    color: '#3c73f0',
+    color: '#19a0a4',
     fontWeight: 'bold',
   },
   profileIcon: {
     textDecoration: 'none',
-    color: '#3c73f0',
+    color: '#19a0a4',
     fontSize: '2rem',
     marginLeft: '1rem',
   },

--- a/sunny_sales_web/src/index.css
+++ b/sunny_sales_web/src/index.css
@@ -3,7 +3,7 @@
 :root {
   /* Tema default */
   --primary-color: #f9c200;
-  --secondary-color: #063d93;
+  --secondary-color: #19a0a4;
   --bg-color: #ffffff;
   --text-color: #06286e;
   font-family: 'Segoe UI', sans-serif;

--- a/sunny_sales_web/src/pages/Invoices.jsx
+++ b/sunny_sales_web/src/pages/Invoices.jsx
@@ -69,14 +69,14 @@ const styles = {
   link: {
     marginLeft: '1rem',
     textDecoration: 'none',
-    color: '#0077ff',
+    color: '#19a0a4',
     fontWeight: 'bold',
   },
   back: {
     marginBottom: '1rem',
     background: 'none',
     border: 'none',
-    color: '#0077ff',
+    color: '#19a0a4',
     fontSize: '1rem',
     cursor: 'pointer',
   },

--- a/sunny_sales_web/src/pages/ModernMapLayout.css
+++ b/sunny_sales_web/src/pages/ModernMapLayout.css
@@ -27,7 +27,7 @@ body {
   margin: 0;
   font-size: 24px;
   font-weight: 600;
-  color: #3c73f0;
+  color: #19a0a4;
 }
 
 .login-buttons {
@@ -94,6 +94,17 @@ body {
   border: 1px solid #dee2e6;
   border-radius: 16px;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+}
+
+.close-btn {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  background: none;
+  border: none;
+  font-size: 1.2rem;
+  cursor: pointer;
+  color: #19a0a4;
 }
 
 .card-header {

--- a/sunny_sales_web/src/pages/ModernMapLayout.jsx
+++ b/sunny_sales_web/src/pages/ModernMapLayout.jsx
@@ -163,6 +163,13 @@ export default function ModernMapLayout() {
 
         {selected && (
           <div className="vendor-card">
+            <button
+              className="close-btn"
+              onClick={() => setSelected(null)}
+              aria-label="Fechar"
+            >
+              ×
+            </button>
             <div className="card-header">
               {selected.profile_photo ? (
                 <img

--- a/sunny_sales_web/src/pages/PaidWeeksScreen.jsx
+++ b/sunny_sales_web/src/pages/PaidWeeksScreen.jsx
@@ -72,14 +72,14 @@ const styles = {
   link: {
     marginLeft: '1rem',
     textDecoration: 'none',
-    color: '#0077ff',
+    color: '#19a0a4',
     fontWeight: 'bold',
   },
   back: {
     marginBottom: '1rem',
     background: 'none',
     border: 'none',
-    color: '#0077ff',
+    color: '#19a0a4',
     fontSize: '1rem',
     cursor: 'pointer',
   },

--- a/sunny_sales_web/src/pages/RouteDetail.jsx
+++ b/sunny_sales_web/src/pages/RouteDetail.jsx
@@ -57,7 +57,7 @@ const styles = {
     border: 'none',
     cursor: 'pointer',
     fontSize: '1rem',
-    color: '#0077cc',
+    color: '#19a0a4',
   },
   map: { height: '400px', width: '100%', marginBottom: '1rem' },
   info: { padding: '1rem', backgroundColor: '#f0f0f0', borderRadius: '8px' },

--- a/sunny_sales_web/src/pages/RoutesScreen.jsx
+++ b/sunny_sales_web/src/pages/RoutesScreen.jsx
@@ -65,7 +65,7 @@ const styles = {
     border: 'none',
     cursor: 'pointer',
     fontSize: '1rem',
-    color: '#0077cc',
+    color: '#19a0a4',
   },
   list: { listStyle: 'none', padding: 0 },
   item: {

--- a/sunny_sales_web/src/pages/StatsScreen.jsx
+++ b/sunny_sales_web/src/pages/StatsScreen.jsx
@@ -78,6 +78,6 @@ const styles = {
     border: 'none',
     cursor: 'pointer',
     fontSize: '1rem',
-    color: '#0077cc',
+    color: '#19a0a4',
   },
 };

--- a/sunny_sales_web/src/pages/TermsScreen.jsx
+++ b/sunny_sales_web/src/pages/TermsScreen.jsx
@@ -79,7 +79,7 @@ const styles = {
     border: 'none',
     cursor: 'pointer',
     fontSize: '1rem',
-    color: '#0077cc',
+    color: '#19a0a4',
   },
   title: {
     fontSize: '1.8rem',

--- a/sunny_sales_web/src/pages/VendorDashboard.jsx
+++ b/sunny_sales_web/src/pages/VendorDashboard.jsx
@@ -197,7 +197,7 @@ const styles = {
   },
   link: {
     textDecoration: 'none',
-    color: '#0077cc',
+    color: '#19a0a4',
   },
   subActive: {
     color: 'green',

--- a/sunny_sales_web/src/pages/VendorLogin.jsx
+++ b/sunny_sales_web/src/pages/VendorLogin.jsx
@@ -102,7 +102,7 @@ export default function VendorLogin() {
           type="button"
           className="outlined-button"
           onClick={() => navigate('/forgot-password')}
-          style={{ background: 'none', border: 'none', color: '#007BFF', textDecoration: 'underline' }}
+          style={{ background: 'none', border: 'none', color: '#19a0a4', textDecoration: 'underline' }}
         >
           Esqueci-me da palavra-passe
         </button>


### PR DESCRIPTION
## Summary
- change header and navigation colors
- update accent color variable
- update vendor card styles and add close button
- tweak page styles to match new color theme

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68680abf4f58832ead0f7572be10da77