### PR TITLE
feat: adicionar rodape com frases rotativas

### DIFF
--- a/sunny_sales_web/src/App.jsx
+++ b/sunny_sales_web/src/App.jsx
@@ -29,6 +29,7 @@ import SobreProjeto from './pages/SobreProjeto';
 import Sustentabilidade from './pages/Sustentabilidade';
 import ImplementarScreen from './pages/ImplementarScreen';
 import WelcomePopup from './components/WelcomePopup';
+import Footer from './components/Footer';
 import './index.css'; // (em português) Importa os estilos globais
 
 // Componente principal que define as rotas da aplicação web
@@ -126,6 +127,7 @@ function AppLayout() {
           <Route path="/dashboard" element={<Dashboard />} />
         </Routes>
       </div>
+      <Footer />
     </div>
   );
 }

--- a/sunny_sales_web/src/components/Footer.css
+++ b/sunny_sales_web/src/components/Footer.css
@@ -1,0 +1,12 @@
+.footer {
+  position: fixed;
+  z-index: 9999;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  background-color: var(--primary-color);
+  color: var(--secondary-color);
+  text-align: center;
+  padding: 0.5rem;
+  font-weight: bold;
+}

--- a/sunny_sales_web/src/components/Footer.jsx
+++ b/sunny_sales_web/src/components/Footer.jsx
@@ -1,0 +1,69 @@
+import { useState, useEffect } from 'react';
+import './Footer.css';
+
+const messages = [
+  "Leva o lixo contigo.",
+  "A praia agradece o teu cuidado.",
+  "O mar não é caixote do lixo.",
+  "Protege a areia, respeita o planeta.",
+  "Cada beata no chão, um peixe em risco.",
+  "Recolhe o que trouxeste.",
+  "Mantém a praia limpa, todos os dias.",
+  "Sol, mar e consciência ambiental.",
+  "Natureza não é cinzeiro.",
+  "Plástico na areia? Não aqui!",
+  "Traz memórias, não lixo.",
+  "Usa o cinzeiro, salva o oceano.",
+  "Praia limpa, planeta feliz.",
+  "O teu gesto faz a diferença.",
+  "Sustentabilidade é ação, não intenção.",
+  "Ama a praia como ela te ama.",
+  "Um passo de cada vez para salvar o mar.",
+  "Proteger a praia é proteger o futuro.",
+  "A tua pegada pode ser verde.",
+  "Desfruta com respeito.",
+  "O futuro começa na areia.",
+  "Cada gesto conta.",
+  "Diz não ao lixo marinho.",
+  "As ondas não limpam o que deixas.",
+  "Sê o exemplo que o planeta precisa.",
+  "Mantém a praia como gostas de a encontrar.",
+  "O planeta começa aqui.",
+  "Cuida da praia como cuidas da tua casa.",
+  "Mar limpo, vida saudável.",
+  "Faz parte da solução, não da poluição.",
+  "Não deixes rastos, deixa boas memórias.",
+  "Reutiliza. Reduz. Recicla.",
+  "Preserva o azul com ações verdes.",
+  "Sem lixo, mais vida marinha.",
+  "Solta a toalha, não o plástico.",
+  "Beatas na areia? Nunca.",
+  "As praias limpas são responsabilidade de todos.",
+  "Junta-te à maré da mudança.",
+  "O respeito pelo ambiente começa contigo.",
+  "Uma praia limpa é uma praia viva.",
+  "Guarda o lixo até encontrares um caixote.",
+  "Cuidar da praia é cuidar de nós.",
+  "As pequenas ações constroem um grande futuro.",
+  "A mudança começa contigo.",
+  "Vive o verão de forma consciente.",
+  "O oceano não quer lembranças de plástico.",
+  "Cada beata recolhida é uma vitória.",
+  "Não há planeta B.",
+  "A tua atitude inspira os outros.",
+  "Praia limpa, alma leve."
+];
+
+export default function Footer() {
+  const [index, setIndex] = useState(0);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setIndex((prevIndex) => (prevIndex + 1) % messages.length);
+    }, 10000);
+    return () => clearInterval(interval);
+  }, []);
+
+  return <footer className="footer">{messages[index]}</footer>;
+}
+


### PR DESCRIPTION
## Summary
- add footer component that rotates sustainability messages every 10 seconds
- style footer with black background and yellow text
- integrate footer into main app layout
- ensure footer stays above map by setting high z-index

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688f94baf47c832eab9df68ac0cb2ae6