### PR TITLE
Fix missing session_token column error

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -10,7 +10,7 @@ from passlib.context import CryptContext
 from . import models, schemas
 import stripe
 from datetime import datetime, timedelta
-from .database import engine, get_db
+from .database import engine, get_db, ensure_latest_schema
 import os
 from pathlib import Path
 import shutil
@@ -80,6 +80,7 @@ if WEB_DIST.is_dir():
 
 # Criar as tabelas na base de dados
 models.Base.metadata.create_all(bind=engine)
+ensure_latest_schema()
 
 # Contexto para hash de password
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")


### PR DESCRIPTION
## Summary
- add automatic migration helper in database module
- call new schema check from FastAPI app on startup

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_688a35ac7970832e9417d0c4c325c1df