### PR TITLE
Expose token credentials in docs

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -303,40 +303,13 @@ def login(credentials: schemas.UserLogin, db: Session = Depends(get_db)):
 @app.post("/token")
 # generate_token
 async def generate_token(
-    request: Request,
+    credentials: schemas.UserLogin,
     db: Session = Depends(get_db),
 ):
-    """Allow token generation using either JSON or form-encoded data."""
-    email = None
-    password = None
-    force = False
-
-
-    content_type = request.headers.get("content-type", "").lower()
-
-    if "application/json" in content_type:
-        data = await request.json()
-        email = data.get("email") or data.get("username")
-        password = data.get("password")
-        force = bool(data.get("force"))
-    elif "application/x-www-form-urlencoded" in content_type or "multipart/form-data" in content_type:
-        form = await request.form()
-        email = form.get("email") or form.get("username")
-        password = form.get("password")
-        force = str(form.get("force", "")).lower() in {"1", "true", "on"}
-    else:
-        # fallback: tentar json primeiro, depois form
-        try:
-            data = await request.json()
-            email = data.get("email") or data.get("username")
-            password = data.get("password")
-            force = bool(data.get("force"))
-        except Exception:
-            form = await request.form()
-            email = form.get("email") or form.get("username")
-            password = form.get("password")
-            force = str(form.get("force", "")).lower() in {"1", "true", "on"}
-
+    """Gerar um token de acesso a partir das credenciais fornecidas."""
+    email = credentials.email or credentials.username
+    password = credentials.password
+    force = credentials.force
 
     if not email or not password:
         raise HTTPException(status_code=400, detail="Email and password required")

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -15,6 +15,7 @@ class UserLogin(BaseModel):
     email: Optional[str] = None
     username: Optional[str] = None
     password: str
+    force: bool = False
 
 # VendorProfileUpdate
 class VendorProfileUpdate(BaseModel):


### PR DESCRIPTION
## Summary
- show email/password fields for token endpoint in Swagger
- extend user login schema with optional force flag

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68921c379970832e9c5f599e681fb3fc