### PR TITLE
Add Expo mobile frontend scaffold

### DIFF
--- a/frontend_mobile/app.config.ts
+++ b/frontend_mobile/app.config.ts
@@ -1,0 +1,37 @@
+// (em português) Configuração Expo da app: nome, ícones e variáveis públicas (BASE_URL).
+import { ExpoConfig } from 'expo/config';
+
+const config: ExpoConfig = {
+  name: 'Sunny Sales',
+  slug: 'sunny-sales',
+  version: '0.1.0',
+  scheme: 'sunnysales',
+  orientation: 'portrait',
+  icon: './assets/icon.png',
+  userInterfaceStyle: 'light',
+  extra: {
+    // (em português) Define a URL do backend; pode ser substituída por variável de ambiente.
+    EXPO_PUBLIC_BASE_URL: process.env.EXPO_PUBLIC_BASE_URL ?? 'https://ss-tester.onrender.com'
+  },
+  experiments: {
+    typedRoutes: true
+  },
+  ios: {
+    supportsTablet: false
+  },
+  android: {
+    package: 'com.sunny.sales',
+    permissions: [
+      "ACCESS_FINE_LOCATION",
+      "ACCESS_COARSE_LOCATION",
+      "FOREGROUND_SERVICE",
+      "ACCESS_BACKGROUND_LOCATION"
+    ]
+  },
+  plugins: [
+    'expo-router',
+    'expo-location'
+  ]
+};
+
+export default config;

--- a/frontend_mobile/app/(auth)/forgot.tsx
+++ b/frontend_mobile/app/(auth)/forgot.tsx
@@ -1,0 +1,27 @@
+// (em português) Ecrã de recuperação de password (chama endpoint do backend).
+import { useState } from 'react';
+import { View, Text, TextInput, Pressable, Alert } from 'react-native';
+import { api } from '~/services/api';
+
+export default function ForgotScreen() {
+  const [email, setEmail] = useState('');
+
+  async function onSubmit() {
+    try {
+      await api.post('/auth/forgot', { email });
+      Alert.alert('Enviado', 'Verifica o teu email.');
+    } catch {
+      Alert.alert('Erro', 'Não foi possível enviar.');
+    }
+  }
+
+  return (
+    <View style={{ flex: 1, padding: 16, gap: 12 }}>
+      <Text style={{ fontSize: 24, fontWeight: 'bold' }}>Recuperar Password</Text>
+      <TextInput placeholder="Email" autoCapitalize="none" value={email} onChangeText={setEmail} style={{ borderWidth: 1, padding: 12, borderRadius: 8 }} />
+      <Pressable onPress={onSubmit} style={{ backgroundColor: '#ffd700', padding: 14, borderRadius: 12, alignItems: 'center' }}>
+        <Text style={{ fontWeight: 'bold' }}>Enviar</Text>
+      </Pressable>
+    </View>
+  );
+}

--- a/frontend_mobile/app/(auth)/login.tsx
+++ b/frontend_mobile/app/(auth)/login.tsx
@@ -1,0 +1,37 @@
+// (em português) Ecrã de login do vendedor com chamada ao backend e armazenamento seguro do token.
+import { useState } from 'react';
+import { View, Text, TextInput, Pressable, Alert } from 'react-native';
+import { login } from '~/services/auth';
+import { router } from 'expo-router';
+
+export default function LoginScreen() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  async function onSubmit() {
+    try {
+      setLoading(true);
+      await login(email, password);
+      router.replace('/(vendor)/dashboard');
+    } catch (e: any) {
+      Alert.alert('Erro', e?.message ?? 'Falha no login');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <View style={{ flex: 1, padding: 16, gap: 12 }}>
+      <Text style={{ fontSize: 24, fontWeight: 'bold' }}>Login Vendedor</Text>
+      <TextInput placeholder="Email" autoCapitalize="none" value={email} onChangeText={setEmail} style={{ borderWidth: 1, padding: 12, borderRadius: 8 }} />
+      <TextInput placeholder="Password" secureTextEntry value={password} onChangeText={setPassword} style={{ borderWidth: 1, padding: 12, borderRadius: 8 }} />
+      <Pressable onPress={onSubmit} style={{ backgroundColor: '#ffd700', padding: 14, borderRadius: 12, alignItems: 'center' }}>
+        <Text style={{ fontWeight: 'bold' }}>{loading ? 'A entrar...' : 'Entrar'}</Text>
+      </Pressable>
+      <Pressable onPress={() => router.push('/(auth)/register')}>
+        <Text>Não tens conta? Regista-te</Text>
+      </Pressable>
+    </View>
+  );
+}

--- a/frontend_mobile/app/(auth)/register.tsx
+++ b/frontend_mobile/app/(auth)/register.tsx
@@ -1,0 +1,53 @@
+// (em português) Ecrã de registo com upload opcional de foto (pré-estrutura).
+import { useState } from 'react';
+import { View, Text, TextInput, Pressable, Alert } from 'react-native';
+import * as ImagePicker from 'expo-image-picker';
+import { api } from '~/services/api';
+import { router } from 'expo-router';
+
+export default function RegisterScreen() {
+  const [name, setName] = useState('');
+  const [product, setProduct] = useState('Bolas de Berlim');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [photoUri, setPhotoUri] = useState<string | null>(null);
+
+  async function pickPhoto() {
+    const res = await ImagePicker.launchImageLibraryAsync({ allowsEditing: true, quality: 0.8 });
+    if (!res.canceled) setPhotoUri(res.assets[0].uri);
+  }
+
+  async function onSubmit() {
+    try {
+      const form = new FormData();
+      form.append('name', name);
+      form.append('email', email);
+      form.append('password', password);
+      form.append('product', product);
+      if (photoUri) {
+        // @ts-ignore
+        form.append('photo', { uri: photoUri, name: 'photo.jpg', type: 'image/jpeg' });
+      }
+      await api.post('/auth/register', form, { headers: { 'Content-Type': 'multipart/form-data' } });
+      Alert.alert('Sucesso', 'Conta criada. Faz login.');
+      router.replace('/(auth)/login');
+    } catch (e: any) {
+      Alert.alert('Erro', e?.message ?? 'Falha no registo');
+    }
+  }
+
+  return (
+    <View style={{ flex: 1, padding: 16, gap: 12 }}>
+      <Text style={{ fontSize: 24, fontWeight: 'bold' }}>Registo Vendedor</Text>
+      <TextInput placeholder="Nome" value={name} onChangeText={setName} style={{ borderWidth: 1, padding: 12, borderRadius: 8 }} />
+      <TextInput placeholder="Email" autoCapitalize="none" value={email} onChangeText={setEmail} style={{ borderWidth: 1, padding: 12, borderRadius: 8 }} />
+      <TextInput placeholder="Password" secureTextEntry value={password} onChangeText={setPassword} style={{ borderWidth: 1, padding: 12, borderRadius: 8 }} />
+      <Pressable onPress={pickPhoto} style={{ backgroundColor: '#eee', padding: 12, borderRadius: 8 }}>
+        <Text>{photoUri ? 'Foto selecionada ✅' : 'Selecionar foto'}</Text>
+      </Pressable>
+      <Pressable onPress={onSubmit} style={{ backgroundColor: '#ffd700', padding: 14, borderRadius: 12, alignItems: 'center' }}>
+        <Text style={{ fontWeight: 'bold' }}>Criar conta</Text>
+      </Pressable>
+    </View>
+  );
+}

--- a/frontend_mobile/app/(public)/map/index.tsx
+++ b/frontend_mobile/app/(public)/map/index.tsx
@@ -1,0 +1,62 @@
+// (em português) Mapa público com pins de vendedores ativos e filtro por produto.
+import { useEffect, useState } from 'react';
+import { View } from 'react-native';
+import MapView, { Marker, Callout } from 'react-native-maps';
+import * as Location from 'expo-location';
+import { getActiveVendors } from '~/services/vendor';
+import ProductFilter from '~/components/ProductFilter';
+
+const PRODUCTS = ['Bolas de Berlim', 'Gelados', 'Acessórios de Praia'] as const;
+
+export default function PublicMapScreen() {
+  const [region, setRegion] = useState({
+    latitude: 38.7,
+    longitude: -9.2,
+    latitudeDelta: 0.05,
+    longitudeDelta: 0.05
+  });
+  const [vendors, setVendors] = useState<any[]>([]);
+  const [selectedProducts, setSelectedProducts] = useState<string[]>([...PRODUCTS]);
+
+  useEffect(() => {
+    (async () => {
+      const { status } = await Location.requestForegroundPermissionsAsync();
+      if (status === 'granted') {
+        const pos = await Location.getCurrentPositionAsync({});
+        setRegion(r => ({ ...r, latitude: pos.coords.latitude, longitude: pos.coords.longitude }));
+      }
+      const data = await getActiveVendors();
+      setVendors(data || []);
+    })();
+  }, []);
+
+  return (
+    <View style={{ flex: 1 }}>
+      <MapView style={{ flex: 1 }} region={region} onRegionChangeComplete={setRegion}>
+        {vendors
+          .filter(v => selectedProducts.includes(v.product))
+          .map(v => (
+            <Marker
+              key={v.id}
+              coordinate={{ latitude: v.current_lat, longitude: v.current_lng }}
+              title={v.name}
+              description={v.product}
+            >
+              <Callout>
+                {/* (em português) Aqui podemos mostrar foto, rating e ações (favorito) */}
+              </Callout>
+            </Marker>
+          ))}
+      </MapView>
+      <ProductFilter
+        products={PRODUCTS as unknown as string[]}
+        selected={selectedProducts}
+        onToggle={(p) =>
+          setSelectedProducts(s =>
+            s.includes(p) ? s.filter(x => x !== p) : [...s, p]
+          )
+        }
+      />
+    </View>
+  );
+}

--- a/frontend_mobile/app/(vendor)/account/edit-profile.tsx
+++ b/frontend_mobile/app/(vendor)/account/edit-profile.tsx
@@ -1,0 +1,10 @@
+// (em português) Edição de perfil do vendedor (estrutura base).
+import { View, Text } from 'react-native';
+
+export default function EditProfile() {
+  return (
+    <View style={{ flex: 1, padding: 16 }}>
+      <Text>Editar perfil</Text>
+    </View>
+  );
+}

--- a/frontend_mobile/app/(vendor)/account/manage.tsx
+++ b/frontend_mobile/app/(vendor)/account/manage.tsx
@@ -1,0 +1,10 @@
+// (em português) Gestão de conta do vendedor (estrutura base).
+import { View, Text } from 'react-native';
+
+export default function ManageAccount() {
+  return (
+    <View style={{ flex: 1, padding: 16 }}>
+      <Text>Gerir conta</Text>
+    </View>
+  );
+}

--- a/frontend_mobile/app/(vendor)/account/sessions.tsx
+++ b/frontend_mobile/app/(vendor)/account/sessions.tsx
@@ -1,0 +1,10 @@
+// (em português) Gestão de sessões ativas (estrutura base).
+import { View, Text } from 'react-native';
+
+export default function Sessions() {
+  return (
+    <View style={{ flex: 1, padding: 16 }}>
+      <Text>Sessões ativas</Text>
+    </View>
+  );
+}

--- a/frontend_mobile/app/(vendor)/account/settings.tsx
+++ b/frontend_mobile/app/(vendor)/account/settings.tsx
@@ -1,0 +1,10 @@
+// (em português) Definições de conta (estrutura base).
+import { View, Text } from 'react-native';
+
+export default function AccountSettings() {
+  return (
+    <View style={{ flex: 1, padding: 16 }}>
+      <Text>Definições</Text>
+    </View>
+  );
+}

--- a/frontend_mobile/app/(vendor)/billing/invoices.tsx
+++ b/frontend_mobile/app/(vendor)/billing/invoices.tsx
@@ -1,0 +1,10 @@
+// (em português) Lista de faturas (estrutura base).
+import { View, Text } from 'react-native';
+
+export default function Invoices() {
+  return (
+    <View style={{ flex: 1, padding: 16 }}>
+      <Text>Faturas</Text>
+    </View>
+  );
+}

--- a/frontend_mobile/app/(vendor)/billing/paid-weeks.tsx
+++ b/frontend_mobile/app/(vendor)/billing/paid-weeks.tsx
@@ -1,0 +1,10 @@
+// (em português) Semanas pagas (estrutura base).
+import { View, Text } from 'react-native';
+
+export default function PaidWeeks() {
+  return (
+    <View style={{ flex: 1, padding: 16 }}>
+      <Text>Semanas pagas</Text>
+    </View>
+  );
+}

--- a/frontend_mobile/app/(vendor)/dashboard/index.tsx
+++ b/frontend_mobile/app/(vendor)/dashboard/index.tsx
@@ -1,0 +1,35 @@
+// (em português) Dashboard do vendedor com botão Ativo/Inativo e controlo de partilha de localização.
+import { useEffect, useState } from 'react';
+import { View, Text, Pressable, Alert } from 'react-native';
+import { setActive } from '~/services/vendor';
+import { startLocationSharing, stopLocationSharing } from '~/tasks/locationTask';
+
+export default function VendorDashboard() {
+  const [active, setActiveState] = useState(false);
+
+  useEffect(() => {
+    // (em português) No futuro, podemos carregar estado do backend.
+  }, []);
+
+  async function toggleActive() {
+    try {
+      const next = !active;
+      setActiveState(next);
+      await setActive(next);
+      if (next) await startLocationSharing();
+      else await stopLocationSharing();
+      Alert.alert('Estado', next ? 'Ativo' : 'Inativo');
+    } catch {
+      Alert.alert('Erro', 'Não foi possível atualizar o estado.');
+    }
+  }
+
+  return (
+    <View style={{ flex: 1, padding: 16, gap: 12 }}>
+      <Text style={{ fontSize: 24, fontWeight: 'bold' }}>Painel do Vendedor</Text>
+      <Pressable onPress={toggleActive} style={{ backgroundColor: active ? '#90ee90' : '#f08080', padding: 16, borderRadius: 12, alignItems: 'center' }}>
+        <Text style={{ fontWeight: 'bold' }}>{active ? 'Parar partilha (Inativo)' : 'Iniciar partilha (Ativo)'}</Text>
+      </Pressable>
+    </View>
+  );
+}

--- a/frontend_mobile/app/(vendor)/routes/[id].tsx
+++ b/frontend_mobile/app/(vendor)/routes/[id].tsx
@@ -1,0 +1,10 @@
+// (em português) Detalhe de um trajeto (estrutura base; integrar no futuro).
+import { View, Text } from 'react-native';
+
+export default function RouteDetail() {
+  return (
+    <View style={{ flex: 1, padding: 16 }}>
+      <Text>Detalhe do trajeto</Text>
+    </View>
+  );
+}

--- a/frontend_mobile/app/(vendor)/routes/index.tsx
+++ b/frontend_mobile/app/(vendor)/routes/index.tsx
@@ -1,0 +1,10 @@
+// (em português) Lista de trajetos do vendedor (estrutura base; integrar com backend).
+import { View, Text } from 'react-native';
+
+export default function RoutesScreen() {
+  return (
+    <View style={{ flex: 1, padding: 16 }}>
+      <Text style={{ fontSize: 20, fontWeight: 'bold' }}>Os meus trajetos</Text>
+    </View>
+  );
+}

--- a/frontend_mobile/app/(vendor)/stats/index.tsx
+++ b/frontend_mobile/app/(vendor)/stats/index.tsx
@@ -1,0 +1,10 @@
+// (em português) Estatísticas do vendedor (estrutura base para gráficos).
+import { View, Text } from 'react-native';
+
+export default function StatsScreen() {
+  return (
+    <View style={{ flex: 1, padding: 16 }}>
+      <Text>Estatísticas</Text>
+    </View>
+  );
+}

--- a/frontend_mobile/app/_layout.tsx
+++ b/frontend_mobile/app/_layout.tsx
@@ -1,0 +1,17 @@
+// (em português) Layout principal com navegação do expo-router e proteção básica de sessão.
+import { Slot } from 'expo-router';
+import { useEffect } from 'react';
+import { SafeAreaView, StatusBar } from 'react-native';
+
+export default function RootLayout() {
+  useEffect(() => {
+    // (em português) Aqui podemos inicializar listeners globais no futuro.
+  }, []);
+
+  return (
+    <SafeAreaView style={{ flex: 1, backgroundColor: '#fff' }}>
+      <StatusBar barStyle="dark-content" />
+      <Slot />
+    </SafeAreaView>
+  );
+}

--- a/frontend_mobile/app/about.tsx
+++ b/frontend_mobile/app/about.tsx
@@ -1,0 +1,10 @@
+// (em português) Página "Sobre".
+import { View, Text } from 'react-native';
+
+export default function About() {
+  return (
+    <View style={{ flex: 1, padding: 16 }}>
+      <Text>Sobre o projeto Sunny Sales</Text>
+    </View>
+  );
+}

--- a/frontend_mobile/app/index.tsx
+++ b/frontend_mobile/app/index.tsx
@@ -1,0 +1,6 @@
+// (em português) Ecrã inicial: redireciona para mapa público. No futuro pode verificar sessão e role.
+import { Redirect } from 'expo-router';
+
+export default function Index() {
+  return <Redirect href="/(public)/map" />;
+}

--- a/frontend_mobile/app/project.tsx
+++ b/frontend_mobile/app/project.tsx
@@ -1,0 +1,10 @@
+// (em português) Página "Sobre o Projeto".
+import { View, Text } from 'react-native';
+
+export default function Project() {
+  return (
+    <View style={{ flex: 1, padding: 16 }}>
+      <Text>Detalhes do projeto</Text>
+    </View>
+  );
+}

--- a/frontend_mobile/app/sustainability.tsx
+++ b/frontend_mobile/app/sustainability.tsx
@@ -1,0 +1,10 @@
+// (em português) Página "Sustentabilidade".
+import { View, Text } from 'react-native';
+
+export default function Sustainability() {
+  return (
+    <View style={{ flex: 1, padding: 16 }}>
+      <Text>Sustentabilidade</Text>
+    </View>
+  );
+}

--- a/frontend_mobile/app/terms.tsx
+++ b/frontend_mobile/app/terms.tsx
@@ -1,0 +1,10 @@
+// (em português) Página "Termos".
+import { View, Text } from 'react-native';
+
+export default function Terms() {
+  return (
+    <View style={{ flex: 1, padding: 16 }}>
+      <Text>Termos e Condições</Text>
+    </View>
+  );
+}

--- a/frontend_mobile/assets/.keep
+++ b/frontend_mobile/assets/.keep
@@ -1,0 +1,1 @@
+// (em português) Placeholder para a pasta de assets (ícones/imagens).

--- a/frontend_mobile/components/Footer.tsx
+++ b/frontend_mobile/components/Footer.tsx
@@ -1,0 +1,10 @@
+// (em português) Rodapé simples para reutilizar em várias páginas.
+import { View, Text } from 'react-native';
+
+export default function Footer() {
+  return (
+    <View style={{ padding: 12, alignItems: 'center' }}>
+      <Text style={{ color: '#666' }}>Sunny Sales © {new Date().getFullYear()}</Text>
+    </View>
+  );
+}

--- a/frontend_mobile/components/LoadingDots.tsx
+++ b/frontend_mobile/components/LoadingDots.tsx
@@ -1,0 +1,10 @@
+// (em português) Indicador simples de carregamento com três pontos.
+import { View, Text } from 'react-native';
+
+export default function LoadingDots() {
+  return (
+    <View style={{ flexDirection: 'row', gap: 4 }}>
+      <Text>•</Text><Text>•</Text><Text>•</Text>
+    </View>
+  );
+}

--- a/frontend_mobile/components/LocateHint.tsx
+++ b/frontend_mobile/components/LocateHint.tsx
@@ -1,0 +1,10 @@
+// (em português) Aviso para orientar permissões de localização.
+import { View, Text } from 'react-native';
+
+export default function LocateHint() {
+  return (
+    <View style={{ padding: 12, backgroundColor: '#fff3cd', borderColor: '#ffeeba', borderWidth: 1, borderRadius: 8 }}>
+      <Text style={{ color: '#856404' }}>Ativa a localização nas definições do dispositivo para veres vendedores próximos.</Text>
+    </View>
+  );
+}

--- a/frontend_mobile/components/ProductFilter.tsx
+++ b/frontend_mobile/components/ProductFilter.tsx
@@ -1,0 +1,27 @@
+// (em português) Componente de filtro por produto com "chips" simples.
+import { View, Text, Pressable } from 'react-native';
+
+type Props = {
+  products: string[];
+  selected: string[];
+  onToggle: (product: string) => void;
+};
+
+export default function ProductFilter({ products, selected, onToggle }: Props) {
+  return (
+    <View style={{ position: 'absolute', bottom: 16, left: 16, right: 16, flexDirection: 'row', gap: 8, flexWrap: 'wrap' }}>
+      {products.map(p => {
+        const active = selected.includes(p);
+        return (
+          <Pressable
+            key={p}
+            onPress={() => onToggle(p)}
+            style={{ paddingHorizontal: 12, paddingVertical: 8, borderRadius: 999, backgroundColor: active ? '#ffd700' : '#eee' }}
+          >
+            <Text style={{ fontWeight: '500' }}>{p}</Text>
+          </Pressable>
+        );
+      })}
+    </View>
+  );
+}

--- a/frontend_mobile/hooks/useAuth.ts
+++ b/frontend_mobile/hooks/useAuth.ts
@@ -1,0 +1,7 @@
+// (em português) Hook simples para autenticação (placeholder para expansão futura).
+import { useState } from 'react';
+
+export function useAuth() {
+  const [user, setUser] = useState<any>(null);
+  return { user, setUser };
+}

--- a/frontend_mobile/hooks/useVendors.ts
+++ b/frontend_mobile/hooks/useVendors.ts
@@ -1,0 +1,13 @@
+// (em português) Hook para carregar e filtrar vendedores (placeholder).
+import { useEffect, useState } from 'react';
+import { getActiveVendors } from '~/services/vendor';
+
+export function useVendors() {
+  const [vendors, setVendors] = useState<any[]>([]);
+
+  useEffect(() => {
+    (async () => setVendors(await getActiveVendors()))();
+  }, []);
+
+  return { vendors, setVendors };
+}

--- a/frontend_mobile/package.json
+++ b/frontend_mobile/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "sunny_sales_mobile",
+  "version": "0.1.0",
+  "private": true,
+  "main": "expo-router/entry",
+  "scripts": {
+    "start": "expo start -c",
+    "android": "expo run:android",
+    "ios": "expo run:ios",
+    "web": "expo start --web"
+  },
+  "dependencies": {
+    "expo": "~51.0.0",
+    "expo-router": "~3.5.0",
+    "react": "18.2.0",
+    "react-native": "0.74.0",
+    "axios": "^1.10.0",
+    "expo-location": "~16.5.5",
+    "expo-task-manager": "~11.8.2",
+    "expo-secure-store": "~12.8.1",
+    "expo-image-picker": "~15.0.7",
+    "expo-image-manipulator": "~12.8.2",
+    "react-native-maps": "1.14.0",
+    "react-native-svg": "15.2.0",
+    "victory-native": "^36.9.2",
+    "@expo/vector-icons": "^14.0.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.6.2"
+  }
+}

--- a/frontend_mobile/services/api.ts
+++ b/frontend_mobile/services/api.ts
@@ -1,0 +1,12 @@
+// (em português) Serviço base Axios com injeção automática do JWT guardado em SecureStore.
+import axios from 'axios';
+import * as SecureStore from 'expo-secure-store';
+
+export const BASE_URL = process.env.EXPO_PUBLIC_BASE_URL ?? 'http://localhost:8000';
+export const api = axios.create({ baseURL: BASE_URL });
+
+api.interceptors.request.use(async (config) => {
+  const token = await SecureStore.getItemAsync('auth_token');
+  if (token) config.headers.Authorization = `Bearer ${token}`;
+  return config;
+});

--- a/frontend_mobile/services/auth.ts
+++ b/frontend_mobile/services/auth.ts
@@ -1,0 +1,15 @@
+// (em português) Autenticação: login/logout com armazenamento seguro do token.
+import * as SecureStore from 'expo-secure-store';
+import { api } from './api';
+
+export async function login(email: string, password: string) {
+  const { data } = await api.post('/auth/login', { email, password });
+  if (data?.access_token) {
+    await SecureStore.setItemAsync('auth_token', data.access_token);
+  }
+  return data;
+}
+
+export async function logout() {
+  await SecureStore.deleteItemAsync('auth_token');
+}

--- a/frontend_mobile/services/vendor.ts
+++ b/frontend_mobile/services/vendor.ts
@@ -1,0 +1,15 @@
+// (em português) Endpoints relacionados com vendedores: lista ativos, atualizar localização e estado.
+import { api } from './api';
+
+export async function getActiveVendors() {
+  const { data } = await api.get('/vendors/active');
+  return data;
+}
+
+export async function updateLocation(lat: number, lng: number) {
+  return api.post('/vendors/location', { lat, lng });
+}
+
+export async function setActive(active: boolean) {
+  return api.post('/vendors/active', { active });
+}

--- a/frontend_mobile/tasks/locationTask.ts
+++ b/frontend_mobile/tasks/locationTask.ts
@@ -1,0 +1,40 @@
+// (em português) Tarefa em background para enviar localização periódica do vendedor ao backend.
+import * as TaskManager from 'expo-task-manager';
+import * as Location from 'expo-location';
+import { updateLocation } from '~/services/vendor';
+
+export const LOCATION_TASK = 'vendor-location-task';
+
+TaskManager.defineTask(LOCATION_TASK, async ({ data, error }) => {
+  if (error) return;
+  const { locations } = data as any;
+  const last = locations?.[0];
+  if (last) {
+    await updateLocation(last.coords.latitude, last.coords.longitude);
+  }
+});
+
+export async function startLocationSharing() {
+  const fg = await Location.requestForegroundPermissionsAsync();
+  if (fg.status !== 'granted') return;
+
+  const bg = await Location.requestBackgroundPermissionsAsync();
+  if (bg.status !== 'granted') return;
+
+  await Location.startLocationUpdatesAsync(LOCATION_TASK, {
+    accuracy: Location.Accuracy.Balanced,
+    timeInterval: 5000,
+    distanceInterval: 5,
+    pausesUpdatesAutomatically: true,
+    showsBackgroundLocationIndicator: true,
+    foregroundService: {
+      notificationTitle: 'Sunny Sales',
+      notificationBody: 'A partilhar a tua localização.'
+    }
+  });
+}
+
+export async function stopLocationSharing() {
+  const running = await Location.hasStartedLocationUpdatesAsync(LOCATION_TASK);
+  if (running) await Location.stopLocationUpdatesAsync(LOCATION_TASK);
+}

--- a/frontend_mobile/tsconfig.json
+++ b/frontend_mobile/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "jsx": "react-jsx",
+    "strict": true,
+    "baseUrl": ".",
+    "paths": {
+      "~/*": ["./*"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add Expo Router mobile app scaffold with authentication and vendor maps
- implement background location sharing and API service helpers

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@expo%2fvector-icons)*
- `npx expo prebuild --platform android` *(fails: 403 Forbidden - GET https://registry.npmjs.org/expo)*
- `npm run android` *(fails: expo: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68967b41f19c832ea541f9e04f101e29