### PR TITLE
style: update theme colors and background

### DIFF
--- a/sunny_sales_web/public/background.svg
+++ b/sunny_sales_web/public/background.svg
@@ -1,0 +1,11 @@
+<svg class="border shadow-md dark:border-slate-700" viewBox="0 0 748 748" style="width: 748px; height: 748px;" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none"><rect class="bg" id="bg" x="0" y="0" width="748" height="748" fill="#e29f6c"></rect><g transform="rotate(0 374 374)"><path d="M -249.33 458.00 S -134.67 453.00
+            0.00 458.00 114.67 277.00
+            249.33 458.00 247.67 302.00
+            498.67 458.00 609.00 437.00
+            748.00 458.00 862.67 382.00
+            997.33 458.00 h 110 V 1348 H -249.33 Z" fill="#4090AB"></path><path d="M -249.33 315.00 S -137.00 113.00
+            0.00 315.00 42.33 167.50
+            249.33 315.00 364.00 167.50
+            498.67 315.00 613.33 167.50
+            748.00 315.00 786.33 85.00
+            997.33 315.00 h 110 V -600 H -249.33 Z" fill="#E29F6C"></path></g></svg>

--- a/sunny_sales_web/src/App.jsx
+++ b/sunny_sales_web/src/App.jsx
@@ -75,7 +75,10 @@ function AppLayout() {
   return (
     <div className="wrapper">
       {/* (em português) Barra de navegação */}
-      <header className="header-wrapper">
+      <header
+        className="header-wrapper"
+        style={{ backgroundColor: '#4090ab' }}
+      >
         <div className="navbar">
           <Link className="nav-logo" to="/">Sunny Sales</Link>
           <button

--- a/sunny_sales_web/src/components/Footer.css
+++ b/sunny_sales_web/src/components/Footer.css
@@ -6,7 +6,7 @@
   width: 100%;
   height: 40px;
   overflow: hidden;
-  background-color: var(--bg-top-color);
+  background-color: #e29f6c;
 }
 
 .footer-message {

--- a/sunny_sales_web/src/components/Footer.jsx
+++ b/sunny_sales_web/src/components/Footer.jsx
@@ -65,7 +65,10 @@ export default function Footer() {
   }, []);
 
   return (
-    <footer className="footer-wrapper">
+    <footer
+      className="footer-wrapper"
+      style={{ backgroundColor: '#e29f6c' }}
+    >
       <div className="footer-message">{messages[index]}</div>
     </footer>
   );

--- a/sunny_sales_web/src/index.css
+++ b/sunny_sales_web/src/index.css
@@ -8,8 +8,9 @@
   --primary-color: #fdc500; /* amarelo */
   --secondary-color: #fdc500; /* amarelo */
 
-  /* Cores de fundo superior e inferior */
-  --bg-top-color: #ff9720; /* laranja */
+  /* Cores do cabeçalho e rodapé */
+  --header-color: #4090ab; /* azul */
+  --footer-color: #e29f6c; /* laranja */
 
   --bg-color: transparent;
 
@@ -22,8 +23,10 @@ body {
   margin: 0;
   padding: 0;
 
-  background-color: #166c6c;
-  background-image: url("https://www.transparenttextures.com/patterns/dust.png");
+  background-color: #e29f6c;
+  background-image: url('/background.svg');
+  background-repeat: no-repeat;
+  background-size: cover;
 
   overflow-x: hidden;
 }
@@ -75,7 +78,7 @@ body {
   z-index: 1000;
   overflow: hidden;
 
-  background-color: var(--bg-top-color);
+  background-color: #4090ab;
 
 }
 


### PR DESCRIPTION
## Summary
- ensure header renders with #4090ab and footer with #e29f6c
- load requested SVG background from public assets
- apply orange fallback background to the body

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/react-icons)*

------
https://chatgpt.com/codex/tasks/task_e_68adc9249f5c832e903ca779a708cf81