### PR TITLE
Fix overflowing form fields

### DIFF
--- a/sunny_sales_web/src/index.css
+++ b/sunny_sales_web/src/index.css
@@ -613,6 +613,7 @@ input[type='checkbox'] {
   border-radius: 0.5rem;
   padding: 1rem 0.75rem;
   width: 100%;
+  box-sizing: border-box;
   border: none;
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- fix form input width so fields don't overflow container

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_688a22c31f54832e9f431e8375fd97ba