### PR TITLE
fix: repair mobile package and imports

### DIFF
--- a/sunny_sales_mobile/package.json
+++ b/sunny_sales_mobile/package.json
@@ -1,4 +1,3 @@
-// package.json
 {
   "name": "sunny_sales_mobile",
   "version": "0.1.0",

--- a/sunny_sales_mobile/src/components/VendorCard.tsx
+++ b/sunny_sales_mobile/src/components/VendorCard.tsx
@@ -1,6 +1,6 @@
 // src/components/VendorCard.tsx
 import { View, Text, StyleSheet, Image } from 'react-native';
-import { Vendor } from '@/types';
+import { Vendor } from '../types';
 export default function VendorCard({ vendor }: { vendor: Vendor }) {
   return (
     <View style={styles.card}>

--- a/sunny_sales_mobile/src/services/api.ts
+++ b/sunny_sales_mobile/src/services/api.ts
@@ -1,6 +1,6 @@
 // src/services/api.ts
 import axios from 'axios';
-import { BASE_URL } from '@/config';
+import { BASE_URL } from '../config';
 
 export const api = axios.create({ baseURL: BASE_URL, timeout: 15000 });
 


### PR DESCRIPTION
## Summary
- remove invalid comment from mobile `package.json`
- switch mobile API and component imports to relative paths

## Testing
- `node -p "require('./sunny_sales_mobile/package.json').name"`
- `npm --prefix sunny_sales_mobile test` *(fails: Missing script: "test")*
- `npx --yes -p typescript@5.3.3 -p @types/react@18.2.45 -p @types/react-native@0.73.0 tsc -p sunny_sales_mobile/tsconfig.json --noEmit` *(fails: 403 Forbidden)
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6897229d16ec832ea80cde6a96cedba5