### PR TITLE
Fix vendor login with username

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -137,6 +137,19 @@ def test_login_accepts_username_field(client):
     assert resp.status_code == 200
 
 
+def test_login_with_vendor_name(client):
+    """Permite autenticar usando o nome do vendedor."""
+
+    register_vendor(client, email="nome@example.com", name="vendedor1")
+    confirm_latest_email(client)
+
+    resp = client.post(
+        "/login",
+        json={"username": "vendedor1", "password": "Secret123"},
+    )
+    assert resp.status_code == 200
+
+
 def test_password_reset_flow(client):
     register_vendor(client)
     confirm_latest_email(client)


### PR DESCRIPTION
## Summary
- allow vendors to sign in using their name or email
- test login via vendor name

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f903ad19c832e912849c4b7851ec1