### PR TITLE
feat: utilizar OpenStreetMap no mobile

### DIFF
--- a/sunny_sales_mobile/src/screens/MapScreen.tsx
+++ b/sunny_sales_mobile/src/screens/MapScreen.tsx
@@ -115,9 +115,10 @@ export default function MapScreen() {
       style={styles.map}
       initialRegion={region}
       showsUserLocation
-      provider={null} // 👈 impede uso do Google Maps
+      provider={null} // 👈 impede uso explícito do Google Maps
+      mapType="none" // 👈 remove os mapas base para mostrar apenas o OpenStreetMap
     >
-      {/* Tiles do OpenStreetMap */}
+      {/* Renderiza tiles do OpenStreetMap */}
       <UrlTile
         urlTemplate="https://a.tile.openstreetmap.org/{z}/{x}/{y}.png"
         maximumZ={19}


### PR DESCRIPTION
## Summary
- use OpenStreetMap tiles in mobile MapView by hiding default Google base map

## Testing
- `npm test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5d57c5520832e82848f0ac0036015