### PR TITLE
Change login button styling to black

### DIFF
--- a/sunny_sales_web/src/index.css
+++ b/sunny_sales_web/src/index.css
@@ -355,6 +355,15 @@ button {
   font-weight: bold;
 }
 
+/* Utilizado para destacar botoes de acoes principais em preto */
+.black-button {
+  --primary-color: #000000;
+  --secondary-color: #FFFFFF;
+  --hover-color: #000000;
+  background-color: var(--primary-color);
+  color: var(--secondary-color);
+}
+
 button .arrow-wrapper {
   display: flex;
   justify-content: center;

--- a/sunny_sales_web/src/pages/ClientLogin.jsx
+++ b/sunny_sales_web/src/pages/ClientLogin.jsx
@@ -127,12 +127,16 @@ export default function ClientLogin() {
             className="input"
           />
         </div>
-        <button onClick={login} disabled={!email || !password || loading}>
+        <button
+          className="black-button"
+          onClick={login}
+          disabled={!email || !password || loading}
+        >
           {loading ? <LoadingDots /> : 'Entrar'}
         </button>
         <button
           type="button"
-          className="outlined-button"
+          className="black-button"
           onClick={() => navigate('/register')}
         >
           Registar
@@ -141,22 +145,12 @@ export default function ClientLogin() {
         <div className="buttons-container">
           <button
             type="button"
-            className="google-login-button"
-
+            className="black-button"
             onClick={() => oauthLogin('google')}
-
-            onClick={() =>
-              alert('Login com Google ainda não disponível')
-            }
-
           >
             <FaGoogle className="google-icon" /> Entrar com Google
           </button>
-          <button
-            type="button"
-            className="apple-login-button"
-
-          >
+          <button type="button" className="black-button">
             <FaApple className="apple-icon" /> Entrar com Apple
           </button>
         </div>

--- a/sunny_sales_web/src/pages/LoginSelection.jsx
+++ b/sunny_sales_web/src/pages/LoginSelection.jsx
@@ -32,7 +32,8 @@ const styles = {
   },
   button: {
     padding: '0.75rem 1.5rem',
-    backgroundColor: '#19a0a4',
+    backgroundColor: '#000',
+    color: '#fff',
     border: 'none',
     cursor: 'pointer',
   },

--- a/sunny_sales_web/src/pages/VendorLogin.jsx
+++ b/sunny_sales_web/src/pages/VendorLogin.jsx
@@ -89,13 +89,17 @@ export default function VendorLogin() {
           />
         </div>
 
-        <button onClick={login} disabled={!email || !password || loading}>
+        <button
+          className="black-button"
+          onClick={login}
+          disabled={!email || !password || loading}
+        >
           {loading ? <LoadingDots /> : 'Entrar'}
         </button>
 
         <button
           type="button"
-          className="outlined-button"
+          className="black-button"
           onClick={() => navigate('/vendor-register')}
         >
           Registar
@@ -103,9 +107,9 @@ export default function VendorLogin() {
 
         <button
           type="button"
-          className="outlined-button"
+          className="black-button"
           onClick={() => navigate('/forgot-password')}
-          style={{ background: 'none', border: 'none', color: '#19a0a4', textDecoration: 'underline' }}
+          style={{ textDecoration: 'underline' }}
         >
           Esqueci-me da palavra-passe
         </button>


### PR DESCRIPTION
## Summary
- make button style customizable via new `.black-button` CSS class
- update login pages to use `.black-button` so buttons appear black with white text

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68888f342638832e9cdebd5f44e024da