### PR TITLE
Optimize mobile header size

### DIFF
--- a/sunny_sales_web/src/index.css
+++ b/sunny_sales_web/src/index.css
@@ -419,7 +419,7 @@ input[type='checkbox'] {
   .header-wrapper {
     flex-direction: column;
     align-items: center;
-    padding: 16px 0;
+    padding: 8px 0;
   }
 
   .logo-outside {
@@ -430,6 +430,11 @@ input[type='checkbox'] {
 
   .navbar {
     width: 100%;
+    padding: 8px 16px;
+    border-radius: 20px;
+  }
+  .logo-link {
+    font-size: 28px;
   }
   .nav-links {
     display: none;
@@ -460,6 +465,13 @@ input[type='checkbox'] {
   .form-container,
   .form-container.login-container {
     width: 90%;
+  }
+  .logo-link {
+    font-size: 24px;
+  }
+  .navbar {
+    padding: 6px 12px;
+    border-radius: 12px;
   }
 }
 


### PR DESCRIPTION
## Summary
- reduce header padding on small screens
- shrink logo and navbar padding on mobile

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_688a27622b40832e8e9647f96fc8a476