### PR TITLE
Add Sunny Sales logo to navbar

### DIFF
--- a/sunny_sales_web/src/App.jsx
+++ b/sunny_sales_web/src/App.jsx
@@ -76,6 +76,7 @@ function AppLayout() {
       {/* (em português) Barra de navegação */}
       <header className="header-wrapper">
         <div className="navbar">
+          <Link className="nav-logo" to="/">Sunny Sales</Link>
           <button
             className="menu-toggle"
             onClick={() => setMenuOpen(!menuOpen)}
@@ -114,8 +115,6 @@ function AppLayout() {
           </Link>
         </div>
       </header>
-
-      <Link className="logo-link" to="/">Sunny Sales</Link>
 
       {/* (em português) Container central da aplicação */}
       <div className="container">

--- a/sunny_sales_web/src/index.css
+++ b/sunny_sales_web/src/index.css
@@ -98,16 +98,11 @@ body {
   pointer-events: none;
 }
 
-.logo-link {
+.nav-logo {
   text-decoration: none;
-  color: #fccc34;
-  font-size: 40px;
+  color: #fff;
+  font-size: 1.5rem;
   font-weight: 600;
-  letter-spacing: 1px;
-  margin-top: 120px;
-  margin-bottom: 0.5rem;
-  display: block;
-  text-align: center;
 }
 
 .nav-links {
@@ -468,7 +463,7 @@ input[type='checkbox'] {
   .profile-icon {
     margin-left: 0;
   }
-  .logo-link {
+  .nav-logo {
     font-size: 28px;
   }
   .nav-links {
@@ -502,7 +497,7 @@ input[type='checkbox'] {
   .form-container.login-container {
     width: 90%;
   }
-  .logo-link {
+  .nav-logo {
     font-size: 24px;
   }
   .navbar {


### PR DESCRIPTION
## Summary
- add "Sunny Sales" logo text to navbar
- style logo with white text and responsive sizing

## Testing
- `pytest`
- `cd sunny_sales_web && npm test` *(fails: Missing script "test")*
- `cd sunny_sales_web && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689356280088832e92ca40563746dbd9