### PR TITLE
Remove redundant filter heading

### DIFF
--- a/sunny_sales_web/src/pages/ModernMapLayout.jsx
+++ b/sunny_sales_web/src/pages/ModernMapLayout.jsx
@@ -76,7 +76,6 @@ export default function ModernMapLayout() {
       <aside className="sidebar">
 
         <div className="filters">
-          <h2 className="filters-title">Filtros</h2>
           <p className="filters-subtitle">Produto vendido</p>
           {PRODUCTS.map((p) => (
             <label key={p} className="filter-label">


### PR DESCRIPTION
## Summary
- remove the "Filtros" heading from ModernMapLayout

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68877f82f510832e848bc8ad6b9ea02b