### PR TITLE
Add screen capture permission for Android

### DIFF
--- a/sunny_sales_mobile/app.config.ts
+++ b/sunny_sales_mobile/app.config.ts
@@ -1,27 +1,46 @@
 // app.config.ts
+// Configuração principal da aplicação Expo
 import { ExpoConfig } from 'expo/config';
 
+// Objeto de configuração exportado para definir metadados e permissões
 const config: ExpoConfig = {
+  // Nome apresentado da aplicação
   name: 'Sunny Sales',
+  // Identificador amigável utilizado pelo Expo
   slug: 'sunny-sales',
+  // Versão da aplicação
   version: '0.1.0',
+  // Esquema de URI para deep linking
   scheme: 'sunnysales',
+  // Orientação padrão do ecrã
   orientation: 'portrait',
+  // Ícone da aplicação
   icon: './assets/icon.png',
+  // Tema visual global
   userInterfaceStyle: 'light',
+  // Variáveis extras partilhadas com a aplicação
   extra: {
     EXPO_PUBLIC_BASE_URL: process.env.EXPO_PUBLIC_BASE_URL ?? 'https://ss-tester.onrender.com'
   },
+  // Configurações específicas para iOS
   ios: { supportsTablet: false },
+  // Configurações específicas para Android
   android: {
+    // Identificador do pacote Android
     package: 'com.sunny.sales',
+    // Lista de permissões necessárias para o funcionamento da app
     permissions: [
       'ACCESS_FINE_LOCATION',
       'ACCESS_COARSE_LOCATION',
       'FOREGROUND_SERVICE',
-      'ACCESS_BACKGROUND_LOCATION'
+      'ACCESS_BACKGROUND_LOCATION',
+      // Permissão para detetar captura de ecrã (Android 14+)
+      'DETECT_SCREEN_CAPTURE'
     ]
   },
+  // Plugins Expo utilizados pela aplicação
   plugins: ['expo-router', 'expo-location']
 };
+
+// Exporta a configuração para ser utilizada pelo Expo
 export default config;


### PR DESCRIPTION
## Summary
- ensure Android build declares DETECT_SCREEN_CAPTURE permission to allow screen capture observer

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b1e6b244fc832eae2322db07092f42