### PR TITLE
fix: speed up geolocation pin display

### DIFF
--- a/sunny_sales_web/src/components/LocateButton.jsx
+++ b/sunny_sales_web/src/components/LocateButton.jsx
@@ -32,7 +32,7 @@ export default function LocateButton({ onLocationFound }) {
 
     map.on('locationfound', onFound);
     map.on('locationerror', onError);
-    map.locate({ enableHighAccuracy: true });
+    map.locate({ enableHighAccuracy: false, timeout: 5000, maximumAge: 60000 });
   };
 
   return (

--- a/sunny_sales_web/src/pages/ModernMapLayout.jsx
+++ b/sunny_sales_web/src/pages/ModernMapLayout.jsx
@@ -49,17 +49,25 @@ export default function ModernMapLayout() {
   useEffect(() => {
     let watchId;
     if (mapReady && navigator.geolocation) {
+      const updatePosition = (pos) => {
+        const coords = {
+          lat: pos.coords.latitude,
+          lng: pos.coords.longitude,
+        };
+        setClientPos(coords);
+        if (mapRef.current) {
+          mapRef.current.setView([coords.lat, coords.lng]);
+        }
+      };
+
+      navigator.geolocation.getCurrentPosition(
+        updatePosition,
+        (err) => console.error('Erro localização inicial:', err),
+        { enableHighAccuracy: false, timeout: 5000, maximumAge: 60000 }
+      );
+
       watchId = navigator.geolocation.watchPosition(
-        (pos) => {
-          const coords = {
-            lat: pos.coords.latitude,
-            lng: pos.coords.longitude,
-          };
-          setClientPos(coords);
-          if (mapRef.current) {
-            mapRef.current.setView([coords.lat, coords.lng]);
-          }
-        },
+        updatePosition,
         (err) => console.error('Erro localização:', err),
         { enableHighAccuracy: true, maximumAge: 0 }
       );


### PR DESCRIPTION
## Summary
- use an initial `getCurrentPosition` call followed by `watchPosition` to show the user's pin faster
- relax accuracy and caching on locate button for quicker manual location lookup

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f884e9384832ea784a298b48dee9d