### PR TITLE
Make header profile icon white

### DIFF
--- a/sunny_sales_web/src/App.jsx
+++ b/sunny_sales_web/src/App.jsx
@@ -91,7 +91,7 @@ const styles = {
   },
   profileIcon: {
     textDecoration: 'none',
-    color: '#19a0a4',
+    color: '#ffffff',
     fontSize: '2rem',
     marginLeft: '1rem',
   },

--- a/sunny_sales_web/src/index.css
+++ b/sunny_sales_web/src/index.css
@@ -32,7 +32,7 @@ header a {
 }
 
 header a:last-child {
-  color: var(--secondary-color) !important;
+  color: #FFFFFF !important;
 
 }
 


### PR DESCRIPTION
## Summary
- change profile icon color in App.jsx to white
- set header last link color to white in global styles

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_687629adbbf8832eae85cb77171664d5