### PR TITLE
Atualiza cores da navegação e rodapé

### DIFF
--- a/sunny_sales_web/src/components/Footer.css
+++ b/sunny_sales_web/src/components/Footer.css
@@ -4,8 +4,8 @@
   bottom: 0;
   left: 0;
   width: 100%;
-  background-color: var(--primary-color);
-  color: var(--secondary-color);
+  background-color: #8424e8;
+  color: #fff;
   text-align: center;
   padding: 0.5rem;
   font-weight: bold;

--- a/sunny_sales_web/src/index.css
+++ b/sunny_sales_web/src/index.css
@@ -8,7 +8,7 @@
   --primary-color: #F79D65; /* laranja */
   --secondary-color: #FDF38A; /* amarelo */
 
-  --bg-color: #FDF38A; /* fundo amarelo */
+  --bg-color: #fccc34; /* fundo amarelo */
 
 
   --text-color: #000000;
@@ -82,7 +82,7 @@ body {
   align-items: center;
   box-sizing: border-box;
   padding: 12px 24px;
-  background-color: #F79D65;
+  background-color: #8424e8;
   border-radius: 40px;
   box-shadow: 0px 2px 10px rgba(0, 0, 0, 0.2);
 
@@ -167,7 +167,7 @@ body {
 
 .menu-toggle {
   display: none;
-  background: none;
+  background-color: #8424e8;
   border: none;
   color: #fff;
   font-size: 2rem;
@@ -474,7 +474,7 @@ input[type='checkbox'] {
     top: 100%;
     left: 0;
     width: 100%;
-    background-color: #F79D65;
+    background-color: #8424e8;
     padding: 1rem 2rem;
   }
 


### PR DESCRIPTION
## Summary
- define o fundo global como #fccc34
- aplica #8424e8 à barra de navegação, menu hambúrguer e rodapé

## Testing
- `npm test` *(erro: Missing script "test")*
- `npm run lint`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689322666b74832ebdcdccc6bd54b9c4