### PR TITLE
Fix map alignment with header

### DIFF
--- a/sunny_sales_web/src/App.jsx
+++ b/sunny_sales_web/src/App.jsx
@@ -51,7 +51,7 @@ function AppLayout() {
   const profileLink = isLoggedIn ? '/dashboard' : '/vendor-login';
 
   return (
-    <>
+    <div className="wrapper">
       {/* (em português) Barra de navegação */}
       <header className="header-wrapper">
         <Link className="logo-link logo-outside" to="/">Sunny Sales</Link>
@@ -123,7 +123,7 @@ function AppLayout() {
           <Route path="/dashboard" element={<Dashboard />} />
         </Routes>
       </div>
-    </>
+    </div>
   );
 }
 

--- a/sunny_sales_web/src/index.css
+++ b/sunny_sales_web/src/index.css
@@ -33,6 +33,21 @@ body {
   box-sizing: border-box;
 }
 
+/* Envolve o cabeçalho e o mapa */
+.wrapper {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding-left: 2rem;
+  padding-right: 2rem;
+}
+
+@media (max-width: 768px) {
+  .wrapper {
+    padding-left: 1rem;
+    padding-right: 1rem;
+  }
+}
+
 @media (max-width: 768px) {
   .container {
     padding: 0 0.5rem;
@@ -52,7 +67,7 @@ body {
 
 .logo-outside {
   position: absolute;
-  left: 24px;
+  left: 2rem;
   top: 50%;
   transform: translateY(-50%);
 

--- a/sunny_sales_web/src/pages/ModernMapLayout.css
+++ b/sunny_sales_web/src/pages/ModernMapLayout.css
@@ -78,25 +78,18 @@ body {
 
 .map-area {
   position: relative;
-  /*
-   * Align the map with the header.
-   * Left edge should start aligned with the "S" of "Sunny Sales" (24px).
-   * Right edge should end at the right side of the black navigation box
-   * which sits at 75% of the viewport width.
-   */
-  width: calc(75vw - 24px);
+  width: 100%;
   height: 80vh;
   padding: 1rem;
   box-sizing: border-box;
   margin: 0;
-  margin-left: 24px;
 }
 
 .map-container {
   width: 100%;
   height: 100%;
   /* Only keep rounded corners at the bottom to merge with the header */
-  border-radius: 0 0 16px 16px;
+  border-radius: 0 0 12px 12px;
   box-shadow: 0 2px 20px rgba(0, 0, 0, 0.08);
   background: var(--secondary-color);
 }


### PR DESCRIPTION
## Summary
- wrap header and main content in `.wrapper`
- style `.wrapper` for consistent padding
- keep map width in sync with layout and update border radius
- align header logo with new wrapper

## Testing
- `PYTHONPATH=. pytest -q` *(fails: test_single_session, test_paid_weeks_listing)*

------
https://chatgpt.com/codex/tasks/task_e_688c9e73fbdc832ebe3aac738ecc102e