### PR TITLE
feat: add beach conditions widget

### DIFF
--- a/sunny_sales_mobile/app/index.tsx
+++ b/sunny_sales_mobile/app/index.tsx
@@ -1,6 +1,7 @@
 // app/index.tsx
 import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
 import { Link } from 'expo-router';
+import BeachConditions from '../src/components/BeachConditions';
 
 export default function HomeScreen() {
   return (
@@ -15,6 +16,7 @@ export default function HomeScreen() {
       <Link href="/(vendor)/dashboard" asChild>
         <TouchableOpacity style={styles.btn}><Text>Dashboard Vendedor</Text></TouchableOpacity>
       </Link>
+      <BeachConditions />
     </View>
   );
 }

--- a/sunny_sales_mobile/src/components/BeachConditions.tsx
+++ b/sunny_sales_mobile/src/components/BeachConditions.tsx
@@ -1,0 +1,152 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, Button, StyleSheet, ActivityIndicator } from 'react-native';
+import * as Location from 'expo-location';
+
+// Widget "Condições de Praia" para mobile
+export default function BeachConditions() {
+  const [coords, setCoords] = useState<{ latitude: number; longitude: number } | null>(null);
+  const [weather, setWeather] = useState<any>(null);
+  const [tides, setTides] = useState<any[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const requestLocation = async () => {
+    setLoading(true);
+    try {
+      const { status } = await Location.requestForegroundPermissionsAsync();
+      if (status !== 'granted') {
+        setError('Permissão de localização negada.');
+        setLoading(false);
+        return;
+      }
+      const loc = await Location.getCurrentPositionAsync({});
+      setCoords({ latitude: loc.coords.latitude, longitude: loc.coords.longitude });
+      setError(null);
+    } catch (e) {
+      setError('Erro ao obter localização.');
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    requestLocation();
+  }, []);
+
+  useEffect(() => {
+    if (!coords) return;
+    const fetchData = async () => {
+      try {
+        const weatherUrl = `https://api.open-meteo.com/v1/forecast?latitude=${coords.latitude}&longitude=${coords.longitude}&current=temperature_2m,wind_speed_10m,relative_humidity_2m&daily=uv_index_max&forecast_days=1&timezone=auto`;
+        const marineUrl = `https://marine-api.open-meteo.com/v1/marine?latitude=${coords.latitude}&longitude=${coords.longitude}&hourly=sea_level_height&length=1&timezone=auto`;
+        const [wRes, mRes] = await Promise.all([
+          fetch(weatherUrl),
+          fetch(marineUrl),
+        ]);
+        const wData = await wRes.json();
+        const mData = await mRes.json();
+        setWeather({
+          temperature: wData.current?.temperature_2m,
+          wind: wData.current?.wind_speed_10m,
+          humidity: wData.current?.relative_humidity_2m,
+          uvMax: wData.daily?.uv_index_max?.[0],
+          timezone: wData.timezone,
+        });
+        const tideEvents = calcTides(
+          mData.hourly?.time || [],
+          mData.hourly?.sea_level_height || []
+        );
+        setTides(tideEvents);
+      } catch (e) {
+        setError('Erro ao carregar dados.');
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchData();
+  }, [coords]);
+
+  const fmt = (t: string) =>
+    new Date(t).toLocaleTimeString('pt-PT', {
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: false,
+      timeZone: weather?.timezone || 'UTC',
+    });
+
+  if (loading) {
+    return (
+      <View style={styles.container}>
+        <ActivityIndicator />
+      </View>
+    );
+  }
+
+  if (error) {
+    return (
+      <View style={styles.container}>
+        <Text>{error}</Text>
+        <Button title="Tentar novamente" onPress={requestLocation} />
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.block}>
+        <Text>Temperatura: {weather.temperature}°C</Text>
+        <Text>Vento: {weather.wind} km/h</Text>
+        <Text>Humidade: {weather.humidity}%</Text>
+        <Text>UV máx: {weather.uvMax}</Text>
+      </View>
+      <View style={styles.block}>
+        <Text>Marés de hoje:</Text>
+        {tides.map((t) => (
+          <Text key={t.time}>
+            {t.type === 'high' ? 'Alta' : 'Baixa'} {fmt(t.time)}
+          </Text>
+        ))}
+      </View>
+      <Text style={styles.warning}>
+        Estimativa para uso recreativo; não usar para navegação.
+      </Text>
+    </View>
+  );
+}
+
+function calcTides(times: string[], levels: number[]) {
+  const events: { type: 'high' | 'low'; time: string }[] = [];
+  for (let i = 1; i < levels.length - 1; i++) {
+    const prev = levels[i - 1];
+    const curr = levels[i];
+    const next = levels[i + 1];
+    if (curr > prev && curr > next) events.push({ type: 'high', time: times[i] });
+    if (curr < prev && curr < next) events.push({ type: 'low', time: times[i] });
+  }
+  events.sort((a, b) => new Date(a.time).getTime() - new Date(b.time).getTime());
+  const unique: typeof events = [];
+  for (const ev of events) {
+    const last = unique[unique.length - 1];
+    if (!last || new Date(ev.time).getTime() - new Date(last.time).getTime() >= 60 * 60 * 1000) {
+      unique.push(ev);
+    }
+  }
+  return unique;
+}
+
+const styles = StyleSheet.create({
+  container: {
+    padding: 16,
+    borderWidth: 1,
+    borderColor: '#ccc',
+    borderRadius: 8,
+    backgroundColor: '#fff',
+    alignSelf: 'stretch',
+  },
+  block: {
+    marginBottom: 8,
+  },
+  warning: {
+    fontSize: 12,
+    color: '#555',
+  },
+});

--- a/sunny_sales_web/src/components/BeachConditions.css
+++ b/sunny_sales_web/src/components/BeachConditions.css
@@ -1,0 +1,37 @@
+.bc-container {
+  border: 1px solid #ccc;
+  padding: 1rem;
+  max-width: 320px;
+  width: 100%;
+  font-size: 0.9rem;
+  background: #fff;
+  border-radius: 8px;
+}
+
+.bc-weather,
+.bc-tides {
+  margin-bottom: 0.5rem;
+}
+
+.bc-tides ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.bc-tides li {
+  margin: 0.25rem 0;
+}
+
+.bc-warning {
+  font-size: 0.75rem;
+  color: #555;
+  margin-top: 0.5rem;
+}
+
+@media (min-width: 640px) {
+  .bc-container {
+    display: flex;
+    flex-direction: column;
+  }
+}

--- a/sunny_sales_web/src/components/BeachConditions.jsx
+++ b/sunny_sales_web/src/components/BeachConditions.jsx
@@ -1,0 +1,129 @@
+import React, { useEffect, useState } from 'react';
+import './BeachConditions.css';
+
+// Widget "Condições de Praia" baseado na localização do utilizador
+export default function BeachConditions() {
+  const [coords, setCoords] = useState(null);
+  const [weather, setWeather] = useState(null);
+  const [tides, setTides] = useState([]);
+  const [error, setError] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  const requestLocation = () => {
+    setLoading(true);
+    if (!navigator.geolocation) {
+      setError('Geolocalização não suportada');
+      setLoading(false);
+      return;
+    }
+    navigator.geolocation.getCurrentPosition(
+      (pos) => {
+        setCoords({ lat: pos.coords.latitude, lon: pos.coords.longitude });
+        setError(null);
+      },
+      () => {
+        setError('Não foi possível obter a localização.');
+        setLoading(false);
+      }
+    );
+  };
+
+  useEffect(() => {
+    requestLocation();
+  }, []);
+
+  useEffect(() => {
+    if (!coords) return;
+    const fetchData = async () => {
+      try {
+        const weatherUrl = `https://api.open-meteo.com/v1/forecast?latitude=${coords.lat}&longitude=${coords.lon}&current=temperature_2m,wind_speed_10m,relative_humidity_2m&daily=uv_index_max&forecast_days=1&timezone=auto`;
+        const marineUrl = `https://marine-api.open-meteo.com/v1/marine?latitude=${coords.lat}&longitude=${coords.lon}&hourly=sea_level_height&length=1&timezone=auto`;
+        const [wRes, mRes] = await Promise.all([
+          fetch(weatherUrl),
+          fetch(marineUrl),
+        ]);
+        const wData = await wRes.json();
+        const mData = await mRes.json();
+        setWeather({
+          temperature: wData.current?.temperature_2m,
+          wind: wData.current?.wind_speed_10m,
+          humidity: wData.current?.relative_humidity_2m,
+          uvMax: wData.daily?.uv_index_max?.[0],
+          timezone: wData.timezone,
+        });
+        const tideEvents = calcTides(
+          mData.hourly?.time || [],
+          mData.hourly?.sea_level_height || []
+        );
+        setTides(tideEvents);
+      } catch (e) {
+        setError('Erro ao carregar dados.');
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchData();
+  }, [coords]);
+
+  const fmt = (t) =>
+    new Date(t).toLocaleTimeString('pt-PT', {
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: false,
+      timeZone: weather?.timezone || 'UTC',
+    });
+
+  if (loading) return <div className="bc-container">A carregar...</div>;
+
+  if (error)
+    return (
+      <div className="bc-container">
+        <p>{error}</p>
+        <button onClick={requestLocation}>Tentar novamente</button>
+      </div>
+    );
+
+  return (
+    <div className="bc-container">
+      <div className="bc-weather">
+        <div>Temperatura: {weather.temperature}&deg;C</div>
+        <div>Vento: {weather.wind} km/h</div>
+        <div>Humidade: {weather.humidity}%</div>
+        <div>UV máx: {weather.uvMax}</div>
+      </div>
+      <div className="bc-tides">
+        <p>Marés de hoje:</p>
+        <ul>
+          {tides.map((t) => (
+            <li key={t.time}>
+              {t.type === 'high' ? 'Alta' : 'Baixa'} {fmt(t.time)}
+            </li>
+          ))}
+        </ul>
+      </div>
+      <p className="bc-warning">
+        Estimativa para uso recreativo; não usar para navegação.
+      </p>
+    </div>
+  );
+}
+
+function calcTides(times, levels) {
+  const events = [];
+  for (let i = 1; i < levels.length - 1; i++) {
+    const prev = levels[i - 1];
+    const curr = levels[i];
+    const next = levels[i + 1];
+    if (curr > prev && curr > next) events.push({ type: 'high', time: times[i] });
+    if (curr < prev && curr < next) events.push({ type: 'low', time: times[i] });
+  }
+  events.sort((a, b) => new Date(a.time) - new Date(b.time));
+  const unique = [];
+  for (const ev of events) {
+    const last = unique[unique.length - 1];
+    if (!last || new Date(ev.time) - new Date(last.time) >= 60 * 60 * 1000) {
+      unique.push(ev);
+    }
+  }
+  return unique;
+}

--- a/sunny_sales_web/src/pages/ModernMapLayout.jsx
+++ b/sunny_sales_web/src/pages/ModernMapLayout.jsx
@@ -6,6 +6,7 @@ import { BASE_URL } from '../config';
 import LocateButton from '../components/LocateButton';
 import VendorLocateButton from '../components/VendorLocateButton';
 import LocateHint from '../components/LocateHint';
+import BeachConditions from '../components/BeachConditions';
 import './ModernMapLayout.css';
 
 // Layout principal com mapa e lista de vendedores online
@@ -130,6 +131,7 @@ export default function ModernMapLayout() {
 
   return (
     <div className="modern-layout">
+      <BeachConditions />
       {!isVendorLogged && (
         <div className="filters">
           <p className="filters-subtitle">Vendedores:</p>


### PR DESCRIPTION
## Summary
- add reusable BeachConditions widget for web and mobile
- fetch weather, UV index and tide estimates from Open-Meteo based on geolocation
- display cautionary warning and retry option if geolocation fails

## Testing
- `pytest`
- `npm --prefix sunny_sales_web run lint` *(fails: Cannot find package '@eslint/js')*
- `npm --prefix sunny_sales_web install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/react-icons)*

------
https://chatgpt.com/codex/tasks/task_e_68aed1ece8cc832e915603356d481488