### PR TITLE
feat: track client location continuously

### DIFF
--- a/sunny_sales_web/src/pages/ModernMapLayout.jsx
+++ b/sunny_sales_web/src/pages/ModernMapLayout.jsx
@@ -60,16 +60,10 @@ export default function ModernMapLayout() {
         }
       };
 
-      navigator.geolocation.getCurrentPosition(
-        updatePosition,
-        (err) => console.error('Erro localização inicial:', err),
-        { enableHighAccuracy: false, timeout: 5000, maximumAge: 60000 }
-      );
-
       watchId = navigator.geolocation.watchPosition(
         updatePosition,
         (err) => console.error('Erro localização:', err),
-        { enableHighAccuracy: true, maximumAge: 0 }
+        { enableHighAccuracy: true, maximumAge: 1000 }
       );
     }
     return () => {


### PR DESCRIPTION
## Summary
- track client browser location continuously using geolocation watch

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6891b36e0ae8832eab336934f257a82a