### PR TITLE
feat: restyle layout colors and navigation

### DIFF
--- a/sunny_sales_web/src/App.jsx
+++ b/sunny_sales_web/src/App.jsx
@@ -74,50 +74,46 @@ function AppLayout() {
 
   return (
     <div className="wrapper">
-      {/* (em português) Barra de navegação */}
-      <header
-        className="header-wrapper"
-      >
-        <div className="navbar">
-          <Link className="nav-logo" to="/">Sunny Sales</Link>
-          <button
-            className="menu-toggle"
-            onClick={() => setMenuOpen(!menuOpen)}
-            aria-label="Menu"
+      {/* (em português) Links de navegação sobre o fundo */}
+      <nav className="navbar">
+        <Link className="nav-logo" to="/">Sunny Sales</Link>
+        <button
+          className="menu-toggle"
+          onClick={() => setMenuOpen(!menuOpen)}
+          aria-label="Menu"
+        >
+          <FiMenu />
+        </button>
+
+        {/* (em português) Links de navegação para as páginas informativas */}
+        <div className={`nav-links ${menuOpen ? 'open' : ''}`}>
+          <Link
+            className="nav-link"
+            to="/sobre-projeto"
+            onClick={() => setMenuOpen(false)}
           >
-            <FiMenu />
-          </button>
-
-          {/* (em português) Links de navegação para as páginas informativas */}
-          <nav className={`nav-links ${menuOpen ? 'open' : ''}`}>
-            <Link
-              className="nav-link"
-              to="/sobre-projeto"
-              onClick={() => setMenuOpen(false)}
-            >
-              Sobre o Projeto
-            </Link>
-            <Link
-              className="nav-link"
-              to="/sustentabilidade"
-              onClick={() => setMenuOpen(false)}
-            >
-              Sustentabilidade
-            </Link>
-            <Link
-              className="nav-link"
-              to="/implementacao"
-              onClick={() => setMenuOpen(false)}
-            >
-              Implementar
-            </Link>
-          </nav>
-
-          <Link to={profileLink} className="profile-icon" aria-label="Login">
-            <FiUser />
+            Sobre o Projeto
+          </Link>
+          <Link
+            className="nav-link"
+            to="/sustentabilidade"
+            onClick={() => setMenuOpen(false)}
+          >
+            Sustentabilidade
+          </Link>
+          <Link
+            className="nav-link"
+            to="/implementacao"
+            onClick={() => setMenuOpen(false)}
+          >
+            Implementar
           </Link>
         </div>
-      </header>
+
+        <Link to={profileLink} className="profile-icon" aria-label="Login">
+          <FiUser />
+        </Link>
+      </nav>
 
       {/* (em português) Container central da aplicação */}
       <div className="container">

--- a/sunny_sales_web/src/components/Footer.css
+++ b/sunny_sales_web/src/components/Footer.css
@@ -1,12 +1,11 @@
 .footer-wrapper {
   position: fixed;
   z-index: 9999;
-  bottom: 0;
+  top: 0;
   left: 0;
   width: 100%;
   height: 40px;
   overflow: hidden;
-
   background-color: var(--footer-color);
 
 }

--- a/sunny_sales_web/src/index.css
+++ b/sunny_sales_web/src/index.css
@@ -9,10 +9,10 @@
   --secondary-color: #fdc500; /* amarelo */
 
   /* Cores do cabeçalho e rodapé */
-  --header-color: #fdc500; /* amarelo */
-  --footer-color: #fdc500; /* amarelo */
+  --header-color: transparent;
+  --footer-color: #7BC5C1;
 
-  --bg-color: #d7ebff; /* azul claro de fundo */
+  --bg-color: #F3CC91;
 
   --text-color: #000000;
   font-family: 'Roboto', sans-serif;
@@ -25,11 +25,9 @@ body {
   
 
   background-color: var(--bg-color);
-  background-image: url('./assets/background.svg');
-
+  background-image: none;
   background-repeat: no-repeat;
   background-size: cover;
-
   overflow-x: hidden;
 }
 
@@ -71,38 +69,24 @@ body {
 
 
 
-.header-wrapper {
+.navbar {
   position: fixed;
-  top: 0;
+  top: 40px;
   left: 0;
   width: 100%;
-  height: 100px;
-  z-index: 1000;
-  overflow: hidden;
-
-
-  background-color: var(--header-color);
-
-
-}
-
-.navbar {
+  height: 60px;
   display: flex;
   justify-content: space-between;
   align-items: center;
   box-sizing: border-box;
   padding: 10px 20px;
-  width: 100%;
-  height: 100%;
-  position: absolute;
-  top: 0;
-  left: 0;
-  z-index: 1;
+  background: transparent;
+  z-index: 1000;
 }
 
 .nav-logo {
   text-decoration: none;
-  color: #fff;
+  color: #7BC5C1;
   font-size: 1.5rem;
   font-weight: 600;
 }
@@ -115,13 +99,11 @@ body {
 }
 
 .nav-link {
-  color: #fff;
+  color: #7BC5C1;
   text-decoration: none;
   font-size: 1rem;
   font-weight: bold;
-
   text-transform: uppercase;
-
   transition: color 0.3s;
 }
 
@@ -133,7 +115,7 @@ body {
 
 .profile-icon {
   text-decoration: none;
-  color: #fff;
+  color: #7BC5C1;
   font-size: 1.5rem;
   margin-left: 1rem;
   display: flex;
@@ -170,9 +152,9 @@ body {
 
 .menu-toggle {
   display: none;
-  background-color: #fdc500;
+  background-color: transparent;
   border: none;
-  color: #fff;
+  color: #7BC5C1;
   font-size: 2rem;
 }
 
@@ -476,7 +458,7 @@ input[type='checkbox'] {
     top: 100%;
     left: 0;
     width: 100%;
-    background-color: #fdc500;
+    background-color: transparent;
     padding: 1rem 2rem;
   }
 


### PR DESCRIPTION
## Summary
- overlay navigation menus on background and remove header bar
- move footer bar to top and update brand colors
- switch site background to soft gold tone

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aecca2b8d0832eb43c2cdc983a6072