### PR TITLE
Adjust login form layout

### DIFF
--- a/sunny_sales_web/src/index.css
+++ b/sunny_sales_web/src/index.css
@@ -77,6 +77,11 @@ h2 {
   padding: 20px 30px;
 }
 
+/* Versão mais compacta usada nos ecrãs de login */
+.form-container.login-container {
+  height: auto;
+}
+
 .title {
   text-align: center;
   font-family: "Lucida Sans", "Lucida Sans Regular", "Lucida Grande",

--- a/sunny_sales_web/src/pages/ClientLogin.jsx
+++ b/sunny_sales_web/src/pages/ClientLogin.jsx
@@ -71,7 +71,7 @@ export default function ClientLogin() {
         <p style={{ color: 'red', marginBottom: '1rem' }}>{error}</p>
       )}
       <div className="form">
-        <div className="form-container">
+        <div className="form-container login-container">
           <input
             type="email"
             placeholder="Email"

--- a/sunny_sales_web/src/pages/VendorLogin.jsx
+++ b/sunny_sales_web/src/pages/VendorLogin.jsx
@@ -69,7 +69,7 @@ export default function VendorLogin() {
       {error && <p style={{ color: 'red', marginBottom: '1rem' }}>{error}</p>}
 
       <div className="form">
-        <div className="form-container">
+        <div className="form-container login-container">
           <input
             type="email"
             placeholder="Email"


### PR DESCRIPTION
## Summary
- shrink login box to fit just the inputs
- keep buttons closer to the form on both vendor and client login pages

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686e1d357f28832e81a86fada8135721