### PR TITLE
feat: add wave background to footer

### DIFF
--- a/sunny_sales_web/src/components/Footer.css
+++ b/sunny_sales_web/src/components/Footer.css
@@ -1,12 +1,34 @@
-.footer {
+.footer-wrapper {
   position: fixed;
   z-index: 9999;
   bottom: 0;
   left: 0;
   width: 100%;
-  background-color: #fccc34;
+  height: 40px;
+  overflow: hidden;
+}
+
+.footer-wave {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: fill;
+  transform: rotate(180deg);
+  z-index: 0;
+}
+
+.footer-message {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   color: #fff;
-  text-align: center;
-  padding: 0.5rem;
   font-weight: bold;
+  z-index: 1;
 }

--- a/sunny_sales_web/src/components/Footer.jsx
+++ b/sunny_sales_web/src/components/Footer.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import footerWave from '../assets/navbar-wave.svg';
 import './Footer.css';
 
 const messages = [
@@ -64,6 +65,11 @@ export default function Footer() {
     return () => clearInterval(interval);
   }, []);
 
-  return <footer className="footer">{messages[index]}</footer>;
+  return (
+    <footer className="footer-wrapper">
+      <img src={footerWave} alt="" className="footer-wave" />
+      <div className="footer-message">{messages[index]}</div>
+    </footer>
+  );
 }
 


### PR DESCRIPTION
## Summary
- add animated SVG wave to footer to mirror header style
- keep footer compact while displaying rotating environmental messages

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689372db3500832e8236eaefe9a6f952