### PR TITLE
Improve comments across web app

### DIFF
--- a/sunny_sales_web/src/App.jsx
+++ b/sunny_sales_web/src/App.jsx
@@ -23,6 +23,7 @@ import ModernMapLayout from './pages/ModernMapLayout';
 import LoginSelection from './pages/LoginSelection';
 import './index.css'; // (em português) Importa os estilos globais
 
+// Componente principal que define as rotas da aplicação web
 export default function App() {
   const isLoggedIn = localStorage.getItem('user') || localStorage.getItem('client');
   const profileLink = isLoggedIn ? '/dashboard' : '/login-selection';

--- a/sunny_sales_web/src/components/LoadingDots.jsx
+++ b/sunny_sales_web/src/components/LoadingDots.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import './LoadingDots.css';
 
+// Componente de indicador de carregamento com três pontos animados
 export default function LoadingDots() {
   return (
     <div className="dots-container" aria-label="A carregar" role="status">

--- a/sunny_sales_web/src/main.jsx
+++ b/sunny_sales_web/src/main.jsx
@@ -3,6 +3,8 @@ import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.jsx'
 
+// Ponto de entrada que renderiza a aplicação React
+
 createRoot(document.getElementById('root')).render(
   <StrictMode>
     <App />

--- a/sunny_sales_web/src/pages/About.jsx
+++ b/sunny_sales_web/src/pages/About.jsx
@@ -33,6 +33,7 @@ const styles = {
   }
 };
 
+// Página informativa sobre a aplicação
 export default function About() {
   const navigate = useNavigate();
   return (

--- a/sunny_sales_web/src/pages/AccountSettings.jsx
+++ b/sunny_sales_web/src/pages/AccountSettings.jsx
@@ -3,22 +3,25 @@
 import React, { useEffect, useState } from 'react';
 
 // Simulação dos serviços (deves adaptar ao que tiveres no backend/localStorage)
-const isNotificationsEnabled = async () => {
-  return localStorage.getItem('notifications_enabled') === 'true';
-};
+// Obtém se as notificações estão ativas no localStorage
+const isNotificationsEnabled = () =>
+  localStorage.getItem('notifications_enabled') === 'true';
 
-const setNotificationsEnabled = async (value) => {
+// Atualiza o estado de notificações no localStorage
+const setNotificationsEnabled = (value) => {
   localStorage.setItem('notifications_enabled', value);
 };
 
-const getNotificationRadius = async () => {
-  return parseInt(localStorage.getItem('notification_radius') || '20', 10);
-};
+// Obtém o raio configurado
+const getNotificationRadius = () =>
+  parseInt(localStorage.getItem('notification_radius') || '20', 10);
 
-const setNotificationRadius = async (value) => {
+// Guarda o raio de alertas
+const setNotificationRadius = (value) => {
   localStorage.setItem('notification_radius', value);
 };
 
+// Componente que permite configurar notificações e raio de alertas
 export default function AccountSettings() {
   const [enabled, setEnabled] = useState(true);
   const [radius, setRadius] = useState('20');
@@ -32,12 +35,14 @@ export default function AccountSettings() {
     load();
   }, []);
 
+  // Alterna o estado das notificações
   const toggleNotifications = async () => {
     const val = !enabled;
     setEnabled(val);
     await setNotificationsEnabled(val);
   };
 
+  // Atualiza o raio de alertas no localStorage
   const changeRadius = async (value) => {
     setRadius(String(value));
     await setNotificationRadius(value);
@@ -73,4 +78,3 @@ export default function AccountSettings() {
   );
 }
 
-// (em português) Estilos incluídos no mesmo ficheiro

--- a/sunny_sales_web/src/pages/ClientLogin.jsx
+++ b/sunny_sales_web/src/pages/ClientLogin.jsx
@@ -6,6 +6,7 @@ import axios from 'axios';
 import { BASE_URL } from '../config';
 import LoadingDots from '../components/LoadingDots';
 
+// Componente de login para clientes
 export default function ClientLogin() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
@@ -24,6 +25,7 @@ export default function ClientLogin() {
     }
   };
 
+  // Tenta autenticar o cliente no backend
   const login = async () => {
     if (!email || !password) return;
     setLoading(true);

--- a/sunny_sales_web/src/pages/ClientRegister.jsx
+++ b/sunny_sales_web/src/pages/ClientRegister.jsx
@@ -6,6 +6,7 @@ import { useNavigate } from 'react-router-dom';
 import { BASE_URL } from '../config';
 import LoadingDots from '../components/LoadingDots';
 
+// Componente de registo de novos clientes
 export default function ClientRegister() {
   const [name, setName] = useState('');
   const [email, setEmail] = useState('');
@@ -15,6 +16,7 @@ export default function ClientRegister() {
   const [loading, setLoading] = useState(false);
   const navigate = useNavigate();
 
+  // Trata a seleção de uma foto de perfil
   const pickImage = (e) => {
     const file = e.target.files[0];
     if (file) {
@@ -22,6 +24,7 @@ export default function ClientRegister() {
     }
   };
 
+  // Envia os dados de registo para o servidor
   const register = async () => {
     if (!name || !email || !password) {
       setError('Preencha todos os campos obrigatórios');
@@ -121,4 +124,3 @@ export default function ClientRegister() {
   );
 }
 
-// (em português) Estilos embutidos

--- a/sunny_sales_web/src/pages/Dashboard.jsx
+++ b/sunny_sales_web/src/pages/Dashboard.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import DashboardCliente from './DashboardCliente';
 import VendorDashboard from './VendorDashboard';
 
+// Escolhe o dashboard apropriado consoante o tipo de utilizador
 export default function Dashboard() {
   const hasClient = !!localStorage.getItem('client');
   const hasVendor = !!localStorage.getItem('user');

--- a/sunny_sales_web/src/pages/DashboardCliente.jsx
+++ b/sunny_sales_web/src/pages/DashboardCliente.jsx
@@ -5,6 +5,7 @@ import { useNavigate } from 'react-router-dom';
 import axios from 'axios';
 import { BASE_URL } from '../config';
 
+// Painel principal do cliente com lista de favoritos
 export default function DashboardCliente() {
   const [client, setClient] = useState(null);
   const [favorites, setFavorites] = useState([]);
@@ -32,6 +33,7 @@ export default function DashboardCliente() {
     }
   };
 
+  // Termina a sessão do cliente
   const logout = () => {
     localStorage.removeItem('client');
     localStorage.removeItem('clientToken');

--- a/sunny_sales_web/src/pages/EditProfileScreen.jsx
+++ b/sunny_sales_web/src/pages/EditProfileScreen.jsx
@@ -3,6 +3,7 @@ import axios from 'axios';
 import { BASE_URL } from '../config';
 import { useNavigate } from 'react-router-dom';
 
+// Ecrã para edição dos dados do utilizador autenticado
 export default function EditProfileScreen() {
   const navigate = useNavigate();
   const [user, setUser] = useState(null);
@@ -32,12 +33,14 @@ export default function EditProfileScreen() {
     }
   }, []);
 
+  // Guarda a foto selecionada pelo utilizador
   const handlePhoto = (e) => {
     if (e.target.files && e.target.files[0]) {
       setPhoto(e.target.files[0]);
     }
   };
 
+  // Envia as alterações de perfil para o servidor
   const save = async (e) => {
     e.preventDefault();
     if (!user) return;

--- a/sunny_sales_web/src/pages/ForgotPassword.jsx
+++ b/sunny_sales_web/src/pages/ForgotPassword.jsx
@@ -4,12 +4,14 @@ import axios from 'axios';
 import { BASE_URL } from '../config';
 import LoadingDots from '../components/LoadingDots';
 
+// Página para solicitar reposição da palavra-passe
 export default function ForgotPassword() {
   const [email, setEmail] = useState('');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
   const [message, setMessage] = useState(null);
 
+  // Envia pedido de redefinição de palavra-passe
   const requestReset = async () => {
     if (!email) return;
     setLoading(true);
@@ -49,4 +51,3 @@ export default function ForgotPassword() {
   );
 }
 
-// (em português) Estilos básicos para a página

--- a/sunny_sales_web/src/pages/Invoices.jsx
+++ b/sunny_sales_web/src/pages/Invoices.jsx
@@ -4,10 +4,12 @@ import axios from 'axios';
 import { BASE_URL } from '../config';
 import { useNavigate } from 'react-router-dom';
 
+// Lista as semanas pagas e respetivas faturas
 export default function Invoices() {
   const [weeks, setWeeks] = useState([]);
   const navigate = useNavigate();
 
+  // Obtém do backend as semanas já pagas
   const loadWeeks = async () => {
     const stored = localStorage.getItem('user');
     const token = localStorage.getItem('token');

--- a/sunny_sales_web/src/pages/LoginSelection.jsx
+++ b/sunny_sales_web/src/pages/LoginSelection.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
 
+// Permite escolher o tipo de conta a iniciar sessão
 export default function LoginSelection() {
   const navigate = useNavigate();
   return (

--- a/sunny_sales_web/src/pages/ManageAccount.jsx
+++ b/sunny_sales_web/src/pages/ManageAccount.jsx
@@ -4,6 +4,7 @@ import React, { useEffect, useState } from 'react';
 import axios from 'axios';
 import { BASE_URL } from '../config';
 
+// Página para o vendedor atualizar ou remover a sua conta
 export default function ManageAccount() {
   const [vendor, setVendor] = useState(null);
   const [name, setName] = useState('');
@@ -28,10 +29,12 @@ export default function ManageAccount() {
     }
   }, []);
 
+  // Guarda a foto enviada no formulário
   const handlePhotoChange = (e) => {
     setPhoto(e.target.files[0]);
   };
 
+  // Envia as alterações do formulário para o backend
   const handleUpdate = async (e) => {
     e.preventDefault();
     if (!vendor) return;
@@ -139,4 +142,3 @@ export default function ManageAccount() {
   );
 }
 
-// (em português) Estilos simples para a página

--- a/sunny_sales_web/src/pages/ModernMapLayout.jsx
+++ b/sunny_sales_web/src/pages/ModernMapLayout.jsx
@@ -6,6 +6,7 @@ import axios from 'axios';
 import { BASE_URL } from '../config';
 import './ModernMapLayout.css';
 
+// Layout principal com mapa e lista de vendedores online
 export default function ModernMapLayout() {
   const navigate = useNavigate();
   const [vendors, setVendors] = useState([]);
@@ -40,12 +41,14 @@ export default function ModernMapLayout() {
     selectedProducts.includes(v.product)
   );
 
+  // Alterna a seleção de um produto no filtro
   const toggleProduct = (p) => {
     setSelectedProducts((prev) =>
       prev.includes(p) ? prev.filter((v) => v !== p) : [...prev, p]
     );
   };
 
+  // Centraliza o mapa no vendedor selecionado
   const focusVendor = (v) => {
     setSelected(v);
     if (mapRef.current) {
@@ -53,6 +56,7 @@ export default function ModernMapLayout() {
     }
   };
 
+  // Marca ou desmarca o vendedor como favorito
   const toggleFavorite = () => {
     if (!selected) return;
     const stored = JSON.parse(localStorage.getItem('favorites') || '[]');

--- a/sunny_sales_web/src/pages/PaidWeeksScreen.jsx
+++ b/sunny_sales_web/src/pages/PaidWeeksScreen.jsx
@@ -5,11 +5,12 @@ import axios from 'axios';
 import { BASE_URL } from '../config';
 import { Link, useNavigate } from 'react-router-dom';
 
+// Mostra ao vendedor as semanas já pagas
 export default function PaidWeeksScreen() {
   const [weeks, setWeeks] = useState([]);
   const navigate = useNavigate();
 
-  // loadWeeks
+  // Carrega as semanas pagas do vendedor
   const loadWeeks = async () => {
     const stored = localStorage.getItem('user');
     const token = localStorage.getItem('token');

--- a/sunny_sales_web/src/pages/RouteDetail.jsx
+++ b/sunny_sales_web/src/pages/RouteDetail.jsx
@@ -4,6 +4,7 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import { MapContainer, TileLayer, Polyline } from 'react-leaflet';
 import 'leaflet/dist/leaflet.css';
 
+// Mostra no mapa o percurso detalhado do trajeto selecionado
 export default function RouteDetail() {
   const location = useLocation();
   const navigate = useNavigate();

--- a/sunny_sales_web/src/pages/RoutesScreen.jsx
+++ b/sunny_sales_web/src/pages/RoutesScreen.jsx
@@ -4,11 +4,12 @@ import { useNavigate } from 'react-router-dom';
 import axios from 'axios';
 import { BASE_URL } from '../config';
 
+// Lista os trajetos registados pelo vendedor
 export default function RoutesScreen() {
   const [routes, setRoutes] = useState([]);
   const navigate = useNavigate();
 
-  // carregar trajetos do vendedor
+  // Obtém do backend os trajetos do vendedor
   const loadRoutes = async () => {
     const stored = localStorage.getItem('user');
     const token = localStorage.getItem('token');

--- a/sunny_sales_web/src/pages/StatsScreen.jsx
+++ b/sunny_sales_web/src/pages/StatsScreen.jsx
@@ -5,11 +5,12 @@ import { BASE_URL } from '../config';
 import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, CartesianGrid } from 'recharts';
 import { useNavigate } from 'react-router-dom';
 
+// Mostra gráfico de distâncias percorridas pelo vendedor
 export default function StatsScreen() {
   const [chartData, setChartData] = useState([]);
   const navigate = useNavigate();
 
-  // carregar dados
+  // Carrega os trajetos para gerar o gráfico
   const loadRoutes = async () => {
     const stored = localStorage.getItem('user');
     const token = localStorage.getItem('token');

--- a/sunny_sales_web/src/pages/TermsScreen.jsx
+++ b/sunny_sales_web/src/pages/TermsScreen.jsx
@@ -3,6 +3,7 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
 
+// Exibe os termos e condições de utilização
 export default function TermsScreen() {
   const navigate = useNavigate();
 

--- a/sunny_sales_web/src/pages/VendorDashboard.jsx
+++ b/sunny_sales_web/src/pages/VendorDashboard.jsx
@@ -5,6 +5,7 @@ import axios from 'axios';
 
 let watchId = null;
 
+// Painel principal do vendedor com partilha de localização
 export default function VendorDashboard() {
   const [vendor, setVendor] = useState(null);
   const [sharing, setSharing] = useState(false);
@@ -35,12 +36,14 @@ export default function VendorDashboard() {
     loadReviews();
   }, [vendor]);
 
+  // Termina sessão do vendedor
   const logout = () => {
     localStorage.removeItem('user');
     localStorage.removeItem('token');
     navigate('/vendor-login');
   };
 
+  // Ativa partilha de localização em tempo real
   const startSharing = async () => {
     if (!vendor) return;
     const token = localStorage.getItem('token');
@@ -71,6 +74,7 @@ export default function VendorDashboard() {
     }
   };
 
+  // Desativa a partilha de localização
   const stopSharing = async () => {
     if (watchId) {
       navigator.geolocation.clearWatch(watchId);
@@ -92,6 +96,7 @@ export default function VendorDashboard() {
     setSharing(false);
   };
 
+  // Abre o checkout de pagamento de subscrição
   const paySubscription = async () => {
     if (!vendor) return;
     try {

--- a/sunny_sales_web/src/pages/VendorDetailScreen.jsx
+++ b/sunny_sales_web/src/pages/VendorDetailScreen.jsx
@@ -4,6 +4,7 @@ import axios from 'axios';
 import { BASE_URL } from '../config';
 import './VendorDetailScreen.css'; // Deves criar este ficheiro com os estilos CSS
 
+// Página de detalhes de um vendedor específico
 export default function VendorDetailScreen({ vendor }) {
   const [reviews, setReviews] = useState([]);
   const [rating, setRating] = useState(0);
@@ -13,6 +14,7 @@ export default function VendorDetailScreen({ vendor }) {
   const [storyIndex, setStoryIndex] = useState(null);
 
   // (em português) Carrega as reviews do vendedor
+  // Carrega avaliações do vendedor
   const loadReviews = async () => {
     try {
       const res = await axios.get(`${BASE_URL}/vendors/${vendor.id}/reviews`);
@@ -23,6 +25,7 @@ export default function VendorDetailScreen({ vendor }) {
   };
 
   // (em português) Carrega os stories
+  // Obtém os stories publicados pelo vendedor
   const loadStories = async () => {
     try {
       const res = await axios.get(`${BASE_URL}/vendors/${vendor.id}/stories`);
@@ -40,6 +43,7 @@ export default function VendorDetailScreen({ vendor }) {
   }, [vendor.id]);
 
   // (em português) Envia nova avaliação
+  // Envia uma nova avaliação do cliente
   const submitReview = async () => {
     const token = localStorage.getItem('clientToken');
     if (!token) return alert('Inicie sessão para avaliar');
@@ -60,6 +64,7 @@ export default function VendorDetailScreen({ vendor }) {
   };
 
   // (em português) Alterna favoritos
+  // Adiciona ou remove o vendedor dos favoritos
   const toggleFavorite = () => {
     const stored = JSON.parse(localStorage.getItem('favorites') || '[]');
     let updated;

--- a/sunny_sales_web/src/pages/VendorLogin.jsx
+++ b/sunny_sales_web/src/pages/VendorLogin.jsx
@@ -6,6 +6,7 @@ import axios from 'axios';
 import { BASE_URL } from '../config';
 import LoadingDots from '../components/LoadingDots';
 
+// Componente de login dedicado aos vendedores
 export default function VendorLogin() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
@@ -25,6 +26,7 @@ export default function VendorLogin() {
   };
 
   // login
+  // Realiza a autenticação do vendedor
   const login = async () => {
     if (!email || !password) return;
     setLoading(true);
@@ -112,4 +114,3 @@ export default function VendorLogin() {
   );
 }
 
-// (em português) Estilos simples para versão Web

--- a/sunny_sales_web/src/pages/VendorRegister.jsx
+++ b/sunny_sales_web/src/pages/VendorRegister.jsx
@@ -3,6 +3,7 @@ import React, { useState } from 'react';
 import axios from 'axios';
 import { BASE_URL } from '../config';
 
+// Formulário de registo para novos vendedores
 export default function VendorRegister() {
   const [name, setName] = useState('');
   const [email, setEmail] = useState('');
@@ -12,12 +13,12 @@ export default function VendorRegister() {
   const [error, setError] = useState('');
   const [success, setSuccess] = useState('');
 
-  // # Função para selecionar imagem
+  // Guarda a imagem de perfil selecionada
   const handlePhotoChange = (e) => {
     setPhoto(e.target.files[0]);
   };
 
-  // # Função para registar
+  // Envia os dados de registo do vendedor
   const handleRegister = async (e) => {
     e.preventDefault();
     setError('');
@@ -114,4 +115,3 @@ export default function VendorRegister() {
   );
 }
 
-// # Estilos simples para layout Web


### PR DESCRIPTION
## Summary
- document components and helper functions in the `sunny_sales_web` React app
- trim leftover style comments
- use synchronous helpers in account settings

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686e4e7ed234832eb461bd262096da8c