### PR TITLE
Expose token credentials in docs

### DIFF
--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -15,6 +15,7 @@ class UserLogin(BaseModel):
     email: Optional[str] = None
     username: Optional[str] = None
     password: str
+    force: bool = False
 
 # VendorProfileUpdate
 class VendorProfileUpdate(BaseModel):


### PR DESCRIPTION
## Summary
- show email/password fields for token endpoint in Swagger
- extend user login schema with optional force flag
- allow token endpoint to accept both JSON and form data so Swagger Authorize works

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68921c379970832e9c5f599e681fb3fc