### PR TITLE
feat: update realtime location tracking

### DIFF
--- a/sunny_sales_web/src/pages/ModernMapLayout.jsx
+++ b/sunny_sales_web/src/pages/ModernMapLayout.jsx
@@ -47,9 +47,9 @@ export default function ModernMapLayout() {
   // Sempre que o mapa estiver pronto, acompanha a posição do utilizador
   // (vendedor ou cliente) e mantém o mapa centrado nessa localização.
   useEffect(() => {
-    let interval;
-    const updatePosition = () => {
-      navigator.geolocation.getCurrentPosition(
+    let watchId;
+    if (mapReady && navigator.geolocation) {
+      watchId = navigator.geolocation.watchPosition(
         (pos) => {
           const coords = {
             lat: pos.coords.latitude,
@@ -61,15 +61,11 @@ export default function ModernMapLayout() {
           }
         },
         (err) => console.error('Erro localização:', err),
-        { enableHighAccuracy: true }
+        { enableHighAccuracy: true, maximumAge: 0 }
       );
-    };
-    if (mapReady && navigator.geolocation) {
-      updatePosition();
-      interval = setInterval(updatePosition, 1000);
     }
     return () => {
-      if (interval) clearInterval(interval);
+      if (watchId !== undefined) navigator.geolocation.clearWatch(watchId);
     };
   }, [mapReady]);
 

--- a/sunny_sales_web/src/pages/VendorDashboard.jsx
+++ b/sunny_sales_web/src/pages/VendorDashboard.jsx
@@ -1,11 +1,11 @@
 // (em português) Painel principal do vendedor com partilha de localização e menu lateral
 
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { BASE_URL } from '../config';
 import axios from 'axios';
 
-let intervalId = null;
+let watchId = null;
 
 export default function VendorDashboard() {
   const [vendor, setVendor] = useState(null);
@@ -22,6 +22,12 @@ export default function VendorDashboard() {
     setSharing(share);
   }, []);
 
+  useEffect(() => {
+    if (sharing && vendor && watchId === null) {
+      startSharing();
+    }
+  }, [sharing, vendor, startSharing]);
+
 
   const logout = () => {
     stopSharing();
@@ -30,7 +36,7 @@ export default function VendorDashboard() {
     navigate('/vendor-login');
   };
 
-  const startSharing = async () => {
+  const startSharing = useCallback(async () => {
     if (!vendor) return;
     const token = localStorage.getItem('token');
     if (!token) return;
@@ -38,34 +44,32 @@ export default function VendorDashboard() {
       await axios.post(`${BASE_URL}/vendors/${vendor.id}/routes/start`, null, {
         headers: { Authorization: `Bearer ${token}` },
       });
-      intervalId = setInterval(() => {
-        navigator.geolocation.getCurrentPosition(
-          async (pos) => {
-            try {
-              await axios.put(
-                `${BASE_URL}/vendors/${vendor.id}/location`,
-                { lat: pos.coords.latitude, lng: pos.coords.longitude },
-                { headers: { Authorization: `Bearer ${token}` } }
-              );
-            } catch (err) {
-              console.log('Erro ao enviar localização:', err);
-            }
-          },
-          (err) => console.log('Erro localização:', err),
-          { enableHighAccuracy: true }
-        );
-      }, 1000);
+      watchId = navigator.geolocation.watchPosition(
+        async (pos) => {
+          try {
+            await axios.put(
+              `${BASE_URL}/vendors/${vendor.id}/location`,
+              { lat: pos.coords.latitude, lng: pos.coords.longitude },
+              { headers: { Authorization: `Bearer ${token}` } }
+            );
+          } catch (err) {
+            console.log('Erro ao enviar localização:', err);
+          }
+        },
+        (err) => console.log('Erro localização:', err),
+        { enableHighAccuracy: true, maximumAge: 0 }
+      );
       localStorage.setItem('sharingLocation', 'true');
       setSharing(true);
     } catch (err) {
       console.log('Erro ao ativar localização:', err);
     }
-  };
+  }, [vendor]);
 
   const stopSharing = async () => {
-    if (intervalId) {
-      clearInterval(intervalId);
-      intervalId = null;
+    if (watchId !== null) {
+      navigator.geolocation.clearWatch(watchId);
+      watchId = null;
     }
     if (vendor) {
       const token = localStorage.getItem('token');
@@ -201,7 +205,7 @@ const styles = {
     verticalAlign: 'middle',
   },
   infoBox: {
-    backgroundColor: '#fff9c4',
+    backgroundColor: '#fff',
     padding: '1rem',
     borderRadius: '12px',
     marginBottom: '1rem',


### PR DESCRIPTION
## Summary
- use geolocation watchPosition to update map pin in real time
- restart vendor location sharing automatically and send updates through watchPosition
- switch vendor dashboard info box to a neutral background to avoid yellow overlay

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f3b3f6e70832eafef05f0878b5729