### PR TITLE
Remove vendor popup

### DIFF
--- a/sunny_sales_web/src/pages/ModernMapLayout.jsx
+++ b/sunny_sales_web/src/pages/ModernMapLayout.jsx
@@ -135,9 +135,7 @@ export default function ModernMapLayout() {
               eventHandlers={{
                 click: () => focusVendor(v),
               }}
-            >
-              <Popup>{v.name}</Popup>
-            </Marker>
+            />
           ))}
 
           {!isVendorLogged && (


### PR DESCRIPTION
## Summary
- remove duplicate popup label when clicking vendor pin

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_688a3dac8e3c832ea534ee46e5d29f51