### PR TITLE
feat: replace static navbar with animated SVG

### DIFF
--- a/sunny_sales_web/src/App.jsx
+++ b/sunny_sales_web/src/App.jsx
@@ -76,6 +76,7 @@ function AppLayout() {
     <div className="wrapper">
       {/* (em português) Barra de navegação */}
       <header className="header-wrapper">
+        <img src={navbarWave} alt="" className="navbar-wave" />
         <div className="navbar">
           <Link className="nav-logo" to="/">Sunny Sales</Link>
           <button
@@ -115,10 +116,6 @@ function AppLayout() {
             <FiUser />
           </Link>
         </div>
-        <div
-          className="navbar-wave"
-          style={{ backgroundImage: `url(${navbarWave})` }}
-        />
       </header>
 
       {/* (em português) Container central da aplicação */}

--- a/sunny_sales_web/src/index.css
+++ b/sunny_sales_web/src/index.css
@@ -65,50 +65,39 @@
 
 
 
-  .header-wrapper {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    z-index: 1000;
-    overflow: hidden;
-  }
+.header-wrapper {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100px;
+  z-index: 1000;
+  overflow: hidden;
+}
 
+.navbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  box-sizing: border-box;
+  padding: 10px 20px;
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 1;
+}
 
-  .navbar {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    box-sizing: border-box;
-    padding: 10px 20px;
-    background-color: #0099ff;
-    box-shadow: 0px 2px 10px rgba(0, 0, 0, 0.2);
-    width: 100%;
-    position: relative;
-    z-index: 1;
-  }
-
-  .navbar-wave {
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    width: 200%;
-    height: 40px;
-    background-repeat: repeat-x;
-    background-size: cover;
-    animation: wave 10s linear infinite;
-    pointer-events: none;
-    z-index: 0;
-  }
-
-  @keyframes wave {
-    from {
-      transform: translateX(0);
-    }
-    to {
-      transform: translateX(-50%);
-    }
-  }
+.navbar-wave {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  z-index: 0;
+}
 
 .nav-logo {
   text-decoration: none;


### PR DESCRIPTION
## Summary
- show animated `navbar-wave` SVG in the header
- layer navigation links on top of the SVG and remove solid color bar

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6893651e0ee0832e83f4447bdeebfd7b