### PR TITLE
Fix session termination when logging in on a new device

### DIFF
--- a/sunny_sales_web/src/App.jsx
+++ b/sunny_sales_web/src/App.jsx
@@ -9,6 +9,8 @@ import {
 } from 'react-router-dom';
 import { FiUser, FiMenu } from 'react-icons/fi';
 import { useState, useEffect } from 'react';
+import axios from 'axios';
+import { BASE_URL } from './config';
 import About from './pages/About';
 import AccountSettings from './pages/AccountSettings';
 import VendorLogin from './pages/VendorLogin';
@@ -46,7 +48,25 @@ function AppLayout() {
   const [isLoggedIn, setIsLoggedIn] = useState(!!localStorage.getItem('user'));
 
   useEffect(() => {
-    setIsLoggedIn(!!localStorage.getItem('user'));
+    const token = localStorage.getItem('token');
+    if (!token) {
+      localStorage.removeItem('user');
+      setIsLoggedIn(false);
+      return;
+    }
+    axios
+      .get(`${BASE_URL}/vendors/me`, {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      .then((res) => {
+        localStorage.setItem('user', JSON.stringify(res.data));
+        setIsLoggedIn(true);
+      })
+      .catch(() => {
+        localStorage.removeItem('token');
+        localStorage.removeItem('user');
+        setIsLoggedIn(false);
+      });
   }, [location]);
 
   const profileLink = isLoggedIn ? '/dashboard' : '/vendor-login';


### PR DESCRIPTION
## Summary
- verify vendor token with the backend on every navigation and drop invalid sessions

## Testing
- `npm run lint`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6892164fe758832eb3b58b1607bab361