### PR TITLE
feat: update theme colors and background

### DIFF
--- a/sunny_sales_web/public/background.svg
+++ b/sunny_sales_web/public/background.svg
@@ -1,11 +1,11 @@
-<svg class="border shadow-md dark:border-slate-700" viewBox="0 0 748 748" style="width: 748px; height: 748px;" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none"><rect class="bg" id="bg" x="0" y="0" width="748" height="748" fill="#e29f6c"></rect><g transform="rotate(0 374 374)"><path d="M -249.33 458.00 S -134.67 453.00
-            0.00 458.00 114.67 277.00
-            249.33 458.00 247.67 302.00
-            498.67 458.00 609.00 437.00
-            748.00 458.00 862.67 382.00
-            997.33 458.00 h 110 V 1348 H -249.33 Z" fill="#4090AB"></path><path d="M -249.33 315.00 S -137.00 113.00
-            0.00 315.00 42.33 167.50
-            249.33 315.00 364.00 167.50
-            498.67 315.00 613.33 167.50
-            748.00 315.00 786.33 85.00
-            997.33 315.00 h 110 V -600 H -249.33 Z" fill="#E29F6C"></path></g></svg>
+<svg class="border shadow-md dark:border-slate-700" viewBox="0 0 748 748" style="width: 748px; height: 748px;" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none"><rect class="bg" id="bg" x="0" y="0" width="748" height="748" fill="#d7ebff"></rect><g transform="rotate(15 374 374)"><path d="M -249.33 558.00 S -189.00 440.00
+            0.00 558.00 114.67 535.00
+            249.33 558.00 330.67 453.00
+            498.67 558.00 541.00 491.00
+            748.00 558.00 744.33 414.00
+            997.33 558.00 h 110 V 1348 H -249.33 Z" fill="none" stroke="#FDC500" stroke-width="10"></path><path d="M -249.33 215.00 S -134.67 117.50
+            0.00 215.00 114.67 117.50
+            249.33 215.00 342.67 105.00
+            498.67 215.00 613.33 81.00
+            748.00 215.00 836.33 87.00
+            997.33 215.00 h 110 V -600 H -249.33 Z" fill="none" stroke="#FDC500" stroke-width="10"></path></g></svg>

--- a/sunny_sales_web/src/App.jsx
+++ b/sunny_sales_web/src/App.jsx
@@ -77,9 +77,6 @@ function AppLayout() {
       {/* (em português) Barra de navegação */}
       <header
         className="header-wrapper"
-
-        style={{ backgroundColor: '#4090ab' }}
-
       >
         <div className="navbar">
           <Link className="nav-logo" to="/">Sunny Sales</Link>

--- a/sunny_sales_web/src/assets/background.svg
+++ b/sunny_sales_web/src/assets/background.svg
@@ -1,11 +1,11 @@
-<svg class="border shadow-md dark:border-slate-700" viewBox="0 0 748 748" style="width: 748px; height: 748px;" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none"><rect class="bg" id="bg" x="0" y="0" width="748" height="748" fill="#e29f6c"></rect><g transform="rotate(0 374 374)"><path d="M -249.33 458.00 S -134.67 453.00
-            0.00 458.00 114.67 277.00
-            249.33 458.00 247.67 302.00
-            498.67 458.00 609.00 437.00
-            748.00 458.00 862.67 382.00
-            997.33 458.00 h 110 V 1348 H -249.33 Z" fill="#4090AB"></path><path d="M -249.33 315.00 S -137.00 113.00
-            0.00 315.00 42.33 167.50
-            249.33 315.00 364.00 167.50
-            498.67 315.00 613.33 167.50
-            748.00 315.00 786.33 85.00
-            997.33 315.00 h 110 V -600 H -249.33 Z" fill="#E29F6C"></path></g></svg>
+<svg class="border shadow-md dark:border-slate-700" viewBox="0 0 748 748" style="width: 748px; height: 748px;" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none"><rect class="bg" id="bg" x="0" y="0" width="748" height="748" fill="#d7ebff"></rect><g transform="rotate(15 374 374)"><path d="M -249.33 558.00 S -189.00 440.00
+            0.00 558.00 114.67 535.00
+            249.33 558.00 330.67 453.00
+            498.67 558.00 541.00 491.00
+            748.00 558.00 744.33 414.00
+            997.33 558.00 h 110 V 1348 H -249.33 Z" fill="none" stroke="#FDC500" stroke-width="10"></path><path d="M -249.33 215.00 S -134.67 117.50
+            0.00 215.00 114.67 117.50
+            249.33 215.00 342.67 105.00
+            498.67 215.00 613.33 81.00
+            748.00 215.00 836.33 87.00
+            997.33 215.00 h 110 V -600 H -249.33 Z" fill="none" stroke="#FDC500" stroke-width="10"></path></g></svg>

--- a/sunny_sales_web/src/components/Footer.jsx
+++ b/sunny_sales_web/src/components/Footer.jsx
@@ -67,9 +67,6 @@ export default function Footer() {
   return (
     <footer
       className="footer-wrapper"
-
-      style={{ backgroundColor: '#e29f6c' }}
-
     >
       <div className="footer-message">{messages[index]}</div>
     </footer>

--- a/sunny_sales_web/src/index.css
+++ b/sunny_sales_web/src/index.css
@@ -9,10 +9,10 @@
   --secondary-color: #fdc500; /* amarelo */
 
   /* Cores do cabeçalho e rodapé */
-  --header-color: #4090ab; /* azul */
-  --footer-color: #e29f6c; /* laranja */
+  --header-color: #fdc500; /* amarelo */
+  --footer-color: #fdc500; /* amarelo */
 
-  --bg-color: transparent;
+  --bg-color: #d7ebff; /* azul claro de fundo */
 
   --text-color: #000000;
   font-family: 'Roboto', sans-serif;
@@ -22,9 +22,9 @@
 body {
   margin: 0;
   padding: 0;
+  
 
-
-  background-color: var(--footer-color);
+  background-color: var(--bg-color);
   background-image: url('./assets/background.svg');
 
   background-repeat: no-repeat;

--- a/sunny_sales_web/src/pages/ModernMapLayout.css
+++ b/sunny_sales_web/src/pages/ModernMapLayout.css
@@ -136,7 +136,11 @@ body {
   /* Only keep rounded corners at the bottom to merge with the header */
   border-radius: 0 0 12px 12px;
   box-shadow: 0 2px 20px rgba(0, 0, 0, 0.08);
-  background: var(--secondary-color);
+  background: transparent;
+}
+
+.leaflet-container {
+  background: transparent;
 }
 
 .vendor-card {


### PR DESCRIPTION
## Summary
- remove hardcoded header and footer colors in favor of theme variable
- allow map and leaflet containers to show page background

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68add87d5b74832ead8ce33d7dfa10ce