### PR TITLE
Fix navbar overflow on mobile

### DIFF
--- a/sunny_sales_web/src/index.css
+++ b/sunny_sales_web/src/index.css
@@ -80,6 +80,7 @@ body {
   justify-content: space-between;
 
   align-items: center;
+  box-sizing: border-box;
   padding: 12px 24px;
   background-color: #000;
   border-radius: 40px;


### PR DESCRIPTION
## Summary
- keep nav width inside screen with box-sizing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d3a9d9dbc832e87f1e9942f368a90