### PR TITLE
Implement dark floating burger menu

### DIFF
--- a/sunny_sales_web/package.json
+++ b/sunny_sales_web/package.json
@@ -16,7 +16,8 @@
     "react-dom": "^19.1.0",
     "react-leaflet": "^5.0.0",
     "react-router-dom": "^7.6.3",
-    "recharts": "^3.0.2"
+    "recharts": "^3.0.2",
+    "react-icons": "^4.11.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.29.0",

--- a/sunny_sales_web/src/App.jsx
+++ b/sunny_sales_web/src/App.jsx
@@ -2,6 +2,7 @@
 
 import { HashRouter as Router, Routes, Route, Link } from 'react-router-dom';
 import HamburgerMenu from './components/HamburgerMenu';
+import { FiLogIn, FiUserPlus } from 'react-icons/fi';
 import About from './pages/About';
 import AccountSettings from './pages/AccountSettings';
 import ClientLogin from './pages/ClientLogin';
@@ -36,10 +37,18 @@ export default function App() {
         {/* (em português) Botão e menu hambúrguer */}
         <HamburgerMenu>
           <nav style={styles.menuLinks}>
-            <Link style={styles.navLink} to="/vendor-login">Login Vendedor</Link>
-            <Link style={styles.navLink} to="/vendor-register">Registar Vendedor</Link>
-            <Link style={styles.navLink} to="/login">Login Cliente</Link>
-            <Link style={styles.navLink} to="/register">Registar Cliente</Link>
+            <Link className="menu-item" to="/vendor-login">
+              <FiLogIn /> Login Vendedor
+            </Link>
+            <Link className="menu-item" to="/vendor-register">
+              <FiUserPlus /> Registar Vendedor
+            </Link>
+            <Link className="menu-item" to="/login">
+              <FiLogIn /> Login Cliente
+            </Link>
+            <Link className="menu-item" to="/register">
+              <FiUserPlus /> Registar Cliente
+            </Link>
           </nav>
         </HamburgerMenu>
 
@@ -99,11 +108,6 @@ const styles = {
   navLinks: {
     display: 'flex',
     gap: '1rem',
-  },
-  navLink: {
-    textDecoration: 'none',
-    color: '#19a0a4',
-    fontWeight: 'bold',
   },
   profileIcon: {
     textDecoration: 'none',

--- a/sunny_sales_web/src/components/HamburgerMenu.css
+++ b/sunny_sales_web/src/components/HamburgerMenu.css
@@ -30,7 +30,7 @@
   display: block;
   height: 3px;
   width: 100%;
-  background: #000;
+  background: #fff;
   margin: 4px 0;
   border-radius: 2px;
   transition: all 0.3s ease;
@@ -53,15 +53,42 @@
   position: absolute;
   top: 40px;
   left: 0;
-  background: #fff;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
-  padding: 1rem;
-  border-radius: 10px;
-  min-width: 220px;
+  background: #0d1117;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+  padding: 0.5rem 0;
+  border-radius: 12px;
+  min-width: 200px;
   z-index: 1999;
+  color: #fff;
+  opacity: 0;
+  transform: translateX(-10px);
+  transition: opacity 0.2s ease, transform 0.2s ease;
+  font-family: 'Segoe UI', 'Roboto', system-ui, sans-serif;
 }
 
 /* (em português) Quando o menu está aberto */
 .popup-window.open {
   display: block;
+  opacity: 1;
+  transform: translateX(0);
+}
+
+.menu-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px;
+  color: #fff;
+  text-decoration: none;
+}
+
+.menu-item:hover {
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.menu-overlay {
+  position: fixed;
+  inset: 0;
+  background: transparent;
+  z-index: 1998;
 }

--- a/sunny_sales_web/src/components/HamburgerMenu.jsx
+++ b/sunny_sales_web/src/components/HamburgerMenu.jsx
@@ -20,6 +20,8 @@ export default function HamburgerMenu({ children }) {
       </button>
 
       {/* (em português) Janela de menu que aparece ao clicar */}
+      {open && <div className="menu-overlay" onClick={() => setOpen(false)} />}
+
       <nav
         className={`popup-window${open ? ' open' : ''}`}
         onClick={() => setOpen(false)}


### PR DESCRIPTION
## Summary
- style HamburgerMenu with dark theme and icons
- add menu overlay and animations
- update App navigation links with icons
- include `react-icons` dependency

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686815a62a80832ebd35483cafb58085