### PR TITLE
Increase nav bar width

### DIFF
--- a/sunny_sales_web/src/index.css
+++ b/sunny_sales_web/src/index.css
@@ -52,6 +52,7 @@ body {
   box-shadow: 0px 2px 10px rgba(0, 0, 0, 0.2);
 
   max-width: 1600px;
+  width: 100%;
   margin: 0 auto;
 
 }


### PR DESCRIPTION
## Summary
- adjust the CSS for `.navbar` so the navigation bar stretches across the header

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6889cdf099a8832ebb8e61e39cae3630