### PR TITLE
Restrict vendor map access

### DIFF
--- a/sunny_sales_web/src/pages/ModernMapLayout.jsx
+++ b/sunny_sales_web/src/pages/ModernMapLayout.jsx
@@ -25,7 +25,12 @@ export default function ModernMapLayout() {
   useEffect(() => {
     const fetchVendors = async () => {
       try {
-        const res = await axios.get(`${BASE_URL}/vendors/`);
+        const headers = {};
+        if (isVendorLogged) {
+          const token = localStorage.getItem('token');
+          if (token) headers.Authorization = `Bearer ${token}`;
+        }
+        const res = await axios.get(`${BASE_URL}/vendors/`, { headers });
         setVendors(res.data);
       } catch (err) {
         console.error('Erro ao carregar vendedores:', err);

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -150,6 +150,22 @@ def test_vendor_listing(client):
         assert "current_lat" in v and "current_lng" in v
 
 
+def test_vendor_listing_authenticated_vendor(client):
+    resp = register_vendor(client, email="auth1@example.com", name="Auth1")
+    vid = resp.json()["id"]
+    confirm_latest_email(client)
+
+    register_vendor(client, email="auth2@example.com", name="Auth2")
+    confirm_latest_email(client)
+
+    token = get_token(client, email="auth1@example.com")
+    resp = client.get("/vendors/", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 200
+    vendors = resp.json()
+    assert len(vendors) == 1
+    assert vendors[0]["id"] == vid
+
+
 def test_protected_routes(client):
     resp = register_vendor(client)
     vendor_id = resp.json()["id"]


### PR DESCRIPTION
## Summary
- add `get_current_vendor_optional` helper
- limit `/vendors/` API to return a single vendor when authenticated
- fetch vendor list with token when vendor logged in
- test vendor listing behaviour when authenticated

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_688b96ce16ec832e922ed10cf0ddd29e