### PR TITLE
Fix mobile endpoints to align with FastAPI backend

### DIFF
--- a/sunny_sales_mobile/package.json
+++ b/sunny_sales_mobile/package.json
@@ -15,6 +15,7 @@
     "@react-navigation/native-stack": "^6.9.12",
     "axios": "^1.6.2",
     "expo": "~50.0.0",
+    "expo-image-picker": "~14.7.1",
     "expo-location": "~16.5.5",
     "expo-status-bar": "~1.11.1",
     "react": "18.2.0",

--- a/sunny_sales_mobile/src/context/AuthContext.tsx
+++ b/sunny_sales_mobile/src/context/AuthContext.tsx
@@ -2,23 +2,52 @@ import React, { createContext, useState, useEffect, ReactNode } from "react";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import api from "../services/api";
 
+/**
+ * Estrutura de dados para guardar informações do vendedor autenticado.
+ */
+interface Vendor {
+  id: number;
+  name: string;
+  email: string;
+  product: string;
+  profile_photo: string;
+}
+
+/**
+ * Dados expostos pelo contexto de autenticação.
+ */
 interface AuthContextData {
   token: string | null;
+  vendor: Vendor | null;
   login: (email: string, password: string) => Promise<void>;
-  register: (name: string, email: string, password: string) => Promise<void>;
+  register: (
+    name: string,
+    email: string,
+    password: string,
+    product: string,
+    profilePhoto: string
+  ) => Promise<void>;
   logout: () => Promise<void>;
 }
 
 export const AuthContext = createContext<AuthContextData>({
   token: null,
+  vendor: null,
   login: async () => {},
   register: async () => {},
   logout: async () => {},
 });
 
+/**
+ * Componente que fornece o contexto de autenticação à aplicação.
+ */
 export function AuthProvider({ children }: { children: ReactNode }) {
+  // Estado que guarda o token JWT
   const [token, setToken] = useState<string | null>(null);
+  // Estado que guarda os dados do vendedor autenticado
+  const [vendor, setVendor] = useState<Vendor | null>(null);
 
+  // Carrega o token armazenado ao iniciar a aplicação
   useEffect(() => {
     const loadToken = async () => {
       try {
@@ -33,37 +62,71 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     loadToken();
   }, []);
 
+  /**
+   * Executa o processo de login junto do backend.
+   */
   const login = async (email: string, password: string) => {
     try {
-      const response = await api.post("/auth/login", { email, password });
-      const newToken = response.data.access_token;
+      // Primeiro, obter o token JWT
+      const tokenRes = await api.post("/token", { email, password });
+      const newToken = tokenRes.data.access_token;
       setToken(newToken);
       await AsyncStorage.setItem("token", newToken);
+
+      // Em seguida, obter os dados do vendedor
+      const userRes = await api.post("/login", { email, password });
+      setVendor(userRes.data);
     } catch (error: any) {
       console.error("Erro no login:", error.message || error);
-      throw new Error("Não foi possível iniciar sessão. Verifica a internet ou o servidor.");
+      throw new Error(
+        "Não foi possível iniciar sessão. Verifica a internet ou o servidor."
+      );
     }
   };
 
-  const register = async (name: string, email: string, password: string) => {
+  /**
+   * Regista um novo vendedor e efetua login automático.
+   */
+  const register = async (
+    name: string,
+    email: string,
+    password: string,
+    product: string,
+    profilePhoto: string
+  ) => {
     try {
-      const response = await api.post("/auth/register", {
-        name,
-        email,
-        password,
+      const formData = new FormData();
+      formData.append("name", name);
+      formData.append("email", email);
+      formData.append("password", password);
+      formData.append("product", product);
+      formData.append("profile_photo", {
+        uri: profilePhoto,
+        name: "profile.jpg",
+        type: "image/jpeg",
+      } as any);
+
+      await api.post("/vendors/", formData, {
+        headers: { "Content-Type": "multipart/form-data" },
       });
-      const newToken = response.data.access_token;
-      setToken(newToken);
-      await AsyncStorage.setItem("token", newToken);
+
+      // Após registo, efetuar login para obter token e dados do vendedor
+      await login(email, password);
     } catch (error: any) {
       console.error("Erro no registo:", error.message || error);
-      throw new Error("Não foi possível registar. Verifica a internet ou o servidor.");
+      throw new Error(
+        "Não foi possível registar. Verifica a internet ou o servidor."
+      );
     }
   };
 
+  /**
+   * Termina a sessão do utilizador, removendo o token guardado.
+   */
   const logout = async () => {
     try {
       setToken(null);
+      setVendor(null);
       await AsyncStorage.removeItem("token");
     } catch (error) {
       console.error("Erro ao terminar sessão:", error);
@@ -71,7 +134,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   };
 
   return (
-    <AuthContext.Provider value={{ token, login, register, logout }}>
+    <AuthContext.Provider value={{ token, vendor, login, register, logout }}>
       {children}
     </AuthContext.Provider>
   );

--- a/sunny_sales_mobile/src/screens/RegisterScreen.tsx
+++ b/sunny_sales_mobile/src/screens/RegisterScreen.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useContext } from 'react';
-import { View, Text, StyleSheet, TextInput, Button } from 'react-native';
+import { View, Text, StyleSheet, TextInput, Button, Image } from 'react-native';
+import * as ImagePicker from 'expo-image-picker';
 import { AuthContext } from '../context/AuthContext';
 
 /**
@@ -11,14 +12,33 @@ export default function RegisterScreen({ navigation }: any) {
   const [name, setName] = useState('');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  // Campo para o produto vendido
+  const [product, setProduct] = useState('');
+  // URI da foto de perfil escolhida
+  const [photo, setPhoto] = useState<string | null>(null);
 
   // Função de registo disponibilizada pelo contexto
   const { register } = useContext(AuthContext);
 
+  // Abre a galeria para o utilizador escolher uma foto
+  const pickPhoto = async () => {
+    const result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: ImagePicker.MediaTypeOptions.Images,
+      allowsEditing: true,
+      quality: 1,
+    });
+    if (!result.canceled) {
+      setPhoto(result.assets[0].uri);
+    }
+  };
+
   // Trata o envio do formulário
   const handleRegister = async () => {
     try {
-      await register(name, email, password);
+      if (!photo) {
+        throw new Error('É necessária uma foto de perfil.');
+      }
+      await register(name, email, password, product, photo);
       // Após registo, o token é guardado e o utilizador fica autenticado
     } catch (error) {
       console.error('Erro no registo:', error);
@@ -57,6 +77,25 @@ export default function RegisterScreen({ navigation }: any) {
         onChangeText={setPassword}
         secureTextEntry
       />
+
+      {/* Campo para o produto */}
+      <TextInput
+        style={styles.input}
+        placeholder="Product"
+        value={product}
+        onChangeText={setProduct}
+      />
+
+      {/* Botão para escolher a foto de perfil */}
+      <Button title="Selecionar Foto" onPress={pickPhoto} />
+
+      {/* Pré-visualização da foto escolhida */}
+      {photo && (
+        <Image
+          source={{ uri: photo }}
+          style={{ width: 100, height: 100, marginVertical: 10 }}
+        />
+      )}
 
       {/* Botão que executa o registo */}
       <Button title="Registar" onPress={handleRegister} />


### PR DESCRIPTION
## Summary
- Use /token and /login for mobile authentication and store vendor data
- Register vendors via /vendors/ with product and profile photo upload
- Add expo-image-picker dependency and extend register screen

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5c09daa3c832e998557a15ebdc3cb