### PR TITLE
feat: vendor zoom button

### DIFF
--- a/sunny_sales_web/src/components/VendorLocateButton.jsx
+++ b/sunny_sales_web/src/components/VendorLocateButton.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { useMap } from 'react-leaflet';
+
+export default function VendorLocateButton({ vendor }) {
+  const map = useMap();
+
+  const handleLocate = () => {
+    if (vendor && vendor.current_lat && vendor.current_lng) {
+      map.flyTo([vendor.current_lat, vendor.current_lng], 16);
+    }
+  };
+
+  return (
+    <button
+      className="vendor-locate-btn"
+      onClick={handleLocate}
+      aria-label="Localizar vendedor"
+      disabled={!vendor}
+    >
+      {'\ud83d\udccd'}
+    </button>
+  );
+}
+

--- a/sunny_sales_web/src/pages/ModernMapLayout.css
+++ b/sunny_sales_web/src/pages/ModernMapLayout.css
@@ -180,6 +180,23 @@ body {
   z-index: 500;
 }
 
+.vendor-locate-btn {
+  position: absolute;
+  bottom: 5rem;
+  right: 1rem;
+  width: 44.8px;
+  height: 44.8px;
+  background: var(--secondary-color);
+  border: none;
+  border-radius: 50%;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+  z-index: 500;
+}
+
 
 /* From Uiverse.io by JaydipPrajapati1910 */
 .loader {

--- a/sunny_sales_web/src/pages/ModernMapLayout.jsx
+++ b/sunny_sales_web/src/pages/ModernMapLayout.jsx
@@ -4,6 +4,7 @@ import L from 'leaflet';
 import axios from 'axios';
 import { BASE_URL } from '../config';
 import LocateButton from '../components/LocateButton';
+import VendorLocateButton from '../components/VendorLocateButton';
 import './ModernMapLayout.css';
 
 // Layout principal com mapa e lista de vendedores online
@@ -68,6 +69,19 @@ export default function ModernMapLayout() {
   const filteredVendors = activeVendors.filter((v) =>
     selectedProducts.includes(v.product)
   );
+
+  let loggedVendor = null;
+  if (isVendorLogged) {
+    try {
+      const stored = localStorage.getItem('user');
+      if (stored) {
+        const { id } = JSON.parse(stored);
+        loggedVendor = activeVendors.find((v) => v.id === id) || null;
+      }
+    } catch (e) {
+      console.error('Erro ao ler vendedor logado:', e);
+    }
+  }
 
   // Alterna a seleção de um produto no filtro
   const toggleProduct = (p) => {
@@ -146,6 +160,8 @@ export default function ModernMapLayout() {
           {!isVendorLogged && (
             <LocateButton onLocationFound={setClientPos} />
           )}
+
+          <VendorLocateButton vendor={selected || loggedVendor} />
 
         </MapContainer>
 


### PR DESCRIPTION
## Summary
- added `VendorLocateButton` to let a vendor recenter the map
- always show the vendor locate button and fall back to the logged-in vendor
- move vendor locate button to the right side

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement fastapi)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_688a694b1640832e94c50bc2edcc0f9f