### PR TITLE
Fix unclosed CSS block

### DIFF
--- a/sunny_sales_web/src/pages/ModernMapLayout.css
+++ b/sunny_sales_web/src/pages/ModernMapLayout.css
@@ -241,6 +241,7 @@ body {
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
 
   z-index: 500;
+}
 
 
 /* From Uiverse.io by JaydipPrajapati1910 */


### PR DESCRIPTION
## Summary
- fix unclosed `.locate-btn` CSS block in `ModernMapLayout.css`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888fd8e14cc832e833920ec402d67d3