### PR TITLE
Ensure backend package is importable during tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+# Ensure the project root is available for imports like `backend.*`
+ROOT = Path(__file__).resolve().parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))


### PR DESCRIPTION
## Summary
- add conftest to insert project root into sys.path

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688e34517df0832e940173e7b6dd08c9