### PR TITLE
fix: declare screen capture permission

### DIFF
--- a/sunny_sales_mobile/app.config.ts
+++ b/sunny_sales_mobile/app.config.ts
@@ -34,8 +34,8 @@ const config: ExpoConfig = {
       'ACCESS_COARSE_LOCATION',
       'FOREGROUND_SERVICE',
       'ACCESS_BACKGROUND_LOCATION',
-      // Permissão para detetar captura de ecrã (Android 14+)
-      'DETECT_SCREEN_CAPTURE'
+      // Permissão necessária para observar capturas de ecrã (Android 14+)
+      'android.permission.DETECT_SCREEN_CAPTURE'
     ]
   },
   // Plugins Expo utilizados pela aplicação


### PR DESCRIPTION
## Summary
- include `android.permission.DETECT_SCREEN_CAPTURE` in Android permissions

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b1eb8d78f4832eb92538451586216a