### PR TITLE
Remove login options from map layout

### DIFF
--- a/sunny_sales_web/src/pages/ModernMapLayout.jsx
+++ b/sunny_sales_web/src/pages/ModernMapLayout.jsx
@@ -74,18 +74,6 @@ export default function ModernMapLayout() {
   return (
     <div className="modern-layout">
       <aside className="sidebar">
-        <h1 className="app-name">Sunny Sales</h1>
-        <div className="login-buttons">
-          <button
-            className="login-btn"
-            onClick={() => navigate('/vendor-login')}
-          >
-            Login Vendedor
-          </button>
-          <button className="login-btn" onClick={() => navigate('/login')}>
-            Login Cliente
-          </button>
-        </div>
 
         <div className="filters">
           <h2 className="filters-title">Filtros</h2>


### PR DESCRIPTION
## Summary
- clean up the sidebar of `ModernMapLayout`
- remove the 'Sunny Sales' label and the vendor/client login buttons

## Testing
- `npm test --prefix sunny_sales_web` *(fails: Missing script 'test')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68877b8fdd84832eac0227e7b59834c8