### PR TITLE
Fix vendor forms and styles

### DIFF
--- a/sunny_sales_web/src/index.css
+++ b/sunny_sales_web/src/index.css
@@ -353,6 +353,7 @@ button {
   padding: 0.5em 1.2em;
   background: var(--primary-color);
   display: flex;
+  justify-content: center;
   transition: 0.2s background;
   align-items: center;
   gap: 0.6em;
@@ -543,12 +544,12 @@ input[type='checkbox'] {
 
 /* === Switch de partilha de localização === */
 .theme-checkbox {
-  --toggle-size: 16px;
+  --toggle-size: 14px;
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
-  width: 6.25em;
-  height: 3.125em;
+  width: 4em;
+  height: 2em;
   background: linear-gradient(to right, #ffffff 50%, #000000 50%) no-repeat;
   background-size: 205%;
   background-position: 0;
@@ -561,11 +562,11 @@ input[type='checkbox'] {
 
 .theme-checkbox::before {
   content: "";
-  width: 2.25em;
-  height: 2.25em;
+  width: 1.5em;
+  height: 1.5em;
   position: absolute;
-  top: 0.438em;
-  left: 0.438em;
+  top: 0.25em;
+  left: 0.25em;
   background: linear-gradient(to right, #ffffff 50%, #000000 50%) no-repeat;
   background-size: 205%;
   background-position: 100%;
@@ -574,7 +575,7 @@ input[type='checkbox'] {
 }
 
 .theme-checkbox:checked::before {
-  left: calc(100% - 2.25em - 0.438em);
+  left: calc(100% - 1.5em - 0.25em);
   background-position: 0;
 }
 
@@ -586,7 +587,7 @@ input[type='checkbox'] {
 .form {
   --bg-light: #efefef;
   --bg-dark: #707070;
-  --clr: #58bc82;
+  --clr: #000000;
   --clr-alpha: #9c9c9c60;
   display: flex;
   flex-direction: column;

--- a/sunny_sales_web/src/pages/ManageAccount.jsx
+++ b/sunny_sales_web/src/pages/ManageAccount.jsx
@@ -88,7 +88,7 @@ export default function ManageAccount() {
       <h2 className="title">Definições de Conta</h2>
       <form onSubmit={handleUpdate} className="form">
         {error && <p style={{ color: 'red' }}>{error}</p>}
-        {success && <p style={{ color: 'green' }}>{success}</p>}
+        {success && <p style={{ color: 'black' }}>{success}</p>}
         <span className="input-span">
           <label className="label">Nome</label>
           <input
@@ -143,6 +143,7 @@ export default function ManageAccount() {
             value={pinColor}
             onChange={(e) => setPinColor(e.target.value)}
           />
+          <span>{pinColor}</span>
         </span>
         <span className="input-span">
           <label className="label">Foto</label>

--- a/sunny_sales_web/src/pages/VendorRegister.jsx
+++ b/sunny_sales_web/src/pages/VendorRegister.jsx
@@ -71,7 +71,7 @@ export default function VendorRegister() {
       <h2 className="title auth-title">Registo de Vendedor</h2>
 
       {error && <p style={{ color: 'red', marginBottom: '1rem' }}>{error}</p>}
-      {success && <p style={{ color: 'green', marginBottom: '1rem' }}>{success}</p>}
+      {success && <p style={{ color: 'black', marginBottom: '1rem' }}>{success}</p>}
 
       <form onSubmit={handleRegister} className="form login-form auth-form">
         <span className="input-span">


### PR DESCRIPTION
## Summary
- center text for all buttons
- shrink location switch size
- show selected pin color in Manage Account
- make form success messages black instead of green

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_688a18c4b61c832eaae602f368d4a0b3