### PR TITLE
feat: update vendor location switch token and color

### DIFF
--- a/sunny_sales_web/src/index.css
+++ b/sunny_sales_web/src/index.css
@@ -745,7 +745,7 @@ input[type='checkbox'] {
 }
 
 .location-switch input:checked + .track {
-  background: linear-gradient(to right, #60a5fa, #6366f1);
+  background: #FCB454; /* Laranja igual ao header ao ativar a partilha */
 }
 
 .location-switch input:checked + .track::after {

--- a/sunny_sales_web/src/pages/VendorDashboard.jsx
+++ b/sunny_sales_web/src/pages/VendorDashboard.jsx
@@ -24,7 +24,7 @@ export default function VendorDashboard() {
 
   const startSharing = useCallback(async () => {
     if (!vendor) return;
-    // Prevent enabling location when subscription is not active
+    // Impede ativar a localização quando a subscrição não está ativa
     const expires = vendor.subscription_valid_until
       ? new Date(vendor.subscription_valid_until)
       : null;
@@ -32,7 +32,8 @@ export default function VendorDashboard() {
       alert('Não consegue partilhar a localização porque não tem a subscrição ativa');
       return;
     }
-    const token = localStorage.getItem('token');
+    // Token JWT fornecido para autenticação nas requisições de localização
+    const token = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE3NTY5NzYxNTksImp0aSI6IjRhZGVkZWQ5ZTgzMDQ4YzU4MTI5NDk2OGZhNjQwZWExIiwic3ViIjoxfQ.Elsk92DJnIzFyYLbROkBK1lIVN00v7wlOC6_oVuM3w0';
     if (!token) return;
     try {
       await axios.post(`${BASE_URL}/vendors/${vendor.id}/routes/start`, null, {
@@ -85,15 +86,14 @@ export default function VendorDashboard() {
       watchId = null;
     }
     if (vendor) {
-      const token = localStorage.getItem('token');
-      if (token) {
-        try {
-          await axios.post(`${BASE_URL}/vendors/${vendor.id}/routes/stop`, null, {
-            headers: { Authorization: `Bearer ${token}` },
-          });
-        } catch (err) {
-          console.error('Erro ao parar localização:', err);
-        }
+      // Mesmo token JWT utilizado para autenticar o encerramento da partilha
+      const token = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE3NTY5NzYxNTksImp0aSI6IjRhZGVkZWQ5ZTgzMDQ4YzU4MTI5NDk2OGZhNjQwZWExIiwic3ViIjoxfQ.Elsk92DJnIzFyYLbROkBK1lIVN00v7wlOC6_oVuM3w0';
+      try {
+        await axios.post(`${BASE_URL}/vendors/${vendor.id}/routes/stop`, null, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+      } catch (err) {
+        console.error('Erro ao parar localização:', err);
       }
     }
     localStorage.setItem('sharingLocation', 'false');


### PR DESCRIPTION
## Summary
- use provided JWT token when starting and stopping vendor location sharing
- change location sharing toggle active color to site header orange

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install` *(fails: 403 Forbidden for react-icons)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b025e16324832e80ae61572311a349