### PR TITLE
Fix mobile header layout

### DIFF
--- a/sunny_sales_web/src/index.css
+++ b/sunny_sales_web/src/index.css
@@ -411,6 +411,21 @@ input[type='checkbox'] {
 }
 
 @media (max-width: 768px) {
+  .header-wrapper {
+    flex-direction: column;
+    align-items: center;
+    padding: 16px 0;
+  }
+
+  .logo-outside {
+    position: static;
+    transform: none;
+    margin-bottom: 8px;
+  }
+
+  .navbar {
+    width: 100%;
+  }
   .nav-links {
     display: none;
     flex-direction: column;


### PR DESCRIPTION
## Summary
- tweak responsive CSS so the logo doesn't overlap the navigation bar on small screens

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_688912485aec832eb98cc85ea761dafc