### PR TITLE
Refine vendor authentication UI

### DIFF
--- a/sunny_sales_mobile/App.js
+++ b/sunny_sales_mobile/App.js
@@ -136,7 +136,7 @@ export default function App() {
 
 const styles = StyleSheet.create({
   container: { flex: 1, justifyContent: 'center', padding: 20 },
-  title: { fontSize: 20, marginBottom: 20 },
+  title: { fontSize: 20, marginBottom: 20, color: '#FDF38A' },
   input: { borderWidth: 1, marginBottom: 10, padding: 8 },
   error: { color: 'red', marginTop: 10 },
 });

--- a/sunny_sales_mobile/VendorRegister.js
+++ b/sunny_sales_mobile/VendorRegister.js
@@ -72,7 +72,7 @@ export default function VendorRegister({ onBack }) {
 }
 
 const styles = StyleSheet.create({
-  title: { fontSize: 20, marginBottom: 20 },
+  title: { fontSize: 20, marginBottom: 20, color: '#FDF38A' },
   input: { borderWidth: 1, marginBottom: 10, padding: 8 },
   error: { color: 'red', marginTop: 10 },
   success: { color: 'green', marginTop: 10 },

--- a/sunny_sales_web/src/index.css
+++ b/sunny_sales_web/src/index.css
@@ -528,7 +528,7 @@ input[type='checkbox'] {
   display: flex;
   align-items: center;
   padding-left: 30px;
-  color: #fff;
+  color: #FDF38A;
 }
 
 .auth-title::before,

--- a/sunny_sales_web/src/pages/VendorLogin.jsx
+++ b/sunny_sales_web/src/pages/VendorLogin.jsx
@@ -1,7 +1,7 @@
 // (em português) Página Web para login de vendedores
 
 import React, { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, Link } from 'react-router-dom';
 import axios from 'axios';
 import { BASE_URL } from '../config';
 import LoadingDots from '../components/LoadingDots';
@@ -93,7 +93,6 @@ export default function VendorLogin() {
 
       <div className="form login-form auth-form">
         <span className="input-span">
-          <label className="label">Email</label>
           <input
             type="email"
             placeholder="Email"
@@ -102,7 +101,6 @@ export default function VendorLogin() {
           />
         </span>
         <span className="input-span">
-          <label className="label">Palavra-passe</label>
           <input
             type="password"
             placeholder="Palavra-passe"
@@ -127,14 +125,11 @@ export default function VendorLogin() {
           Registar
         </button>
 
-        <button
-          type="button"
-          className="submit"
-          onClick={() => navigate('/forgot-password')}
-          style={{ textDecoration: 'underline' }}
-        >
-          Esqueci-me da palavra-passe
-        </button>
+        <div style={{ marginTop: '1rem' }}>
+          <Link to="/forgot-password" style={{ textDecoration: 'underline' }}>
+            Esqueci-me da palavra-passe
+          </Link>
+        </div>
       </div>
     </div>
   );

--- a/sunny_sales_web/src/pages/VendorRegister.jsx
+++ b/sunny_sales_web/src/pages/VendorRegister.jsx
@@ -102,7 +102,6 @@ export default function VendorRegister() {
           />
         </span>
         <span className="input-span">
-          <label className="label">Email</label>
           <input
             type="email"
             placeholder="Email"
@@ -111,7 +110,6 @@ export default function VendorRegister() {
           />
         </span>
         <span className="input-span">
-          <label className="label">Palavra-passe</label>
           <input
             type="password"
             placeholder="Palavra-passe"


### PR DESCRIPTION
## Summary
- remove redundant Email and password labels on vendor register and login forms
- convert forgotten password button into a link
- color vendor auth titles yellow on web and mobile

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`
- `npm test` in `sunny_sales_mobile` (fails: Missing script)
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689379661490832ebc08510d96f2cbb3