### PR TITLE
Fix geolocation button feedback

### DIFF
--- a/sunny_sales_web/src/pages/ModernMapLayout.css
+++ b/sunny_sales_web/src/pages/ModernMapLayout.css
@@ -242,6 +242,11 @@ body {
   z-index: 500;
 }
 
+.locate-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
 /* From Uiverse.io by JaydipPrajapati1910 */
 .loader {
   width: 24px;

--- a/sunny_sales_web/src/pages/ModernMapLayout.jsx
+++ b/sunny_sales_web/src/pages/ModernMapLayout.jsx
@@ -15,6 +15,7 @@ export default function ModernMapLayout() {
   const [selected, setSelected] = useState(null);
   const [favorite, setFavorite] = useState(false);
   const [locating, setLocating] = useState(false);
+  const [mapReady, setMapReady] = useState(false);
   const [clientPos, setClientPos] = useState(null);
   const [clientData, setClientData] = useState(null);
   const mapRef = useRef(null);
@@ -103,9 +104,12 @@ export default function ModernMapLayout() {
   };
 
   const handleLocate = () => {
-
-    if (!navigator.geolocation || !mapRef.current) {
-      alert('Geolocalização não suportada.');
+    if (!navigator.geolocation) {
+      alert('Navegador não suporta geolocalização.');
+      return;
+    }
+    if (!mapRef.current) {
+      alert('Mapa ainda está carregando.');
       return;
     }
     setLocating(true);
@@ -148,6 +152,7 @@ export default function ModernMapLayout() {
           className="map-container"
           whenCreated={(map) => {
             mapRef.current = map;
+            setMapReady(true);
           }}
         >
           <TileLayer
@@ -197,6 +202,7 @@ export default function ModernMapLayout() {
           className="locate-btn"
           onClick={handleLocate}
           aria-label="Localizar-me"
+          disabled={locating || !mapReady}
         >
           {locating ? <span className="loader" /> : '📍'}
         </button>


### PR DESCRIPTION
## Summary
- mark when the leaflet map is ready
- prevent locate button usage until map is ready and show clearer alerts
- style disabled locate button

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6888b0acd018832eae247c23e1805d4d