### PR TITLE
Fix navbar layout

### DIFF
--- a/sunny_sales_web/src/index.css
+++ b/sunny_sales_web/src/index.css
@@ -92,9 +92,9 @@ body {
 
   max-width: 1600px;
 
-
-  width: 100%;
-  margin: 0;
+  /* Decrease width so the logo sits outside the bar */
+  width: 80%;
+  margin: 0 auto;
 
 }
 


### PR DESCRIPTION
## Summary
- resize navbar so the Sunny Sales logo sits outside it

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ce7dab754832e8dc9baccfab7ea4d