### PR TITLE
feat: update realtime location tracking

### DIFF
--- a/sunny_sales_web/src/pages/ModernMapLayout.jsx
+++ b/sunny_sales_web/src/pages/ModernMapLayout.jsx
@@ -47,9 +47,9 @@ export default function ModernMapLayout() {
   // Sempre que o mapa estiver pronto, acompanha a posição do utilizador
   // (vendedor ou cliente) e mantém o mapa centrado nessa localização.
   useEffect(() => {
-    let interval;
-    const updatePosition = () => {
-      navigator.geolocation.getCurrentPosition(
+    let watchId;
+    if (mapReady && navigator.geolocation) {
+      watchId = navigator.geolocation.watchPosition(
         (pos) => {
           const coords = {
             lat: pos.coords.latitude,
@@ -61,15 +61,11 @@ export default function ModernMapLayout() {
           }
         },
         (err) => console.error('Erro localização:', err),
-        { enableHighAccuracy: true }
+        { enableHighAccuracy: true, maximumAge: 0 }
       );
-    };
-    if (mapReady && navigator.geolocation) {
-      updatePosition();
-      interval = setInterval(updatePosition, 1000);
     }
     return () => {
-      if (interval) clearInterval(interval);
+      if (watchId !== undefined) navigator.geolocation.clearWatch(watchId);
     };
   }, [mapReady]);
 


### PR DESCRIPTION
## Summary
- use geolocation watchPosition to update map pin in real time
- restart vendor location sharing automatically and send updates through watchPosition

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f3b3f6e70832eafef05f0878b5729