### PR TITLE
feat: add basic mobile auth and dashboard

### DIFF
--- a/sunny_sales_mobile/app/(auth)/login.tsx
+++ b/sunny_sales_mobile/app/(auth)/login.tsx
@@ -1,3 +1,59 @@
-// app/(auth)/login.tsx
-import { View, Text } from 'react-native';
-export default function LoginScreen() { return <View><Text>Login</Text></View>; }
+import { View, Text, TextInput, Button, StyleSheet } from 'react-native';
+import { useState } from 'react';
+import { useRouter } from 'expo-router';
+import TopBar from '../../src/components/TopBar';
+import { useAuth } from '../../src/hooks/useAuth';
+
+export default function LoginScreen() {
+  const { login } = useAuth();
+  const router = useRouter();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const handleLogin = async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      await login(email, password);
+      router.replace('/(vendor)/dashboard');
+    } catch {
+      setError('Credenciais inválidas');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <TopBar title="Login" />
+      <View style={styles.form}>
+        <TextInput
+          placeholder="Email"
+          value={email}
+          onChangeText={setEmail}
+          autoCapitalize="none"
+          style={styles.input}
+        />
+        <TextInput
+          placeholder="Password"
+          value={password}
+          onChangeText={setPassword}
+          secureTextEntry
+          style={styles.input}
+        />
+        {error ? <Text style={styles.error}>{error}</Text> : null}
+        <Button title={loading ? '...' : 'Entrar'} onPress={handleLogin} disabled={loading} />
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, padding: 16 },
+  form: { gap: 12, marginTop: 24 },
+  input: { borderWidth: 1, borderColor: '#ccc', padding: 8, borderRadius: 4 },
+  error: { color: 'red' },
+});
+

--- a/sunny_sales_mobile/app/(vendor)/dashboard.tsx
+++ b/sunny_sales_mobile/app/(vendor)/dashboard.tsx
@@ -1,3 +1,44 @@
-// app/(vendor)/dashboard.tsx
-import { View, Text } from 'react-native';
-export default function VendorDashboard() { return <View><Text>Vendor Dashboard</Text></View>; }
+import { View, Text, StyleSheet } from 'react-native';
+import { useEffect, useState } from 'react';
+import { useRouter } from 'expo-router';
+import TopBar from '../../src/components/TopBar';
+import { api } from '../../src/services/api';
+import { Vendor } from '../../src/types';
+import { useAuth } from '../../src/hooks/useAuth';
+
+export default function VendorDashboard() {
+  const { token } = useAuth();
+  const router = useRouter();
+  const [vendor, setVendor] = useState<Vendor | null>(null);
+
+  useEffect(() => {
+    if (!token) {
+      router.replace('/(auth)/login');
+      return;
+    }
+    api.get('/vendors/me')
+      .then((res) => setVendor(res.data))
+      .catch(() => setVendor(null));
+  }, [token]);
+
+  return (
+    <View style={styles.container}>
+      <TopBar title="Dashboard" />
+      {vendor ? (
+        <View style={styles.content}>
+          <Text style={styles.name}>{vendor.name}</Text>
+          <Text>{vendor.product}</Text>
+        </View>
+      ) : (
+        <Text>Loading...</Text>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  content: { padding: 16, gap: 8 },
+  name: { fontSize: 20, fontWeight: 'bold' },
+});
+

--- a/sunny_sales_mobile/app/_layout.tsx
+++ b/sunny_sales_mobile/app/_layout.tsx
@@ -1,10 +1,12 @@
-// app/_layout.tsx
 import { Stack } from 'expo-router';
+import { AuthProvider } from '../src/contexts/AuthContext';
 
 export default function RootLayout() {
   return (
-    <Stack screenOptions={{ headerStyle: { backgroundColor: '#ffd700' }, headerTintColor: '#000' }}>
-      <Stack.Screen name="index" options={{ title: 'Sunny Sales' }} />
-    </Stack>
+    <AuthProvider>
+      <Stack screenOptions={{ headerStyle: { backgroundColor: '#ffd700' }, headerTintColor: '#000' }}>
+        <Stack.Screen name="index" options={{ title: 'Sunny Sales' }} />
+      </Stack>
+    </AuthProvider>
   );
 }

--- a/sunny_sales_mobile/src/contexts/AuthContext.tsx
+++ b/sunny_sales_mobile/src/contexts/AuthContext.tsx
@@ -1,0 +1,41 @@
+import { createContext, useContext, useState, ReactNode } from 'react';
+import { api } from '../services/api';
+
+export type AuthContextData = {
+  token: string | null;
+  login: (email: string, password: string) => Promise<void>;
+  logout: () => void;
+};
+
+export const AuthContext = createContext<AuthContextData>({
+  token: null,
+  login: async () => {},
+  logout: () => {},
+});
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [token, setToken] = useState<string | null>(null);
+
+  const login = async (email: string, password: string) => {
+    const res = await api.post('/token', { username: email, password });
+    const t: string = res.data.access_token;
+    setToken(t);
+    (global as any).__VENDOR_TOKEN__ = t;
+  };
+
+  const logout = () => {
+    setToken(null);
+    (global as any).__VENDOR_TOKEN__ = null;
+  };
+
+  return (
+    <AuthContext.Provider value={{ token, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuth() {
+  return useContext(AuthContext);
+}
+

--- a/sunny_sales_mobile/src/hooks/useAuth.ts
+++ b/sunny_sales_mobile/src/hooks/useAuth.ts
@@ -1,9 +1,1 @@
-// src/hooks/useAuth.ts
-import { useState } from 'react';
-
-export function useAuth() {
-  const [token, setToken] = useState<string | null>(null);
-  const login = async (email: string, password: string) => { /* ligar ao backend */ };
-  const logout = () => setToken(null);
-  return { token, login, logout };
-}
+export { useAuth } from '../contexts/AuthContext';


### PR DESCRIPTION
## Summary
- implement auth context to store vendor token
- add login screen and vendor dashboard using backend API
- wrap Expo app with AuthProvider for global auth state

## Testing
- `npx tsc --noEmit`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aec6423348832e95bd3b19311c06fa