### PR TITLE
Add color preview for pin color

### DIFF
--- a/sunny_sales_web/src/index.css
+++ b/sunny_sales_web/src/index.css
@@ -666,3 +666,13 @@ input[type='checkbox'] {
 .span a {
   color: var(--clr);
 }
+
+.color-preview {
+  display: inline-block;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  border: 1px solid var(--bg-dark);
+  margin-left: 8px;
+  vertical-align: middle;
+}

--- a/sunny_sales_web/src/pages/ManageAccount.jsx
+++ b/sunny_sales_web/src/pages/ManageAccount.jsx
@@ -143,7 +143,10 @@ export default function ManageAccount() {
             value={pinColor}
             onChange={(e) => setPinColor(e.target.value)}
           />
-          <span>{pinColor}</span>
+          <span
+            className="color-preview"
+            style={{ backgroundColor: pinColor }}
+          />
         </span>
         <span className="input-span">
           <label className="label">Foto</label>


### PR DESCRIPTION
## Summary
- show a color preview for pin color instead of displaying the hex code
- style color preview dot in CSS

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_688a254b7e90832eba2719edb98ee8a8