### PR TITLE
Change login button styling to black

### DIFF
--- a/sunny_sales_web/src/index.css
+++ b/sunny_sales_web/src/index.css
@@ -355,6 +355,15 @@ button {
   font-weight: bold;
 }
 
+/* Utilizado para destacar botoes de acoes principais em preto */
+.black-button {
+  --primary-color: #000000;
+  --secondary-color: #FFFFFF;
+  --hover-color: #000000;
+  background-color: var(--primary-color);
+  color: var(--secondary-color);
+}
+
 button .arrow-wrapper {
   display: flex;
   justify-content: center;
@@ -424,5 +433,83 @@ input[type='checkbox'] {
 
   .social-icons {
     display: none;
+  }
+}
+
+/* === Estilos para formulários de autenticação === */
+.auth-form {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  max-width: 350px;
+  padding: 20px;
+  border-radius: 20px;
+  position: relative;
+  background-color: #1a1a1a;
+  color: #fff;
+  border: 1px solid #333;
+}
+
+.auth-title {
+  font-size: 28px;
+  font-weight: 600;
+  letter-spacing: -1px;
+  position: relative;
+  display: flex;
+  align-items: center;
+  padding-left: 30px;
+  color: #ffd700;
+}
+
+.auth-title::before,
+.auth-title::after {
+  position: absolute;
+  content: "";
+  height: 16px;
+  width: 16px;
+  border-radius: 50%;
+  left: 0px;
+  background-color: #ffd700;
+}
+
+.auth-title::before {
+  width: 18px;
+  height: 18px;
+}
+
+.auth-title::after {
+  width: 18px;
+  height: 18px;
+  animation: pulse 1s linear infinite;
+}
+
+.auth-form .input {
+  background-color: #333;
+  color: #fff;
+  width: 100%;
+  padding: 20px 5px 5px 10px;
+  outline: 0;
+  border: 1px solid rgba(105, 105, 105, 0.397);
+  border-radius: 10px;
+}
+
+.auth-form button {
+  border: none;
+  outline: none;
+  padding: 10px;
+  border-radius: 10px;
+  color: #fff;
+  font-size: 16px;
+  transition: 0.3s ease;
+}
+
+@keyframes pulse {
+  from {
+    transform: scale(0.9);
+    opacity: 1;
+  }
+  to {
+    transform: scale(1.8);
+    opacity: 0;
   }
 }

--- a/sunny_sales_web/src/pages/ClientLogin.jsx
+++ b/sunny_sales_web/src/pages/ClientLogin.jsx
@@ -99,11 +99,11 @@ export default function ClientLogin() {
 
   return (
     <div className="form-box">
-      <h2 className="title">Login do Cliente</h2>
+      <h2 className="title auth-title">Login do Cliente</h2>
       {error && (
         <p style={{ color: 'red', marginBottom: '1rem' }}>{error}</p>
       )}
-<div className="form login-form">
+<div className="form login-form auth-form">
 
         <div className="form-container login-container">
           <input
@@ -127,12 +127,16 @@ export default function ClientLogin() {
             className="input"
           />
         </div>
-        <button onClick={login} disabled={!email || !password || loading}>
+        <button
+          className="black-button"
+          onClick={login}
+          disabled={!email || !password || loading}
+        >
           {loading ? <LoadingDots /> : 'Entrar'}
         </button>
         <button
           type="button"
-          className="outlined-button"
+          className="black-button"
           onClick={() => navigate('/register')}
         >
           Registar
@@ -141,22 +145,12 @@ export default function ClientLogin() {
         <div className="buttons-container">
           <button
             type="button"
-            className="google-login-button"
-
+            className="black-button"
             onClick={() => oauthLogin('google')}
-
-            onClick={() =>
-              alert('Login com Google ainda não disponível')
-            }
-
           >
             <FaGoogle className="google-icon" /> Entrar com Google
           </button>
-          <button
-            type="button"
-            className="apple-login-button"
-
-          >
+          <button type="button" className="black-button">
             <FaApple className="apple-icon" /> Entrar com Apple
           </button>
         </div>

--- a/sunny_sales_web/src/pages/ClientRegister.jsx
+++ b/sunny_sales_web/src/pages/ClientRegister.jsx
@@ -67,9 +67,9 @@ export default function ClientRegister() {
 
   return (
     <div className="form-box">
-      <h2 className="title">Registo de Cliente</h2>
+      <h2 className="title auth-title">Registo de Cliente</h2>
       {error && <p style={{ color: 'red', marginBottom: '1rem' }}>{error}</p>}
-      <div className="form login-form">
+      <div className="form login-form auth-form">
         <div className="form-container login-container">
           <input
             type="text"
@@ -116,7 +116,7 @@ export default function ClientRegister() {
             }}
           />
         )}
-        <button onClick={register} disabled={loading}>
+        <button className="black-button" onClick={register} disabled={loading}>
           {loading ? <LoadingDots /> : 'Registar'}
         </button>
       </div>

--- a/sunny_sales_web/src/pages/LoginSelection.jsx
+++ b/sunny_sales_web/src/pages/LoginSelection.jsx
@@ -32,7 +32,8 @@ const styles = {
   },
   button: {
     padding: '0.75rem 1.5rem',
-    backgroundColor: '#19a0a4',
+    backgroundColor: '#000',
+    color: '#fff',
     border: 'none',
     cursor: 'pointer',
   },

--- a/sunny_sales_web/src/pages/VendorLogin.jsx
+++ b/sunny_sales_web/src/pages/VendorLogin.jsx
@@ -63,14 +63,14 @@ export default function VendorLogin() {
 
   return (
     <div className="form-box">
-      <h2 className="title">Login de Vendedor</h2>
+      <h2 className="title auth-title">Login de Vendedor</h2>
       <p style={{ marginBottom: '1rem', fontStyle: 'italic' }}>
         Esta página destina-se apenas a vendedores.
       </p>
 
       {error && <p style={{ color: 'red', marginBottom: '1rem' }}>{error}</p>}
 
-<div className="form login-form">
+<div className="form login-form auth-form">
 
         <div className="form-container login-container">
           <input
@@ -89,13 +89,17 @@ export default function VendorLogin() {
           />
         </div>
 
-        <button onClick={login} disabled={!email || !password || loading}>
+        <button
+          className="black-button"
+          onClick={login}
+          disabled={!email || !password || loading}
+        >
           {loading ? <LoadingDots /> : 'Entrar'}
         </button>
 
         <button
           type="button"
-          className="outlined-button"
+          className="black-button"
           onClick={() => navigate('/vendor-register')}
         >
           Registar
@@ -103,9 +107,9 @@ export default function VendorLogin() {
 
         <button
           type="button"
-          className="outlined-button"
+          className="black-button"
           onClick={() => navigate('/forgot-password')}
-          style={{ background: 'none', border: 'none', color: '#19a0a4', textDecoration: 'underline' }}
+          style={{ textDecoration: 'underline' }}
         >
           Esqueci-me da palavra-passe
         </button>

--- a/sunny_sales_web/src/pages/VendorRegister.jsx
+++ b/sunny_sales_web/src/pages/VendorRegister.jsx
@@ -68,12 +68,12 @@ export default function VendorRegister() {
 
   return (
     <div className="form-box">
-      <h2 className="title">Registo de Vendedor</h2>
+      <h2 className="title auth-title">Registo de Vendedor</h2>
 
       {error && <p style={{ color: 'red', marginBottom: '1rem' }}>{error}</p>}
       {success && <p style={{ color: 'green', marginBottom: '1rem' }}>{success}</p>}
 
-      <form onSubmit={handleRegister} className="form login-form">
+      <form onSubmit={handleRegister} className="form login-form auth-form">
         <div className="form-container login-container">
           <input
             type="text"
@@ -109,7 +109,7 @@ export default function VendorRegister() {
 
           <input type="file" onChange={handlePhotoChange} className="input" />
         </div>
-        <button type="submit">Registar</button>
+        <button type="submit" className="black-button">Registar</button>
       </form>
     </div>
   );


### PR DESCRIPTION
## Summary
- make button style customizable via new `.black-button` CSS class
- update login pages to use `.black-button` so buttons appear black with white text
- style login & register forms with dark theme and yellow highlights

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68888f342638832e9cdebd5f44e024da