### PR TITLE
Ensure realtime location refresh

### DIFF
--- a/sunny_sales_mobile/App.js
+++ b/sunny_sales_mobile/App.js
@@ -50,22 +50,25 @@ export default function App() {
       setError('Permissão de localização em background negada');
       return;
     }
-    const watcherSub = await Location.watchPositionAsync(
-      {
-        accuracy: Location.Accuracy.High,
-        timeInterval: 10000,
-        distanceInterval: 5,
-      },
-      (location) => {
-        const { latitude, longitude } = location.coords;
-        axios.put(
-          `${BASE_URL}/vendors/${vendorId}/location`,
-          { lat: latitude, lng: longitude },
-          { headers: { Authorization: `Bearer ${token}` } }
-        ).catch(() => {});
+    const intervalId = setInterval(async () => {
+      try {
+        const { coords } = await Location.getCurrentPositionAsync({
+          accuracy: Location.Accuracy.High,
+        });
+        const { latitude, longitude } = coords;
+        await axios
+          .put(
+            `${BASE_URL}/vendors/${vendorId}/location`,
+            { lat: latitude, lng: longitude },
+            { headers: { Authorization: `Bearer ${token}` } }
+          )
+          .catch(() => {});
+      } catch {
+        // ignore errors retrieving location
       }
-    );
-    setWatcher(watcherSub);
+    }, 1000);
+
+    setWatcher({ remove: () => clearInterval(intervalId) });
   };
 
   return (

--- a/sunny_sales_web/src/pages/ModernMapLayout.jsx
+++ b/sunny_sales_web/src/pages/ModernMapLayout.jsx
@@ -42,10 +42,8 @@ export default function ModernMapLayout() {
   // Sempre que o mapa estiver pronto, acompanha a posição do utilizador
   // (vendedor ou cliente) e mantém o mapa centrado nessa localização.
   useEffect(() => {
-    let watcher;
-    let lastUpdate = 0;
-    if (mapReady && navigator.geolocation) {
-      // Obtém a posição atual assim que o mapa é criado
+    let interval;
+    const updatePosition = () => {
       navigator.geolocation.getCurrentPosition(
         (pos) => {
           const coords = {
@@ -60,29 +58,13 @@ export default function ModernMapLayout() {
         (err) => console.error('Erro localização:', err),
         { enableHighAccuracy: true }
       );
-
-      // Continua a acompanhar a posição para manter o mapa centrado
-      watcher = navigator.geolocation.watchPosition(
-        (pos) => {
-          const now = Date.now();
-          if (now - lastUpdate >= 1000) {
-            lastUpdate = now;
-            const coords = {
-              lat: pos.coords.latitude,
-              lng: pos.coords.longitude,
-            };
-            setClientPos(coords);
-            if (mapRef.current) {
-              mapRef.current.setView([coords.lat, coords.lng]);
-            }
-          }
-        },
-        (err) => console.error('Erro localização:', err),
-        { enableHighAccuracy: true }
-      );
+    };
+    if (mapReady && navigator.geolocation) {
+      updatePosition();
+      interval = setInterval(updatePosition, 1000);
     }
     return () => {
-      if (watcher) navigator.geolocation.clearWatch(watcher);
+      if (interval) clearInterval(interval);
     };
   }, [mapReady]);
 


### PR DESCRIPTION
## Summary
- poll vendor location every second in mobile app
- switch vendor dashboard to 1s geolocation polling
- update client map to refresh position each second

## Testing
- `pytest` *(fails: No module named 'backend')*

------
https://chatgpt.com/codex/tasks/task_e_688e1370ac38832ea33fc5523e2389eb