### PR TITLE
Show pin color in account settings

### DIFF
--- a/sunny_sales_web/src/index.css
+++ b/sunny_sales_web/src/index.css
@@ -651,7 +651,6 @@ input[type='checkbox'] {
 .form input[type="password"],
 .form input[type="text"],
 .form input[type="file"],
-.form input[type="color"],
 .form select {
   border-radius: 0.5rem;
   padding: 1rem 0.75rem;
@@ -669,8 +668,21 @@ input[type='checkbox'] {
 .form input[type="password"]:focus,
 .form input[type="text"]:focus,
 .form input[type="file"]:focus,
-.form input[type="color"]:focus,
 .form select:focus {
+  outline: 2px solid var(--clr);
+}
+
+.form input[type="color"] {
+  border-radius: 0.5rem;
+  padding: 0;
+  width: 100%;
+  height: 3rem;
+  border: none;
+  background: none;
+  outline: 2px solid var(--bg-dark);
+}
+
+.form input[type="color"]:focus {
   outline: 2px solid var(--clr);
 }
 
@@ -710,12 +722,3 @@ input[type='checkbox'] {
   color: var(--clr);
 }
 
-.color-preview {
-  display: inline-block;
-  width: 20px;
-  height: 20px;
-  border-radius: 50%;
-  border: 1px solid var(--bg-dark);
-  margin-left: 8px;
-  vertical-align: middle;
-}

--- a/sunny_sales_web/src/pages/ManageAccount.jsx
+++ b/sunny_sales_web/src/pages/ManageAccount.jsx
@@ -163,9 +163,6 @@ export default function ManageAccount() {
             type="color"
             value={pinColor}
             onChange={(e) => setPinColor(e.target.value)}
-          />
-          <span
-            className="color-preview"
             style={{ backgroundColor: pinColor }}
           />
         </span>


### PR DESCRIPTION
## Summary
- display chosen pin color directly in account settings picker
- remove standalone color preview circle
- style color input without extra preview

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6890cb7702f8832e99bbaf808052dcce