### PR TITLE
feat: replace location checkbox with switch

### DIFF
--- a/sunny_sales_web/src/pages/VendorDashboard.css
+++ b/sunny_sales_web/src/pages/VendorDashboard.css
@@ -1,0 +1,45 @@
+/* (em português) Estilos para o switch que ativa/desativa a localização do vendedor */
+.vendor-switch {
+  position: relative;
+  display: inline-block;
+  width: 50px;
+  height: 24px;
+}
+
+.vendor-switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.vendor-switch .slider {
+  position: absolute;
+  cursor: pointer;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: #ccc;
+  transition: 0.4s;
+  border-radius: 24px;
+}
+
+.vendor-switch .slider:before {
+  position: absolute;
+  content: '';
+  height: 20px;
+  width: 20px;
+  left: 2px;
+  bottom: 2px;
+  background-color: #fff;
+  transition: 0.4s;
+  border-radius: 50%;
+}
+
+.vendor-switch input:checked + .slider {
+  background-color: #4caf50;
+}
+
+.vendor-switch input:checked + .slider:before {
+  transform: translateX(26px);
+}

--- a/sunny_sales_web/src/pages/VendorDashboard.jsx
+++ b/sunny_sales_web/src/pages/VendorDashboard.jsx
@@ -4,6 +4,7 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { BASE_URL } from '../config';
 import axios from 'axios';
+import './VendorDashboard.css';
 
 let watchId = null;
 
@@ -202,16 +203,19 @@ export default function VendorDashboard() {
           </div>
         )}
 
+        {/* (em português) Bloco que contém o switch para ativar/desativar a partilha de localização */}
         <div style={styles.toggleContainer}>
-          <label className="location-switch">
+          <label className="vendor-switch">
             <input
               type="checkbox"
               checked={sharing}
               onChange={sharing ? stopSharing : startSharing}
             />
-            <div className="track"></div>
-            <span className="label">{sharing ? 'Localização Ligada' : 'Localização Desligada'}</span>
+            <span className="slider" />
           </label>
+          <span style={styles.switchLabel}>
+            {sharing ? 'Localização Ligada' : 'Localização Desligada'}
+          </span>
         </div>
 
         <button className="btn" style={styles.logoutButton} onClick={logout}>Sair</button>
@@ -274,6 +278,10 @@ const styles = {
     gap: '0.5rem',
     justifyContent: 'center',
     margin: '12px auto',
+  },
+  // (em português) Texto que mostra o estado atual da localização
+  switchLabel: {
+    fontWeight: 'bold',
   },
   menuButton: {
     position: 'fixed',


### PR DESCRIPTION
## Summary
- replace vendor location checkbox with styled switch toggle
- add CSS styles for vendor location switch

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b0dfb74dbc832ea5e911dbb9683b0a