### PR TITLE
Add slide-out menus to dashboards

### DIFF
--- a/sunny_sales_web/src/pages/DashboardCliente.jsx
+++ b/sunny_sales_web/src/pages/DashboardCliente.jsx
@@ -8,6 +8,7 @@ import { BASE_URL } from '../config';
 export default function DashboardCliente() {
   const [client, setClient] = useState(null);
   const [favorites, setFavorites] = useState([]);
+  const [menuOpen, setMenuOpen] = useState(false);
   const navigate = useNavigate();
 
   // carregar cliente do localStorage
@@ -44,7 +45,15 @@ export default function DashboardCliente() {
 
   return (
     <div style={styles.wrapper}>
-      <div>
+      <button style={styles.menuButton} onClick={() => setMenuOpen(!menuOpen)}>
+        ☰
+      </button>
+      <div
+        style={{
+          ...styles.sideMenu,
+          ...(menuOpen ? styles.sideMenuOpen : {}),
+        }}
+      >
         <legend>Menu</legend>
         <ul>
           <li><button onClick={() => navigate('/settings')}>Notificações</button></li>
@@ -149,4 +158,33 @@ const styles = {
     cursor: 'pointer',
     fontWeight: 'bold',
   },
-}
+  menuButton: {
+    position: 'fixed',
+    top: '6rem',
+    left: '1rem',
+    zIndex: 1100,
+    backgroundColor: '#19a0a4',
+    color: '#fff',
+    border: 'none',
+    padding: '0.5rem 1rem',
+    cursor: 'pointer',
+  },
+  sideMenu: {
+    position: 'fixed',
+    top: 0,
+    left: 0,
+    height: '100%',
+    width: '250px',
+    backgroundColor: '#f8f8f8',
+    boxShadow: '2px 0 5px rgba(0,0,0,0.1)',
+    padding: '1rem',
+    boxSizing: 'border-box',
+    transform: 'translateX(-100%)',
+    transition: 'transform 0.3s ease-in-out',
+    zIndex: 1000,
+  },
+  sideMenuOpen: {
+    transform: 'translateX(0)'
+  },
+};
+

--- a/sunny_sales_web/src/pages/VendorDashboard.jsx
+++ b/sunny_sales_web/src/pages/VendorDashboard.jsx
@@ -9,6 +9,7 @@ export default function VendorDashboard() {
   const [vendor, setVendor] = useState(null);
   const [sharing, setSharing] = useState(false);
   const [reviews, setReviews] = useState([]);
+  const [menuOpen, setMenuOpen] = useState(false);
   const navigate = useNavigate();
 
   // carrega dados do vendedor guardados no localStorage
@@ -108,7 +109,15 @@ export default function VendorDashboard() {
 
   return (
     <div style={styles.wrapper}>
-      <div>
+      <button style={styles.menuButton} onClick={() => setMenuOpen(!menuOpen)}>
+        ☰
+      </button>
+      <div
+        style={{
+          ...styles.sideMenu,
+          ...(menuOpen ? styles.sideMenuOpen : {}),
+        }}
+      >
         <legend>Menu</legend>
         <ul>
           <li><button onClick={paySubscription}>Pagar Semanalidade</button></li>
@@ -209,6 +218,34 @@ const styles = {
     backgroundColor: '#19a0a4',
     cursor: 'pointer',
   },
+  menuButton: {
+    position: 'fixed',
+    top: '6rem',
+    left: '1rem',
+    zIndex: 1100,
+    backgroundColor: '#19a0a4',
+    color: '#fff',
+    border: 'none',
+    padding: '0.5rem 1rem',
+    cursor: 'pointer',
+  },
+  sideMenu: {
+    position: 'fixed',
+    top: 0,
+    left: 0,
+    height: '100%',
+    width: '250px',
+    backgroundColor: '#f8f8f8',
+    boxShadow: '2px 0 5px rgba(0,0,0,0.1)',
+    padding: '1rem',
+    boxSizing: 'border-box',
+    transform: 'translateX(-100%)',
+    transition: 'transform 0.3s ease-in-out',
+    zIndex: 1000,
+  },
+  sideMenuOpen: {
+    transform: 'translateX(0)'
+  },
   shareButton: {
     marginTop: '1rem',
     padding: '0.5rem 1rem',
@@ -238,4 +275,5 @@ const styles = {
     padding: '4px 0',
   },
 };
+
 


### PR DESCRIPTION
## Summary
- enable toggled side menu on customer dashboard
- add same slide-out menu on vendor dashboard
- fix vertical position of side menu button
- add missing newline at end of dashboard files
- remove trailing commas that broke build

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686c017fecf8832e8afb719260632ebc