### PR TITLE
feat: add auth flow with context and axios service

### DIFF
--- a/sunny_sales_mobile/App.tsx
+++ b/sunny_sales_mobile/App.tsx
@@ -1,18 +1,53 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { NavigationContainer } from '@react-navigation/native';
+import { View, Text, Button, StyleSheet } from 'react-native';
 import AuthStack from './src/navigation/AuthStack';
+import { AuthProvider, AuthContext } from './src/context/AuthContext';
+
+/**
+ * Componente que decide qual o fluxo de navegação com base no token.
+ */
+function RootNavigator() {
+  // Obtém token e função de logout a partir do contexto
+  const { token, logout } = useContext(AuthContext);
+
+  // Se existir token, mostra um ecrã simples autenticado
+  if (token) {
+    return (
+      <View style={styles.center}>
+        {/* Texto de exemplo para utilizador autenticado */}
+        <Text>Bem-vindo!</Text>
+        {/* Botão para terminar sessão */}
+        <Button title="Logout" onPress={logout} />
+      </View>
+    );
+  }
+
+  // Caso não exista token, apresenta o fluxo de autenticação
+  return <AuthStack />;
+}
 
 /**
  * Componente principal da aplicação.
- * Envolve toda a navegação dentro do NavigationContainer
- * para gerir o estado de navegação.
+ * Envolve toda a navegação e o contexto de autenticação.
  */
 export default function App() {
   return (
-    // NavigationContainer fornece contexto de navegação para toda a app
-    <NavigationContainer>
-      {/* AuthStack define o fluxo de autenticação (login e registo) */}
-      <AuthStack />
-    </NavigationContainer>
+    // AuthProvider disponibiliza o estado de autenticação à aplicação inteira
+    <AuthProvider>
+      {/* NavigationContainer gere o estado de navegação */}
+      <NavigationContainer>
+        <RootNavigator />
+      </NavigationContainer>
+    </AuthProvider>
   );
 }
+
+// Estilos utilizados para centrar conteúdos
+const styles = StyleSheet.create({
+  center: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/sunny_sales_mobile/package.json
+++ b/sunny_sales_mobile/package.json
@@ -22,7 +22,8 @@
     "react-native": "0.73.4",
     "react-native-maps": "1.10.0",
     "react-native-safe-area-context": "4.8.2",
-    "react-native-screens": "~3.29.0"
+    "react-native-screens": "~3.29.0",
+    "@react-native-async-storage/async-storage": "^1.19.0"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/sunny_sales_mobile/src/context/AuthContext.tsx
+++ b/sunny_sales_mobile/src/context/AuthContext.tsx
@@ -1,0 +1,70 @@
+import React, { createContext, useState, useEffect, ReactNode } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import api from '../services/api';
+
+/**
+ * Interface que define os dados e funções expostos pelo contexto de autenticação.
+ */
+interface AuthContextData {
+  token: string | null;
+  login: (email: string, password: string) => Promise<void>;
+  register: (name: string, email: string, password: string) => Promise<void>;
+  logout: () => Promise<void>;
+}
+
+/**
+ * Criação do contexto com valores padrão.
+ */
+export const AuthContext = createContext<AuthContextData>({
+  token: null,
+  login: async () => {},
+  register: async () => {},
+  logout: async () => {},
+});
+
+/**
+ * Provedor do contexto que gere o estado da autenticação.
+ */
+export function AuthProvider({ children }: { children: ReactNode }) {
+  // Estado que guarda o token JWT
+  const [token, setToken] = useState<string | null>(null);
+
+  // Ao iniciar, tenta carregar o token armazenado localmente
+  useEffect(() => {
+    const loadToken = async () => {
+      const storedToken = await AsyncStorage.getItem('token');
+      if (storedToken) {
+        setToken(storedToken);
+      }
+    };
+    loadToken();
+  }, []);
+
+  // Função que realiza o login no backend
+  const login = async (email: string, password: string) => {
+    const response = await api.post('/auth/login', { email, password });
+    const newToken = response.data.access_token;
+    setToken(newToken);
+    await AsyncStorage.setItem('token', newToken);
+  };
+
+  // Função que realiza o registo no backend
+  const register = async (name: string, email: string, password: string) => {
+    const response = await api.post('/auth/register', { name, email, password });
+    const newToken = response.data.access_token;
+    setToken(newToken);
+    await AsyncStorage.setItem('token', newToken);
+  };
+
+  // Remove o token e termina a sessão
+  const logout = async () => {
+    setToken(null);
+    await AsyncStorage.removeItem('token');
+  };
+
+  return (
+    <AuthContext.Provider value={{ token, login, register, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}

--- a/sunny_sales_mobile/src/screens/LoginScreen.tsx
+++ b/sunny_sales_mobile/src/screens/LoginScreen.tsx
@@ -1,16 +1,59 @@
-import React from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import React, { useState, useContext } from 'react';
+import { View, Text, StyleSheet, TextInput, Button } from 'react-native';
+import { AuthContext } from '../context/AuthContext';
 
 /**
- * Ecrã de login simples.
- * Será substituído posteriormente pela implementação real.
+ * Ecrã responsável pelo login do utilizador.
+ * Contém formulário e utiliza o contexto de autenticação para iniciar a sessão.
  */
-export default function LoginScreen() {
+export default function LoginScreen({ navigation }: any) {
+  // Estados locais para email e palavra-passe
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+
+  // Função de login disponibilizada pelo contexto
+  const { login } = useContext(AuthContext);
+
+  // Trata o envio do formulário
+  const handleLogin = async () => {
+    try {
+      await login(email, password);
+      // A navegação pós-login é gerida pelo App através do token no contexto
+    } catch (error) {
+      console.error('Erro no login:', error);
+    }
+  };
+
   return (
-    // View principal do ecrã
+    // Estrutura principal do ecrã
     <View style={styles.container}>
-      {/* Texto temporário para indicar o ecrã */}
-      <Text>Login Screen</Text>
+      {/* Título do formulário */}
+      <Text style={styles.title}>Login</Text>
+
+      {/* Campo para inserir o email */}
+      <TextInput
+        style={styles.input}
+        placeholder="Email"
+        value={email}
+        onChangeText={setEmail}
+        autoCapitalize="none"
+        keyboardType="email-address"
+      />
+
+      {/* Campo para inserir a palavra-passe */}
+      <TextInput
+        style={styles.input}
+        placeholder="Password"
+        value={password}
+        onChangeText={setPassword}
+        secureTextEntry
+      />
+
+      {/* Botão que executa o login */}
+      <Button title="Login" onPress={handleLogin} />
+
+      {/* Botão que navega para o ecrã de registo */}
+      <Button title="Registar" onPress={() => navigation.navigate('Register')} />
     </View>
   );
 }
@@ -19,7 +62,19 @@ export default function LoginScreen() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    alignItems: 'center',
     justifyContent: 'center',
+    padding: 16,
+  },
+  title: {
+    fontSize: 24,
+    textAlign: 'center',
+    marginBottom: 16,
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: '#ccc',
+    padding: 8,
+    marginBottom: 12,
+    borderRadius: 4,
   },
 });

--- a/sunny_sales_mobile/src/screens/RegisterScreen.tsx
+++ b/sunny_sales_mobile/src/screens/RegisterScreen.tsx
@@ -1,16 +1,68 @@
-import React from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import React, { useState, useContext } from 'react';
+import { View, Text, StyleSheet, TextInput, Button } from 'react-native';
+import { AuthContext } from '../context/AuthContext';
 
 /**
- * Ecrã de registo simples.
- * Será substituído posteriormente pela implementação real.
+ * Ecrã responsável pelo registo de novos utilizadores.
+ * Contém formulário com nome, email e palavra-passe.
  */
-export default function RegisterScreen() {
+export default function RegisterScreen({ navigation }: any) {
+  // Estados locais para os campos do formulário
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+
+  // Função de registo disponibilizada pelo contexto
+  const { register } = useContext(AuthContext);
+
+  // Trata o envio do formulário
+  const handleRegister = async () => {
+    try {
+      await register(name, email, password);
+      // Após registo, o token é guardado e o utilizador fica autenticado
+    } catch (error) {
+      console.error('Erro no registo:', error);
+    }
+  };
+
   return (
-    // View principal do ecrã
+    // Estrutura principal do ecrã
     <View style={styles.container}>
-      {/* Texto temporário para indicar o ecrã */}
-      <Text>Register Screen</Text>
+      {/* Título do formulário */}
+      <Text style={styles.title}>Registo</Text>
+
+      {/* Campo para o nome do utilizador */}
+      <TextInput
+        style={styles.input}
+        placeholder="Name"
+        value={name}
+        onChangeText={setName}
+      />
+
+      {/* Campo para o email */}
+      <TextInput
+        style={styles.input}
+        placeholder="Email"
+        value={email}
+        onChangeText={setEmail}
+        autoCapitalize="none"
+        keyboardType="email-address"
+      />
+
+      {/* Campo para a palavra-passe */}
+      <TextInput
+        style={styles.input}
+        placeholder="Password"
+        value={password}
+        onChangeText={setPassword}
+        secureTextEntry
+      />
+
+      {/* Botão que executa o registo */}
+      <Button title="Registar" onPress={handleRegister} />
+
+      {/* Botão para voltar ao ecrã de login */}
+      <Button title="Voltar ao Login" onPress={() => navigation.navigate('Login')} />
     </View>
   );
 }
@@ -19,7 +71,19 @@ export default function RegisterScreen() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    alignItems: 'center',
     justifyContent: 'center',
+    padding: 16,
+  },
+  title: {
+    fontSize: 24,
+    textAlign: 'center',
+    marginBottom: 16,
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: '#ccc',
+    padding: 8,
+    marginBottom: 12,
+    borderRadius: 4,
   },
 });

--- a/sunny_sales_mobile/src/services/api.ts
+++ b/sunny_sales_mobile/src/services/api.ts
@@ -1,0 +1,41 @@
+import axios from 'axios';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+/**
+ * URL base do backend.
+ * Pode ser definida através da variável de ambiente `EXPO_PUBLIC_BASE_URL`.
+ */
+export const BASE_URL = process.env.EXPO_PUBLIC_BASE_URL || 'http://localhost:8000';
+
+/**
+ * Instância do axios configurada com a URL base.
+ */
+const api = axios.create({
+  baseURL: BASE_URL,
+});
+
+/**
+ * Intercetores que adicionam o token JWT a cada pedido e tratam respostas não autorizadas.
+ */
+api.interceptors.request.use(async (config) => {
+  // Recupera o token armazenado localmente
+  const token = await AsyncStorage.getItem('token');
+  if (token && config.headers) {
+    // Define o cabeçalho Authorization com o token JWT
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+  return config;
+});
+
+api.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    // Em caso de não autorização, remove o token armazenado
+    if (error.response?.status === 401) {
+      await AsyncStorage.removeItem('token');
+    }
+    return Promise.reject(error);
+  }
+);
+
+export default api;


### PR DESCRIPTION
## Summary
- configure axios service with base URL and JWT interceptors
- add authentication context storing token in AsyncStorage
- implement login and register forms calling backend auth endpoints
- wrap app with auth provider and conditional navigation
- add AsyncStorage dependency

## Testing
- `npm test` *(fails: jest not found)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5b346d978832eb8218566e0e7f195