### PR TITLE
Implement client social login

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ scripts/    Utilidades auxiliares
 - **Estatísticas**: painel no aplicativo mostra gráfico das distâncias diárias percorridas.
 - **Favoritos**: clientes podem marcar vendedores favoritos para receber notificações de proximidade.
 - **Respostas a reviews**: vendedores podem responder ou ocultar avaliações via API.
+- **Login social**: clientes podem registar-se com contas Google ou Apple.
 - **Tradução e acessibilidade**: interface com suporte a português e inglês e elementos com labels acessíveis.
    A variável `BASE_URL` em `mobile/config.js` deve apontar para o endereço do backend.
 

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -45,6 +45,8 @@ class Client(Base):
     confirmation_token = Column(String, nullable=True, index=True)
     password_reset_token = Column(String, nullable=True, index=True)
     password_reset_expires = Column(DateTime, nullable=True)
+    google_id = Column(String, unique=True, index=True, nullable=True)
+    apple_id = Column(String, unique=True, index=True, nullable=True)
 
     favorites = relationship("Favorite", back_populates="client")
     reviews = relationship("Review", back_populates="client")


### PR DESCRIPTION
## Summary
- allow clients to authenticate using Google or Apple tokens
- add social login fields to the Client model
- include new tests for `/client-oauth`
- document social login feature in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_687f6dbde94c832e911914db24424364