### PR TITLE
Adjust login form layout

### DIFF
--- a/sunny_sales_web/src/index.css
+++ b/sunny_sales_web/src/index.css
@@ -77,6 +77,27 @@ h2 {
   padding: 20px 30px;
 }
 
+/* Versão mais compacta usada nos ecrãs de login */
+.form-container.login-container {
+  height: auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.login-form {
+  align-items: center;
+}
+
+.login-form button {
+  display: inline-flex;
+  align-self: center;
+}
+
+.form-container.login-container input {
+  width: 100%;
+}
+
 .title {
   text-align: center;
   font-family: "Lucida Sans", "Lucida Sans Regular", "Lucida Grande",

--- a/sunny_sales_web/src/pages/ClientLogin.jsx
+++ b/sunny_sales_web/src/pages/ClientLogin.jsx
@@ -70,8 +70,8 @@ export default function ClientLogin() {
       {error && (
         <p style={{ color: 'red', marginBottom: '1rem' }}>{error}</p>
       )}
-      <div className="form">
-        <div className="form-container">
+      <div className="form login-form">
+        <div className="form-container login-container">
           <input
             type="email"
             placeholder="Email"

--- a/sunny_sales_web/src/pages/VendorLogin.jsx
+++ b/sunny_sales_web/src/pages/VendorLogin.jsx
@@ -68,8 +68,8 @@ export default function VendorLogin() {
 
       {error && <p style={{ color: 'red', marginBottom: '1rem' }}>{error}</p>}
 
-      <div className="form">
-        <div className="form-container">
+      <div className="form login-form">
+        <div className="form-container login-container">
           <input
             type="email"
             placeholder="Email"


### PR DESCRIPTION
## Summary
- shrink login form buttons to fit text and center content
- ensure client and vendor login fields align with the page title

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686e1d357f28832e81a86fada8135721