### PR TITLE
style: apply surf color scheme

### DIFF
--- a/sunny_sales_web/src/components/Footer.css
+++ b/sunny_sales_web/src/components/Footer.css
@@ -6,7 +6,7 @@
   width: 100%;
   height: 40px;
   overflow: hidden;
-  background-color: #0099ff;
+  background-color: var(--bg-top-color);
 }
 
 .footer-message {

--- a/sunny_sales_web/src/index.css
+++ b/sunny_sales_web/src/index.css
@@ -8,24 +8,27 @@
   --primary-color: #fdc500; /* amarelo */
   --secondary-color: #fdc500; /* amarelo */
 
+  /* Cores de fundo superior e inferior */
+  --bg-top-color: #ff9720; /* laranja */
+  --bg-bottom-color: #007f8e; /* azul */
 
-  --bg-color: #dbd0c4; /* fundo padrão do site */
-
-
+  --bg-color: transparent;
 
   --text-color: #000000;
   font-family: 'Roboto', sans-serif;
-  background-color: var(--bg-color);
   color: var(--text-color);
 }
 
-  body {
-    margin: 0;
-    padding: 0;
-
-    background-color: var(--bg-color);
-    overflow-x: hidden;
-  }
+body {
+  margin: 0;
+  padding: 0;
+  background: linear-gradient(
+    to bottom,
+    var(--bg-top-color) 50%,
+    var(--bg-bottom-color) 50%
+  );
+  overflow-x: hidden;
+}
 
 /* Container central para limitar a largura do conteúdo */
   .container {
@@ -35,7 +38,7 @@
     margin: 0 auto;
     padding: 100px 0.5rem 0;
     box-sizing: border-box;
-    background-color: var(--bg-color);
+    background: transparent;
   }
 
 /* Envolve o cabeçalho e o mapa */
@@ -73,7 +76,7 @@
   height: 100px;
   z-index: 1000;
   overflow: hidden;
-  background-color: #0099ff;
+  background-color: var(--bg-bottom-color);
 }
 
 .navbar {


### PR DESCRIPTION
## Summary
- add CSS variables for top orange and bottom blue colors
- apply gradient background and swap header/footer hues

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Cannot find package '@eslint/js')
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68adb0b67f70832ea71c934d2348c6ec