### PR TITLE
feat: enforce single active session

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -309,6 +309,7 @@ async def generate_token(
     """Allow token generation using either JSON or form-encoded data."""
     email = None
     password = None
+    force = False
 
 
     content_type = request.headers.get("content-type", "").lower()
@@ -317,20 +318,24 @@ async def generate_token(
         data = await request.json()
         email = data.get("email") or data.get("username")
         password = data.get("password")
+        force = bool(data.get("force"))
     elif "application/x-www-form-urlencoded" in content_type or "multipart/form-data" in content_type:
         form = await request.form()
         email = form.get("email") or form.get("username")
         password = form.get("password")
+        force = str(form.get("force", "")).lower() in {"1", "true", "on"}
     else:
         # fallback: tentar json primeiro, depois form
         try:
             data = await request.json()
             email = data.get("email") or data.get("username")
             password = data.get("password")
+            force = bool(data.get("force"))
         except Exception:
             form = await request.form()
             email = form.get("email") or form.get("username")
             password = form.get("password")
+            force = str(form.get("force", "")).lower() in {"1", "true", "on"}
 
 
     if not email or not password:
@@ -341,6 +346,23 @@ async def generate_token(
         raise HTTPException(status_code=400, detail="Incorrect email or password")
     if not vendor.email_confirmed:
         raise HTTPException(status_code=400, detail="Email not confirmed")
+
+    # Se j\u00e1 existir uma sess\u00e3o ativa
+    if vendor.session_token:
+        try:
+            decode_token(vendor.session_token)
+        except HTTPException:
+            # Token anterior est\u00e1 expirado ou inv\u00e1lido
+            vendor.session_token = None
+            db.commit()
+        else:
+            if not force:
+                # Sess\u00e3o ainda v\u00e1lida e n\u00e3o foi solicitado for\u00e7ar
+                raise HTTPException(status_code=409, detail="Active session exists")
+            # For\u00e7ar: encerrar sess\u00e3o anterior antes de continuar
+            vendor.session_token = None
+            db.commit()
+
     token = create_access_token({"sub": vendor.id})
     # Guardar o token atual no vendedor para que apenas esta sess\u00e3o seja v\u00e1lida
     vendor.session_token = token

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -54,6 +54,7 @@ def activate_subscription(client, vendor_id):
         headers={"Authorization": f"Bearer {token}"},
     )
     assert resp.status_code == 200
+    return token
 
 
 
@@ -71,8 +72,11 @@ def test_vendor_registration(client):
     assert payload["product"] == "Bolas de Berlim"
 
 
-def get_token(client, email="vendor@example.com", password="Secret123"):
-    resp = client.post("/token", json={"email": email, "password": password})
+def get_token(client, email="vendor@example.com", password="Secret123", force=False):
+    payload = {"email": email, "password": password}
+    if force:
+        payload["force"] = True
+    resp = client.post("/token", json=payload)
     assert resp.status_code == 200
     return resp.json()["access_token"]
 
@@ -97,13 +101,30 @@ def test_single_session(client):
     )
     assert resp.status_code == 200
 
-    # Gerar um novo token que deve invalidar o primeiro
-    token2 = get_token(client, email="single@example.com")
+    # Tentar gerar um novo token sem forçar deve falhar
+    resp = client.post(
+        "/token",
+        json={"email": "single@example.com", "password": "Secret123"},
+    )
+    assert resp.status_code == 409
+
+    # Gerar um novo token forçando o logout anterior
+    token2 = get_token(client, email="single@example.com", force=True)
     resp = client.get(
         "/vendors/me",
         headers={"Authorization": f"Bearer {token2}"},
     )
     assert resp.status_code == 200
+
+    # O token atual armazenado deve corresponder ao novo token
+    from backend.app import models, database
+
+    db = database.SessionLocal()
+    try:
+        vendor = db.query(models.Vendor).filter(models.Vendor.email == "single@example.com").first()
+        assert vendor.session_token == token2
+    finally:
+        db.close()
 
     # Token antigo deve deixar de ser válido
     resp = client.get(
@@ -196,8 +217,7 @@ def test_protected_routes(client):
     resp = register_vendor(client)
     vendor_id = resp.json()["id"]
     confirm_latest_email(client)
-    activate_subscription(client, vendor_id)
-    token = get_token(client)
+    token = activate_subscription(client, vendor_id)
 
     # update profile with auth
     resp = client.patch(
@@ -229,8 +249,7 @@ def test_location_update_fields(client):
     resp = register_vendor(client)
     vendor_id = resp.json()["id"]
     confirm_latest_email(client)
-    activate_subscription(client, vendor_id)
-    token = get_token(client)
+    token = activate_subscription(client, vendor_id)
 
     client.post(
         f"/vendors/{vendor_id}/routes/start",
@@ -255,8 +274,7 @@ def test_websocket_location_broadcast(client):
     resp = register_vendor(client)
     vendor_id = resp.json()["id"]
     confirm_latest_email(client)
-    activate_subscription(client, vendor_id)
-    token = get_token(client)
+    token = activate_subscription(client, vendor_id)
 
     client.post(
         f"/vendors/{vendor_id}/routes/start",
@@ -279,8 +297,7 @@ def test_routes_flow(client):
     resp = register_vendor(client)
     vendor_id = resp.json()["id"]
     confirm_latest_email(client)
-    activate_subscription(client, vendor_id)
-    token = get_token(client)
+    token = activate_subscription(client, vendor_id)
 
     # start route
     resp = client.post(


### PR DESCRIPTION
## Summary
- revoke prior session when login is forced so previous device is signed out
- extend tests to confirm forced logins update stored session tokens and invalidate old ones

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890c483416c832e8e409bb107c228eb