### PR TITLE
Use Roboto font across site

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -741,9 +741,10 @@ async def show_password_reset_form(token: str):
     <html>
     <head>
         <meta charset="UTF-8">
+        <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap" rel="stylesheet">
         <title>Redefinir Senha</title>
     </head>
-    <body style="font-family: Arial; background: #ffffff; padding: 30px;">
+    <body style="font-family: 'Roboto', sans-serif; background: #ffffff; padding: 30px;">
         <h2>Redefinir Senha</h2>
         <form action="/password-reset/{token}" method="post">
             <input type="password" name="new_password" placeholder="Nova senha" required style="padding: 8px; width: 200px;"><br><br>

--- a/sunny_sales_web/public/beach.css
+++ b/sunny_sales_web/public/beach.css
@@ -1,8 +1,10 @@
+@import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap');
+
 html, body {
   margin: 0;
   padding: 0;
   height: 100%;
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: 'Roboto', sans-serif;
 }
 
 .background {

--- a/sunny_sales_web/public/resort-style.css
+++ b/sunny_sales_web/public/resort-style.css
@@ -1,6 +1,8 @@
+@import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap');
+
 body {
     margin: 0;
-    font-family: Arial, Helvetica, sans-serif;
+    font-family: 'Roboto', sans-serif;
 
     background: #FFFFFF;
 


### PR DESCRIPTION
## Summary
- load Google Fonts' Roboto in static beach and resort pages
- serve password reset form with Roboto styling

## Testing
- `npm run lint`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68933bdc6128832e8edf5ca7a1f8bebd