### PR TITLE
feat: replace weather system with Open-Meteo data

### DIFF
--- a/sunny_sales_mobile/src/components/BeachConditions.tsx
+++ b/sunny_sales_mobile/src/components/BeachConditions.tsx
@@ -13,7 +13,6 @@ export default function BeachConditions() {
   const [selected, setSelected] = useState<any | null>(null);
 
   const [weather, setWeather] = useState<any>(null);
-  const [tides, setTides] = useState<any[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
 
@@ -77,14 +76,9 @@ export default function BeachConditions() {
     const fetchData = async () => {
       try {
         const weatherUrl = `https://api.open-meteo.com/v1/forecast?latitude=${selected.latitude}&longitude=${selected.longitude}&current=temperature_2m,wind_speed_10m,relative_humidity_2m&daily=uv_index_max&forecast_days=1&timezone=auto`;
-        const marineUrl = `https://marine-api.open-meteo.com/v1/marine?latitude=${selected.latitude}&longitude=${selected.longitude}&hourly=sea_level&length=2&timezone=auto`;
 
-        const [wRes, mRes] = await Promise.all([
-          fetch(weatherUrl),
-          fetch(marineUrl),
-        ]);
+        const wRes = await fetch(weatherUrl);
         const wData = await wRes.json();
-        const mData = await mRes.json();
         setWeather({
           temperature: wData.current?.temperature_2m,
           wind: wData.current?.wind_speed_10m,
@@ -92,15 +86,6 @@ export default function BeachConditions() {
           uvMax: wData.daily?.uv_index_max?.[0],
           timezone: wData.timezone,
         });
-        const tideEvents = calcTides(
-          mData.hourly?.time || [],
-
-          mData.hourly?.sea_level || [],
-
-          mData.timezone || 'UTC'
-
-        );
-        setTides(tideEvents);
       } catch (e) {
         setError('Erro ao carregar dados.');
       } finally {
@@ -111,14 +96,6 @@ export default function BeachConditions() {
 
   }, [selected]);
 
-
-  const fmt = (t: string) =>
-    new Date(t).toLocaleTimeString('pt-PT', {
-      hour: '2-digit',
-      minute: '2-digit',
-      hour12: false,
-      timeZone: weather?.timezone || 'UTC',
-    });
 
   if (loading) {
     return (
@@ -162,48 +139,10 @@ export default function BeachConditions() {
         <Text>Humidade: {weather.humidity}%</Text>
         <Text>UV máx: {weather.uvMax}</Text>
       </View>
-      <View style={styles.block}>
-        <Text>Marés de hoje:</Text>
-
-        {tides.length ? (
-          tides.map((t) => (
-            <Text key={t.time}>
-              {t.type === 'high' ? 'Alta' : 'Baixa'} {fmt(t.time)}
-            </Text>
-          ))
-        ) : (
-          <Text>Sem dados</Text>
-        )}
-      </View>
       <Text style={styles.warning}>
         Estimativa para uso recreativo; não usar para navegação.
       </Text>
     </View>
-  );
-}
-
-function calcTides(times: string[], levels: number[], timezone: string) {
-  const events: { type: 'high' | 'low'; time: string }[] = [];
-  for (let i = 1; i < levels.length - 1; i++) {
-    const prev = levels[i - 1];
-    const curr = levels[i];
-    const next = levels[i + 1];
-    const rising = curr - prev;
-    const falling = next - curr;
-    if (rising >= 0 && falling <= 0) events.push({ type: 'high', time: times[i] });
-    if (rising <= 0 && falling >= 0) events.push({ type: 'low', time: times[i] });
-  }
-  events.sort((a, b) => new Date(a.time).getTime() - new Date(b.time).getTime());
-  const unique: typeof events = [];
-  for (const ev of events) {
-    const last = unique[unique.length - 1];
-    if (!last || new Date(ev.time).getTime() - new Date(last.time).getTime() >= 60 * 60 * 1000) {
-      unique.push(ev);
-    }
-  }
-  const today = new Date().toLocaleDateString('en-CA', { timeZone: timezone });
-  return unique.filter(
-    (ev) => new Date(ev.time).toLocaleDateString('en-CA', { timeZone: timezone }) === today
   );
 }
 

--- a/sunny_sales_web/src/components/BeachConditions.css
+++ b/sunny_sales_web/src/components/BeachConditions.css
@@ -28,21 +28,8 @@
 
 }
 
-.bc-weather,
-.bc-tides {
-
+.bc-weather {
   flex: 1;
-
-}
-
-.bc-tides ul {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-}
-
-.bc-tides li {
-  margin: 0.25rem 0;
 }
 
 .bc-warning {

--- a/sunny_sales_web/src/components/BeachConditions.jsx
+++ b/sunny_sales_web/src/components/BeachConditions.jsx
@@ -9,7 +9,6 @@ export default function BeachConditions() {
   const [selected, setSelected] = useState(null);
 
   const [weather, setWeather] = useState(null);
-  const [tides, setTides] = useState([]);
   const [error, setError] = useState(null);
   const [loading, setLoading] = useState(true);
 
@@ -77,14 +76,9 @@ export default function BeachConditions() {
     const fetchData = async () => {
       try {
         const weatherUrl = `https://api.open-meteo.com/v1/forecast?latitude=${selected.lat}&longitude=${selected.lon}&current=temperature_2m,wind_speed_10m,relative_humidity_2m&daily=uv_index_max&forecast_days=1&timezone=auto`;
-        const marineUrl = `https://marine-api.open-meteo.com/v1/marine?latitude=${selected.lat}&longitude=${selected.lon}&hourly=sea_level&length=2&timezone=auto`;
 
-        const [wRes, mRes] = await Promise.all([
-          fetch(weatherUrl),
-          fetch(marineUrl),
-        ]);
+        const wRes = await fetch(weatherUrl);
         const wData = await wRes.json();
-        const mData = await mRes.json();
         setWeather({
           temperature: wData.current?.temperature_2m,
           wind: wData.current?.wind_speed_10m,
@@ -92,15 +86,6 @@ export default function BeachConditions() {
           uvMax: wData.daily?.uv_index_max?.[0],
           timezone: wData.timezone,
         });
-        const tideEvents = calcTides(
-          mData.hourly?.time || [],
-
-          mData.hourly?.sea_level || [],
-
-          mData.timezone || 'UTC'
-
-        );
-        setTides(tideEvents);
       } catch (e) {
         setError('Erro ao carregar dados.');
       } finally {
@@ -108,17 +93,7 @@ export default function BeachConditions() {
       }
     };
     fetchData();
-
   }, [selected]);
-
-
-  const fmt = (t) =>
-    new Date(t).toLocaleTimeString('pt-PT', {
-      hour: '2-digit',
-      minute: '2-digit',
-      hour12: false,
-      timeZone: weather?.timezone || 'UTC',
-    });
 
   if (loading) return <div className="bc-container">A carregar...</div>;
 
@@ -160,51 +135,11 @@ export default function BeachConditions() {
           <div>Humidade: {weather.humidity}%</div>
           <div>UV máx: {weather.uvMax}</div>
         </div>
-        <div className="bc-tides">
-          <p>Marés de hoje:</p>
-          <ul>
-
-            {tides.length ? (
-              tides.map((t) => (
-                <li key={t.time}>
-                  {t.type === 'high' ? 'Alta' : 'Baixa'} {fmt(t.time)}
-                </li>
-              ))
-            ) : (
-              <li>Sem dados</li>
-            )}
-          </ul>
-        </div>
 
       </div>
       <p className="bc-warning">
         Estimativa para uso recreativo; não usar para navegação.
       </p>
     </div>
-  );
-}
-
-function calcTides(times, levels, timezone) {
-  const events = [];
-  for (let i = 1; i < levels.length - 1; i++) {
-    const prev = levels[i - 1];
-    const curr = levels[i];
-    const next = levels[i + 1];
-    const rising = curr - prev;
-    const falling = next - curr;
-    if (rising >= 0 && falling <= 0) events.push({ type: 'high', time: times[i] });
-    if (rising <= 0 && falling >= 0) events.push({ type: 'low', time: times[i] });
-  }
-  events.sort((a, b) => new Date(a.time) - new Date(b.time));
-  const unique = [];
-  for (const ev of events) {
-    const last = unique[unique.length - 1];
-    if (!last || new Date(ev.time) - new Date(last.time) >= 60 * 60 * 1000) {
-      unique.push(ev);
-    }
-  }
-  const today = new Date().toLocaleDateString('en-CA', { timeZone: timezone });
-  return unique.filter(
-    (ev) => new Date(ev.time).toLocaleDateString('en-CA', { timeZone: timezone }) === today
   );
 }


### PR DESCRIPTION
## Summary
- remove tide calculations and marine requests
- fetch current conditions from Open-Meteo only

## Testing
- `npm ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/react-icons)*
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: eslint: not found)*
- `npm test` *(fails: Missing script: "test")*
- `npx tsc --noEmit` *(fails: Cannot find module '@react-native-picker/picker' or its corresponding type declarations.)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af0a71e3a0832ea0acbbb0a8416372