### PR TITLE
Improve script efficiency and clean imports

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -10,7 +10,7 @@ from passlib.context import CryptContext
 from . import models, schemas
 import stripe
 from datetime import datetime, timedelta
-from .database import SessionLocal, engine, get_db
+from .database import engine, get_db
 import os
 from pathlib import Path
 import shutil
@@ -21,7 +21,6 @@ from email import policy
 import smtplib
 import time
 import json
-import asyncio
 import base64
 import hmac
 import hashlib

--- a/scripts/simulate_movement.py
+++ b/scripts/simulate_movement.py
@@ -1,6 +1,6 @@
 # Script para simular deslocamento de um vendedor enviando localizacoes
 import os
-import time
+import asyncio
 import httpx
 
 BASE_URL = os.environ.get("BASE_URL", "http://localhost:8000")
@@ -31,10 +31,9 @@ async def main():
             )
             lat += 0.0005
             lng += 0.0005
-            time.sleep(1)
+            await asyncio.sleep(1)
 
         await client.post(f"{BASE_URL}/vendors/{VENDOR_ID}/routes/stop", headers=headers)
 
 if __name__ == "__main__":
-    import asyncio
     asyncio.run(main())


### PR DESCRIPTION
## Summary
- remove unused `SessionLocal` and `asyncio` imports from backend
- avoid blocking sleep in the movement simulation script
- drop redundant import in the script

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_688a28d872d0832e84e79df010648ced