### PR TITLE
Fix mobile header alignment

### DIFF
--- a/sunny_sales_web/src/index.css
+++ b/sunny_sales_web/src/index.css
@@ -425,26 +425,26 @@ input[type='checkbox'] {
   accent-color: var(--secondary-color);
 }
 
-@media (max-width: 768px) {
-  .header-wrapper {
-    flex-direction: row;
-    align-items: center;
-    padding: 6px 0;
-  }
+  @media (max-width: 768px) {
+    .header-wrapper {
+      flex-direction: row;
+      align-items: center;
+      justify-content: flex-start;
+      padding: 6px 0;
+    }
 
-  .logo-outside {
-    position: static;
-    transform: none;
-    margin: 0;
-    margin-right: auto;
-  }
+    .logo-outside {
+      position: static;
+      transform: none;
+      margin: 0 1rem 0 0;
+    }
 
-  .navbar {
-    width: auto;
-    flex: 1;
-    padding: 6px 12px;
-    border-radius: 20px;
-  }
+    .navbar {
+      width: auto;
+      flex: none;
+      padding: 6px 12px;
+      border-radius: 20px;
+    }
   .profile-icon {
     margin-left: 0;
   }


### PR DESCRIPTION
## Summary
- align header contents to the left on mobile screens

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_688a417f1780832eb44c198080459ba9