### PR TITLE
Add informational pages

### DIFF
--- a/sunny_sales_web/src/App.jsx
+++ b/sunny_sales_web/src/App.jsx
@@ -21,6 +21,9 @@ import Invoices from './pages/Invoices';
 import Dashboard from './pages/Dashboard';
 import ModernMapLayout from './pages/ModernMapLayout';
 import LoginSelection from './pages/LoginSelection';
+import SobreProjeto from './pages/SobreProjeto';
+import Sustentabilidade from './pages/Sustentabilidade';
+import ImplementarScreen from './pages/ImplementarScreen';
 import './index.css'; // (em português) Importa os estilos globais
 
 // Componente principal que define as rotas da aplicação web
@@ -34,6 +37,19 @@ export default function App() {
       <header className="navbar">
         <Link className="logo-link" to="/">Sunny Sales</Link>
 
+        {/* (em português) Links de navegação para as páginas informativas */}
+        <nav className="nav-links">
+          <Link className="nav-link" to="/sobre-projeto">
+            Sobre o Projeto
+          </Link>
+          <Link className="nav-link" to="/sustentabilidade">
+            Sustentabilidade
+          </Link>
+          <Link className="nav-link" to="/implementacao">
+            Implementar
+          </Link>
+        </nav>
+
         {/* (em português) Ícone de perfil com cor branca */}
         <Link to={profileLink} className="profile-icon" aria-label="Login">
           <FiUser />
@@ -46,6 +62,9 @@ export default function App() {
           {/* (em português) Página principal com layout moderno */}
           <Route path="/" element={<ModernMapLayout />} />
           <Route path="/about" element={<About />} />
+          <Route path="/sobre-projeto" element={<SobreProjeto />} />
+          <Route path="/sustentabilidade" element={<Sustentabilidade />} />
+          <Route path="/implementacao" element={<ImplementarScreen />} />
           <Route path="/settings" element={<AccountSettings />} />
           <Route path="/login" element={<ClientLogin />} />
           <Route path="/register" element={<ClientRegister />} />

--- a/sunny_sales_web/src/index.css
+++ b/sunny_sales_web/src/index.css
@@ -40,6 +40,19 @@ body {
   font-size: 2.5rem;
 }
 
+.nav-links {
+  display: flex;
+  gap: 1rem;
+  margin-right: 1rem;
+}
+
+.nav-link {
+  color: #ffffff;
+  text-decoration: none;
+  font-size: 1rem;
+  font-weight: bold;
+}
+
 .profile-icon {
   text-decoration: none;
   color: #ffffff;

--- a/sunny_sales_web/src/pages/ImplementarScreen.jsx
+++ b/sunny_sales_web/src/pages/ImplementarScreen.jsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+
+export default function ImplementarScreen() {
+  const navigate = useNavigate();
+  return (
+    <div style={styles.container}>
+      <button onClick={() => navigate(-1)} style={styles.back}>⬅ Voltar</button>
+      <h2 style={styles.title}>Traga o Sunny Sales para a sua praia</h2>
+      <p style={styles.text}>
+        O Sunny Sales é uma solução tecnológica ao serviço do comércio ambulante
+        de praia, ideal para <strong>autarquias, juntas de freguesia e entidades
+        gestoras do litoral</strong> que pretendem modernizar a experiência balnear.
+      </p>
+      <h3 style={styles.sectionTitle}>🏖️ Vantagens para a autarquia:</h3>
+      <ul style={styles.list}>
+        <li>Organização da actividade ambulante</li>
+        <li>Promoção do comércio local e sustentável</li>
+        <li>Melhoria da experiência dos veraneantes</li>
+        <li>Redução de circulação desnecessária e ruído</li>
+        <li>Reforço da imagem de inovação e modernização</li>
+      </ul>
+      <h3 style={styles.sectionTitle}>🚀 O que disponibilizamos:</h3>
+      <ul style={styles.list}>
+        <li>Mapa digital com vendedores em tempo real</li>
+        <li>Filtros por tipo de produto vendido</li>
+        <li>Acesso simples via QR Code</li>
+        <li>Página personalizada por localidade (opcional)</li>
+        <li>Estatísticas de utilização (a pedido)</li>
+      </ul>
+      <h3 style={styles.sectionTitle}>📩 Como implementar?</h3>
+      <ol style={styles.list}>
+        <li>Envie-nos um e-mail para <strong>[teu-email]</strong></li>
+        <li>Agendamos uma demonstração rápida (presencial ou online)</li>
+        <li>Em poucos dias, a sua praia pode estar integrada no sistema</li>
+      </ol>
+      <p style={styles.text}>
+        <strong>Estamos disponíveis para parcerias, protocolos institucionais e
+        acções conjuntas.</strong>
+      </p>
+      <p style={styles.text}>
+        Junte-se à transformação digital das praias portuguesas!
+      </p>
+    </div>
+  );
+}
+
+const styles = {
+  container: {
+    padding: '2rem',
+    maxWidth: 800,
+    margin: '0 auto',
+    backgroundColor: '#fff9e6',
+    borderRadius: '8px',
+    fontFamily: 'sans-serif',
+    color: '#333',
+  },
+  back: {
+    marginBottom: '1rem',
+    background: 'none',
+    border: 'none',
+    cursor: 'pointer',
+    fontSize: '1rem',
+    color: '#19a0a4',
+  },
+  title: {
+    fontSize: '1.8rem',
+    fontWeight: 'bold',
+    textAlign: 'center',
+    marginBottom: '1rem',
+  },
+  sectionTitle: {
+    fontSize: '1.2rem',
+    fontWeight: 'bold',
+    marginTop: '1rem',
+  },
+  text: {
+    fontSize: '1rem',
+    textAlign: 'justify',
+    marginBottom: '1rem',
+  },
+  list: {
+    marginBottom: '1rem',
+    marginLeft: '1.2rem',
+  },
+};

--- a/sunny_sales_web/src/pages/SobreProjeto.jsx
+++ b/sunny_sales_web/src/pages/SobreProjeto.jsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+
+export default function SobreProjeto() {
+  const navigate = useNavigate();
+  return (
+    <div style={styles.container}>
+      <button onClick={() => navigate(-1)} style={styles.back}>⬅ Voltar</button>
+      <h2 style={styles.title}>Sobre o Projeto</h2>
+      <p style={styles.text}>
+        <strong>Sunny Sales</strong> é uma plataforma inovadora que liga vendedores
+        ambulantes de produtos tradicionais de praia (como bolas de Berlim,
+        gelados e acessórios) a banhistas, através de um mapa interactivo em
+        tempo real.
+      </p>
+      <h3 style={styles.sectionTitle}>🏖️ Porquê criámos este projecto?</h3>
+      <p style={styles.text}>
+        Todos já passámos pela experiência de querer comprar algo na praia e não
+        saber onde encontrar o vendedor. Com o Sunny Sales, os utilizadores podem
+        visualizar num mapa os vendedores mais próximos, os produtos disponíveis e
+        até avaliações deixadas por outros clientes.
+      </p>
+      <h3 style={styles.sectionTitle}>🎯 O que resolvemos:</h3>
+      <ul style={styles.list}>
+        <li>Os banhistas deixam de ter de esperar ou procurar os vendedores.</li>
+        <li>Os vendedores poupam tempo e esforço, chegando directamente a quem os procura.</li>
+        <li>As praias tornam-se mais organizadas e sustentáveis.</li>
+      </ul>
+      <p style={styles.text}>
+        O Sunny Sales é uma ponte entre tradição e tecnologia, com foco na
+        praticidade, sustentabilidade e valorização do comércio local.
+      </p>
+    </div>
+  );
+}
+
+const styles = {
+  container: {
+    padding: '2rem',
+    maxWidth: 800,
+    margin: '0 auto',
+    backgroundColor: '#fff9e6',
+    borderRadius: '8px',
+    fontFamily: 'sans-serif',
+    color: '#333',
+  },
+  back: {
+    marginBottom: '1rem',
+    background: 'none',
+    border: 'none',
+    cursor: 'pointer',
+    fontSize: '1rem',
+    color: '#19a0a4',
+  },
+  title: {
+    fontSize: '1.8rem',
+    fontWeight: 'bold',
+    textAlign: 'center',
+    marginBottom: '1rem',
+  },
+  sectionTitle: {
+    fontSize: '1.2rem',
+    fontWeight: 'bold',
+    marginTop: '1rem',
+  },
+  text: {
+    fontSize: '1rem',
+    textAlign: 'justify',
+    marginBottom: '1rem',
+  },
+  list: {
+    marginBottom: '1rem',
+    marginLeft: '1.2rem',
+  },
+};

--- a/sunny_sales_web/src/pages/Sustentabilidade.jsx
+++ b/sunny_sales_web/src/pages/Sustentabilidade.jsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+
+export default function Sustentabilidade() {
+  const navigate = useNavigate();
+  return (
+    <div style={styles.container}>
+      <button onClick={() => navigate(-1)} style={styles.back}>⬅ Voltar</button>
+      <h2 style={styles.title}>Sustentabilidade</h2>
+      <p style={styles.text}>
+        Acreditamos que o futuro do comércio de praia passa por ser mais
+        <strong> eficiente, consciente e ecológico</strong>. O Sunny Sales assume um
+        compromisso activo com a sustentabilidade ambiental e social das zonas
+        balneares.
+      </p>
+      <h3 style={styles.sectionTitle}>🌱 As nossas acções:</h3>
+      <p style={styles.text}><strong>✅ Redução da pegada ecológica</strong><br />
+        Ajudamos os vendedores a evitar deslocações desnecessárias, reduzindo o
+        esforço físico e o impacto ambiental.
+      </p>
+      <p style={styles.text}><strong>✅ Promoção de embalagens sustentáveis</strong><br />
+        Incentivamos a utilização de sacos biodegradáveis, embalagens reutilizáveis
+        e materiais amigos do ambiente.
+      </p>
+      <p style={styles.text}><strong>✅ Consciencialização dos banhistas</strong></p>
+      <ul style={styles.list}>
+        <li>Levar o lixo consigo</li>
+        <li>Utilizar cinzeiros portáteis</li>
+        <li>Preferir protector solar ecológico</li>
+      </ul>
+      <p style={styles.text}><strong>✅ Apoio a campanhas ambientais</strong><br />
+        Apoiamos e divulgamos campanhas de limpeza de praia, sensibilização
+        ambiental e educação para a sustentabilidade.
+      </p>
+      <p style={styles.text}>
+        O nosso compromisso é com praias mais limpas, vendedores mais conscientes
+        e um verão mais responsável.
+      </p>
+    </div>
+  );
+}
+
+const styles = {
+  container: {
+    padding: '2rem',
+    maxWidth: 800,
+    margin: '0 auto',
+    backgroundColor: '#fff9e6',
+    borderRadius: '8px',
+    fontFamily: 'sans-serif',
+    color: '#333',
+  },
+  back: {
+    marginBottom: '1rem',
+    background: 'none',
+    border: 'none',
+    cursor: 'pointer',
+    fontSize: '1rem',
+    color: '#19a0a4',
+  },
+  title: {
+    fontSize: '1.8rem',
+    fontWeight: 'bold',
+    textAlign: 'center',
+    marginBottom: '1rem',
+  },
+  sectionTitle: {
+    fontSize: '1.2rem',
+    fontWeight: 'bold',
+    marginTop: '1rem',
+  },
+  text: {
+    fontSize: '1rem',
+    textAlign: 'justify',
+    marginBottom: '1rem',
+  },
+  list: {
+    marginBottom: '1rem',
+    marginLeft: '1.2rem',
+  },
+};


### PR DESCRIPTION
## Summary
- add Portuguese project pages
- link the new pages in the site header

## Testing
- `npm --prefix sunny_sales_web run lint` *(fails: Cannot find package '@eslint/js')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_688791218034832eade9359b9a0fc107