### PR TITLE
fix: add screen capture permission

### DIFF
--- a/sunny_sales_mobile/app.json
+++ b/sunny_sales_mobile/app.json
@@ -6,6 +6,9 @@
     "sdkVersion": "50.0.0",
     "platforms": ["android", "ios"],
     "orientation": "portrait",
-    "userInterfaceStyle": "light"
+    "userInterfaceStyle": "light",
+    "android": {
+      "permissions": ["android.permission.DETECT_SCREEN_CAPTURE"]
+    }
   }
 }


### PR DESCRIPTION
## Summary
- configure Android to grant DETECT_SCREEN_CAPTURE permission for Expo app

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68966a2b7a50832ebe9f0be4d8b30dd3