### PR TITLE
Improve vendor dashboard styling

### DIFF
--- a/sunny_sales_web/src/index.css
+++ b/sunny_sales_web/src/index.css
@@ -531,3 +531,44 @@ input[type='checkbox'] {
     opacity: 0;
   }
 }
+
+/* === Switch de partilha de localização === */
+.theme-checkbox {
+  --toggle-size: 16px;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  width: 6.25em;
+  height: 3.125em;
+  background: linear-gradient(to right, #efefef 50%, #2a2a2a 50%) no-repeat;
+  background-size: 205%;
+  background-position: 0;
+  transition: 0.4s;
+  border-radius: 99em;
+  position: relative;
+  cursor: pointer;
+  font-size: var(--toggle-size);
+}
+
+.theme-checkbox::before {
+  content: "";
+  width: 2.25em;
+  height: 2.25em;
+  position: absolute;
+  top: 0.438em;
+  left: 0.438em;
+  background: linear-gradient(to right, #efefef 50%, #2a2a2a 50%) no-repeat;
+  background-size: 205%;
+  background-position: 100%;
+  border-radius: 50%;
+  transition: 0.4s;
+}
+
+.theme-checkbox:checked::before {
+  left: calc(100% - 2.25em - 0.438em);
+  background-position: 0;
+}
+
+.theme-checkbox:checked {
+  background-position: 100%;
+}

--- a/sunny_sales_web/src/pages/VendorDashboard.jsx
+++ b/sunny_sales_web/src/pages/VendorDashboard.jsx
@@ -121,7 +121,6 @@ export default function VendorDashboard() {
       </button>
 
       <div style={{ ...styles.sideMenu, ...(menuOpen ? styles.sideMenuOpen : {}) }}>
-        <legend>Menu</legend>
         <ul style={styles.menuList}>
           <li><button style={styles.menuButtonItem} onClick={paySubscription}>Pagar Semanalidade</button></li>
           <li><button style={styles.menuButtonItem} onClick={() => navigate('/paid-weeks')}>Semanas Pagas</button></li>
@@ -178,11 +177,20 @@ export default function VendorDashboard() {
           </>
         )}
 
-        <button className="btn" style={styles.fullButton} onClick={sharing ? stopSharing : startSharing}>
-          {sharing ? 'Desativar Localização' : 'Ativar Localização'}
-        </button>
+        <div style={styles.toggleContainer}>
+          <input
+            id="location-toggle"
+            type="checkbox"
+            className="theme-checkbox"
+            checked={sharing}
+            onChange={sharing ? stopSharing : startSharing}
+          />
+          <label htmlFor="location-toggle">
+            {sharing ? 'Desativar Localização' : 'Ativar Localização'}
+          </label>
+        </div>
 
-        <button className="btn" style={styles.fullButton} onClick={logout}>Sair</button>
+        <button className="btn" style={styles.logoutButton} onClick={logout}>Sair</button>
       </div>
     </div>
   );
@@ -242,12 +250,31 @@ const styles = {
     fontWeight: 'bold',
     color: '#fff',
   },
+  logoutButton: {
+    width: 'auto',
+    alignSelf: 'center',
+    margin: '12px auto',
+    borderRadius: 12,
+    backgroundColor: '#000',
+    border: 'none',
+    padding: '0.5rem 1rem',
+    cursor: 'pointer',
+    fontWeight: 'bold',
+    color: '#fff',
+  },
+  toggleContainer: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '0.5rem',
+    justifyContent: 'center',
+    margin: '12px auto',
+  },
   menuButton: {
     position: 'fixed',
     top: '8rem',
     left: '1rem',
     zIndex: 1100,
-    backgroundColor: '#19a0a4',
+    backgroundColor: '#000',
     color: '#fff',
     border: 'none',
     padding: '0.5rem 1rem',


### PR DESCRIPTION
## Summary
- convert location sharing button to a toggle
- darken hamburger button and logout button
- remove the "Menu" legend
- add toggle styling

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6889ed579720832e8b2ae765f25c38ed