### PR TITLE
Fix locate button clickability and smoother zoom

### DIFF
--- a/sunny_sales_web/src/pages/ModernMapLayout.css
+++ b/sunny_sales_web/src/pages/ModernMapLayout.css
@@ -239,7 +239,7 @@ body {
   align-items: center;
   justify-content: center;
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
-  z-index: 500;
+  z-index: 1100;
 }
 
 .locate-btn:disabled {

--- a/sunny_sales_web/src/pages/ModernMapLayout.jsx
+++ b/sunny_sales_web/src/pages/ModernMapLayout.jsx
@@ -70,7 +70,7 @@ export default function ModernMapLayout() {
   const focusVendor = (v) => {
     setSelected(v);
     if (mapRef.current) {
-      mapRef.current.setView([v.current_lat, v.current_lng], 16);
+      mapRef.current.flyTo([v.current_lat, v.current_lng], 16);
     }
   };
 


### PR DESCRIPTION
## Summary
- ensure the "Go to my location" button appears over Leaflet controls by raising its z-index
- use `flyTo` when centering the map on a vendor for smoother zoom

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6888e178d498832ea5719f503e8fae1a