### PR TITLE
Fix vendor login to accept username alias

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -274,7 +274,13 @@ def verify_active_subscription(vendor: models.Vendor, db: Session):
 @app.post("/login", response_model=schemas.VendorOut)
 # login
 def login(credentials: schemas.UserLogin, db: Session = Depends(get_db)):
-    vendor = db.query(models.Vendor).filter(models.Vendor.email == credentials.email).first()
+    """Autentica um vendedor a partir do email ou username."""
+
+    email = credentials.email or credentials.username
+    if not email or not credentials.password:
+        raise HTTPException(status_code=400, detail="Email and password required")
+
+    vendor = db.query(models.Vendor).filter(models.Vendor.email == email).first()
     if not vendor or not pwd_context.verify(credentials.password, vendor.hashed_password):
         raise HTTPException(status_code=400, detail="Incorrect email or password")
     if not vendor.email_confirmed:

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -5,7 +5,15 @@ from datetime import datetime
 
 # UserLogin
 class UserLogin(BaseModel):
-    email: str
+    """Schema usado para autenticação de vendedores.
+
+    Aceita tanto o campo tradicional ``email`` como ``username``
+    (alias utilizado por algumas bibliotecas OAuth2). Um dos dois
+    deve ser fornecido juntamente com a palavra‑passe.
+    """
+
+    email: Optional[str] = None
+    username: Optional[str] = None
     password: str
 
 # VendorProfileUpdate

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -124,6 +124,19 @@ def test_login_requires_confirmation(client):
     assert resp.status_code == 200
 
 
+def test_login_accepts_username_field(client):
+    """O endpoint /login deve aceitar o campo 'username' como alias de email."""
+
+    register_vendor(client, email="alias@example.com")
+    confirm_latest_email(client)
+
+    resp = client.post(
+        "/login",
+        json={"username": "alias@example.com", "password": "Secret123"},
+    )
+    assert resp.status_code == 200
+
+
 def test_password_reset_flow(client):
     register_vendor(client)
     confirm_latest_email(client)


### PR DESCRIPTION
## Summary
- Allow vendor login schema to accept either `email` or `username`
- Adjust login endpoint to use the provided alias
- Test login using `username` field

## Testing
- `PYTHONWARNINGS=ignore pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f5942ea9c832e94845aa89bb67d27