### PR TITLE
Always show beach selector

### DIFF
--- a/sunny_sales_mobile/src/components/BeachConditions.tsx
+++ b/sunny_sales_mobile/src/components/BeachConditions.tsx
@@ -133,7 +133,7 @@ export default function BeachConditions() {
   return (
     <View style={styles.container}>
 
-      {beaches.length > 1 && (
+      {beaches.length > 0 && (
         <Picker
           selectedValue={selected?.id}
           onValueChange={(val) =>

--- a/sunny_sales_web/src/components/BeachConditions.jsx
+++ b/sunny_sales_web/src/components/BeachConditions.jsx
@@ -124,7 +124,7 @@ export default function BeachConditions() {
   return (
     <div className="bc-container">
 
-      {beaches.length > 1 && (
+      {beaches.length > 0 && (
         <div className="bc-selector">
           <select
             value={selected?.id || ''}


### PR DESCRIPTION
## Summary
- Show beach dropdown in web app even if only current location is available
- Show beach picker in mobile app even with a single option

## Testing
- `pytest`
- `npm test` (sunny_sales_web) *(fails: Missing script "test")*
- `npm test` (sunny_sales_mobile) *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68aedfd6a258832e817718c6068572e2