### PR TITLE
style: update resort map header and footer colors

### DIFF
--- a/sunny_sales_web/public/resort-map.html
+++ b/sunny_sales_web/public/resort-map.html
@@ -43,5 +43,9 @@
             { color: '#fdc500', fillColor: '#fdc500', fillOpacity: 0.5 }
         ).addTo(map);
     </script>
+
+    <footer class="main-footer">
+        © 2024 Sunny Sales
+    </footer>
 </body>
 </html>

--- a/sunny_sales_web/public/resort-style.css
+++ b/sunny_sales_web/public/resort-style.css
@@ -18,7 +18,7 @@ body {
     width: 100%;
     height: 60px;
 
-    background: #fdc500;
+    background: #4090ab;
 
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
     display: flex;
@@ -81,4 +81,19 @@ body {
 .decor-right {
     right: 0;
     top: 0;
+}
+
+.main-footer {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    height: 40px;
+
+    background: #e29f6c;
+
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #FFFFFF;
 }


### PR DESCRIPTION
## Summary
- change resort map header background to blue
- add footer section with orange background

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: eslint: not found)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68add303b8ec832ea7eac7d9e089a581