### PR TITLE
Reduce spacing between header and filters

### DIFF
--- a/sunny_sales_web/src/pages/ModernMapLayout.css
+++ b/sunny_sales_web/src/pages/ModernMapLayout.css
@@ -48,7 +48,7 @@ body {
 }
 
 .filters {
-  margin-top: 0.5rem;
+  margin-top: 0.25rem;
   display: flex;
   gap: 0.75rem;
   justify-content: center;


### PR DESCRIPTION
## Summary
- tweak spacing between the navigation header and the product filters on the map page

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ce3201b18832e8bedaf9854488b9f