### PR TITLE
feat(mobile): add vendor registration screen

### DIFF
--- a/sunny_sales_mobile/App.js
+++ b/sunny_sales_mobile/App.js
@@ -3,6 +3,7 @@ import { View, Text, TextInput, Button, StyleSheet } from 'react-native';
 import * as Location from 'expo-location';
 import axios from 'axios';
 import { BASE_URL } from './src/config';
+import VendorRegister from './VendorRegister';
 
 export default function App() {
   const [email, setEmail] = useState('');
@@ -11,6 +12,7 @@ export default function App() {
   const [vendorId, setVendorId] = useState(null);
   const [watcher, setWatcher] = useState(null);
   const [error, setError] = useState(null);
+  const [showRegister, setShowRegister] = useState(false);
 
   const decodeId = (t) => {
     try {
@@ -73,7 +75,9 @@ export default function App() {
 
   return (
     <View style={styles.container}>
-      {!token ? (
+      {showRegister ? (
+        <VendorRegister onBack={() => setShowRegister(false)} />
+      ) : !token ? (
         <>
           <Text style={styles.title}>Login do Vendedor</Text>
           <TextInput
@@ -90,6 +94,7 @@ export default function App() {
             onChangeText={setPassword}
           />
           <Button title="Entrar" onPress={login} />
+          <Button title="Registar" onPress={() => setShowRegister(true)} />
           {error && <Text style={styles.error}>{error}</Text>}
         </>
       ) : (

--- a/sunny_sales_mobile/VendorRegister.js
+++ b/sunny_sales_mobile/VendorRegister.js
@@ -1,0 +1,79 @@
+import React, { useState } from 'react';
+import { View, Text, TextInput, Button, StyleSheet } from 'react-native';
+import axios from 'axios';
+import { BASE_URL } from './src/config';
+
+export default function VendorRegister({ onBack }) {
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [product, setProduct] = useState('');
+  const [error, setError] = useState('');
+  const [success, setSuccess] = useState('');
+
+  const handleRegister = async () => {
+    setError('');
+    setSuccess('');
+    if (!name || !email || !password || !product) {
+      setError('Preencha todos os campos');
+      return;
+    }
+    try {
+      await axios.post(`${BASE_URL}/vendors/`, {
+        name,
+        email,
+        password,
+        product,
+      });
+      setSuccess('Registo efetuado com sucesso!');
+      setName('');
+      setEmail('');
+      setPassword('');
+      setProduct('');
+    } catch (e) {
+      setError('Erro ao registar');
+    }
+  };
+
+  return (
+    <View>
+      <Text style={styles.title}>Registo de Vendedor</Text>
+      <TextInput
+        placeholder="Nome"
+        style={styles.input}
+        value={name}
+        onChangeText={setName}
+      />
+      <TextInput
+        placeholder="Email"
+        style={styles.input}
+        value={email}
+        onChangeText={setEmail}
+      />
+      <TextInput
+        placeholder="Palavra-passe"
+        style={styles.input}
+        value={password}
+        secureTextEntry
+        onChangeText={setPassword}
+      />
+      <TextInput
+        placeholder="Produto"
+        style={styles.input}
+        value={product}
+        onChangeText={setProduct}
+      />
+      <Button title="Registar" onPress={handleRegister} />
+      {error ? <Text style={styles.error}>{error}</Text> : null}
+      {success ? <Text style={styles.success}>{success}</Text> : null}
+      <Button title="Voltar" onPress={onBack} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  title: { fontSize: 20, marginBottom: 20 },
+  input: { borderWidth: 1, marginBottom: 10, padding: 8 },
+  error: { color: 'red', marginTop: 10 },
+  success: { color: 'green', marginTop: 10 },
+});


### PR DESCRIPTION
## Summary
- add vendor registration screen with required fields and API call
- integrate screen into mobile app login flow

## Testing
- `npm test` (fails: Missing script "test")
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890b4746db8832ebcb7a816b25b7dd3