### PR TITLE
Center inputs on register

### DIFF
--- a/sunny_sales_web/src/pages/ClientRegister.jsx
+++ b/sunny_sales_web/src/pages/ClientRegister.jsx
@@ -69,8 +69,8 @@ export default function ClientRegister() {
     <div className="form-box">
       <h2 className="title">Registo de Cliente</h2>
       {error && <p style={{ color: 'red', marginBottom: '1rem' }}>{error}</p>}
-      <div className="form">
-        <div className="form-container">
+      <div className="form login-form">
+        <div className="form-container login-container">
           <input
             type="text"
             placeholder="Nome"


### PR DESCRIPTION
## Summary
- center client registration fields and button by using login styles

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686e572cd81c832eba0395caf1a2ee98