### PR TITLE
Update modern layout CSS

### DIFF
--- a/sunny_sales_web/src/pages/ModernMapLayout.css
+++ b/sunny_sales_web/src/pages/ModernMapLayout.css
@@ -12,7 +12,7 @@ body {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  min-height: 100vh;
+  min-height: 80vh;
 }
 
 .app-name {


### PR DESCRIPTION
## Summary
- reduce min-height of `.modern-layout` from 100vh to 80vh

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'backend')*

------
https://chatgpt.com/codex/tasks/task_e_688cffd4d570832e9dd9a3a4d5a210ae