### PR TITLE
feat: vendor map locate button

### DIFF
--- a/sunny_sales_web/src/components/VendorLocateButton.jsx
+++ b/sunny_sales_web/src/components/VendorLocateButton.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { useMap } from 'react-leaflet';
+
+export default function VendorLocateButton({ vendor }) {
+  const map = useMap();
+
+  if (!vendor) return null;
+
+  const handleLocate = () => {
+    if (vendor.current_lat && vendor.current_lng) {
+      map.flyTo([vendor.current_lat, vendor.current_lng], 16);
+    }
+  };
+
+  return (
+    <button
+      className="vendor-locate-btn"
+      onClick={handleLocate}
+      aria-label="Localizar vendedor"
+    >
+      {'\ud83d\udccd'}
+    </button>
+  );
+}
+

--- a/sunny_sales_web/src/pages/ModernMapLayout.css
+++ b/sunny_sales_web/src/pages/ModernMapLayout.css
@@ -180,6 +180,23 @@ body {
   z-index: 500;
 }
 
+.vendor-locate-btn {
+  position: absolute;
+  bottom: 1rem;
+  left: 1rem;
+  width: 44.8px;
+  height: 44.8px;
+  background: var(--secondary-color);
+  border: none;
+  border-radius: 50%;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+  z-index: 500;
+}
+
 
 /* From Uiverse.io by JaydipPrajapati1910 */
 .loader {

--- a/sunny_sales_web/src/pages/ModernMapLayout.jsx
+++ b/sunny_sales_web/src/pages/ModernMapLayout.jsx
@@ -4,6 +4,7 @@ import L from 'leaflet';
 import axios from 'axios';
 import { BASE_URL } from '../config';
 import LocateButton from '../components/LocateButton';
+import VendorLocateButton from '../components/VendorLocateButton';
 import './ModernMapLayout.css';
 
 // Layout principal com mapa e lista de vendedores online
@@ -146,6 +147,8 @@ export default function ModernMapLayout() {
           {!isVendorLogged && (
             <LocateButton onLocationFound={setClientPos} />
           )}
+
+          {selected && <VendorLocateButton vendor={selected} />}
 
         </MapContainer>
 


### PR DESCRIPTION
## Summary
- add `VendorLocateButton` component
- style new button in map layout
- render vendor locate button when a vendor is selected

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_688a694b1640832e94c50bc2edcc0f9f