### PR TITLE
Fix vendor registration link

### DIFF
--- a/sunny_sales_web/src/pages/VendorLogin.jsx
+++ b/sunny_sales_web/src/pages/VendorLogin.jsx
@@ -96,7 +96,7 @@ export default function VendorLogin() {
         <button
           type="button"
           className="outlined-button"
-          onClick={() => navigate('/register')}
+          onClick={() => navigate('/vendor-register')}
         >
           Registar
         </button>


### PR DESCRIPTION
## Summary
- link vendor login to the vendor register page instead of the client register page

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_688782fa8954832e83d0dc486ea18afe