### PR TITLE
Atualiza cores da navegação e rodapé

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -743,11 +743,11 @@ async def show_password_reset_form(token: str):
         <meta charset="UTF-8">
         <title>Redefinir Senha</title>
     </head>
-    <body style="font-family: Arial; background: #f0f0f0; padding: 30px;">
+    <body style="font-family: Arial; background: #ffffff; padding: 30px;">
         <h2>Redefinir Senha</h2>
         <form action="/password-reset/{token}" method="post">
             <input type="password" name="new_password" placeholder="Nova senha" required style="padding: 8px; width: 200px;"><br><br>
-            <button type="submit" style="padding: 10px 20px;">Redefinir</button>
+            <button type="submit" style="padding: 10px 20px; background-color: #fccc34; color: #ffffff; border: none; border-radius: 4px;">Redefinir</button>
         </form>
     </body>
     </html>"""

--- a/sunny_sales_web/public/beach.css
+++ b/sunny_sales_web/public/beach.css
@@ -77,7 +77,7 @@ button {
   font-size: 1rem;
   border: none;
   border-radius: 4px;
-  background: #FDF38A;
+  background: #fccc34;
   color: #FFFFFF;
   cursor: pointer;
 }

--- a/sunny_sales_web/src/components/Footer.css
+++ b/sunny_sales_web/src/components/Footer.css
@@ -4,8 +4,8 @@
   bottom: 0;
   left: 0;
   width: 100%;
-  background-color: var(--primary-color);
-  color: var(--secondary-color);
+  background-color: #8424e8;
+  color: #fff;
   text-align: center;
   padding: 0.5rem;
   font-weight: bold;

--- a/sunny_sales_web/src/index.css
+++ b/sunny_sales_web/src/index.css
@@ -8,7 +8,7 @@
   --primary-color: #F79D65; /* laranja */
   --secondary-color: #FDF38A; /* amarelo */
 
-  --bg-color: #FDF38A; /* fundo amarelo */
+  --bg-color: #ffffff; /* fundo branco */
 
 
   --text-color: #000000;
@@ -82,7 +82,7 @@ body {
   align-items: center;
   box-sizing: border-box;
   padding: 12px 24px;
-  background-color: #F79D65;
+  background-color: #8424e8;
   border-radius: 40px;
   box-shadow: 0px 2px 10px rgba(0, 0, 0, 0.2);
 
@@ -167,7 +167,7 @@ body {
 
 .menu-toggle {
   display: none;
-  background: none;
+  background-color: #8424e8;
   border: none;
   color: #fff;
   font-size: 2rem;
@@ -368,18 +368,18 @@ align-items: center;
 
 /* === Estilo para botoes === */
 button {
-  --primary-color: #F79D65;
-  --secondary-color: #fff;
+  --primary-color: #fccc34 !important;
+  --secondary-color: #fff !important;
   --hover-color: #FDF38A;
   --arrow-width: 10px;
   --arrow-stroke: 2px;
   box-sizing: border-box;
   border: 0;
   border-radius: 20px;
-  color: var(--secondary-color);
+  color: var(--secondary-color) !important;
   font-size: 1rem;
   padding: 0.5em 1.2em;
-  background: var(--primary-color);
+  background-color: var(--primary-color) !important;
   display: flex;
   justify-content: center;
   transition: 0.2s background;
@@ -390,7 +390,7 @@ button {
 
 /* Utilizado para destacar botoes de acoes principais em laranja */
 .black-button {
-  --primary-color: #F79D65;
+  --primary-color: #fccc34;
   --secondary-color: #FFFFFF;
   --hover-color: #FDF38A;
   background-color: var(--primary-color);
@@ -474,7 +474,7 @@ input[type='checkbox'] {
     top: 100%;
     left: 0;
     width: 100%;
-    background-color: #F79D65;
+    background-color: #8424e8;
     padding: 1rem 2rem;
   }
 


### PR DESCRIPTION
## Summary
- define o fundo global como #ffffff
- estiliza todos os botões com #fccc34 e texto branco
- aplica as novas cores ao formulário de redefinição de senha e à página estática `beach`

## Testing
- `npm test` *(erro: Missing script "test")*
- `npm run lint`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689322666b74832ebdcdccc6bd54b9c4