### PR TITLE
Ajustes nos menus laterais da versão web

### DIFF
--- a/sunny_sales_web/src/pages/DashboardCliente.jsx
+++ b/sunny_sales_web/src/pages/DashboardCliente.jsx
@@ -57,7 +57,7 @@ export default function DashboardCliente() {
         }}
       >
         <legend>Menu</legend>
-        <ul>
+        <ul style={styles.menuList}>
           <li><button onClick={() => navigate('/settings')}>Notificações</button></li>
           <hr />
           <li><button onClick={() => navigate('/edit-profile')}>Atualizar Dados Pessoais</button></li>
@@ -182,6 +182,7 @@ const styles = {
     backgroundColor: '#f8f8f8',
     boxShadow: '2px 0 5px rgba(0,0,0,0.1)',
     padding: '1rem',
+    paddingTop: '9rem',
     boxSizing: 'border-box',
     transform: 'translateX(-100%)',
     transition: 'transform 0.3s ease-in-out',
@@ -189,5 +190,14 @@ const styles = {
   },
   sideMenuOpen: {
     transform: 'translateX(0)',
+  },
+  menuList: {
+    listStyle: 'none',
+    padding: 0,
+    margin: 0,
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '0.5rem',
+    alignItems: 'flex-start',
   },
 };

--- a/sunny_sales_web/src/pages/VendorDashboard.jsx
+++ b/sunny_sales_web/src/pages/VendorDashboard.jsx
@@ -124,7 +124,7 @@ export default function VendorDashboard() {
         }}
       >
         <legend>Menu</legend>
-        <ul>
+        <ul style={styles.menuList}>
           <li><button onClick={paySubscription}>Pagar Semanalidade</button></li>
           <li><button onClick={() => navigate('/paid-weeks')}>Semanas Pagas</button></li>
           <li><button onClick={() => navigate('/invoices')}>Faturas</button></li>
@@ -246,6 +246,7 @@ const styles = {
     backgroundColor: '#f8f8f8',
     boxShadow: '2px 0 5px rgba(0,0,0,0.1)',
     padding: '1rem',
+    paddingTop: '9rem',
     boxSizing: 'border-box',
     transform: 'translateX(-100%)',
     transition: 'transform 0.3s ease-in-out',
@@ -270,6 +271,15 @@ const styles = {
     listStyle: 'none',
     padding: 0,
     margin: 0,
+  },
+  menuList: {
+    listStyle: 'none',
+    padding: 0,
+    margin: 0,
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '0.5rem',
+    alignItems: 'flex-start',
   },
   reviewItem: {
     borderBottom: '1px solid #ccc',


### PR DESCRIPTION
## Summary
- remove bullets on vendor and client side menus
- ensure first menu item appears below menu icon
- align menu buttons to the left and keep equal spacing

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686e6d1d6018832eab1fefcbd313e6fa