### PR TITLE
feat(mobile): add profile dashboard button

### DIFF
--- a/sunny_sales_mobile/src/navigation/AppNavigator.tsx
+++ b/sunny_sales_mobile/src/navigation/AppNavigator.tsx
@@ -5,6 +5,7 @@ import { Ionicons } from '@expo/vector-icons';
 import MapScreen from '../screens/MapScreen';
 import LoginScreen from '../screens/LoginScreen';
 import RegisterScreen from '../screens/RegisterScreen';
+import DashboardScreen from '../screens/DashboardScreen';
 import { AuthContext } from '../context/AuthContext';
 
 // Cria uma stack para ecrãs principais
@@ -12,31 +13,30 @@ const Stack = createNativeStackNavigator();
 
 /**
  * Componente que define as rotas principais da aplicação.
- * O mapa é o ecrã inicial e o login é acedido através de um ícone no canto superior direito.
+ * O mapa é o ecrã inicial e o perfil é acedido através de um ícone no canto superior direito.
  */
 export default function AppNavigator() {
-  // Obtém token e função de logout a partir do contexto
-  const { token, logout } = useContext(AuthContext);
+  // Obtém token para verificar se o vendedor está autenticado
+  const { token } = useContext(AuthContext);
 
   return (
     // Stack.Navigator organiza os ecrãs principais
     <Stack.Navigator initialRouteName="Map">
-      {/* Ecrã do mapa com ícone de login/logout no topo direito */}
+      {/* Ecrã do mapa com ícone de perfil no topo direito */}
       <Stack.Screen
         name="Map"
         component={MapScreen}
         options={({ navigation }) => ({
           title: 'Sunny Sales',
-          headerRight: () =>
-            token ? (
-              <TouchableOpacity onPress={logout}>
-                <Ionicons name="log-out-outline" size={24} />
-              </TouchableOpacity>
-            ) : (
-              <TouchableOpacity onPress={() => navigation.navigate('Login')}>
-                <Ionicons name="log-in-outline" size={24} />
-              </TouchableOpacity>
-            ),
+          headerRight: () => (
+            <TouchableOpacity
+              onPress={() =>
+                navigation.navigate(token ? 'Dashboard' : 'Login')
+              }
+            >
+              <Ionicons name="person-circle-outline" size={24} />
+            </TouchableOpacity>
+          ),
         })}
       />
       {/* Ecrã de login */}
@@ -50,6 +50,12 @@ export default function AppNavigator() {
         name="Register"
         component={RegisterScreen}
         options={{ title: 'Register' }}
+      />
+      {/* Ecrã do dashboard do vendedor */}
+      <Stack.Screen
+        name="Dashboard"
+        component={DashboardScreen}
+        options={{ title: 'Dashboard' }}
       />
     </Stack.Navigator>
   );

--- a/sunny_sales_mobile/src/screens/DashboardScreen.tsx
+++ b/sunny_sales_mobile/src/screens/DashboardScreen.tsx
@@ -1,0 +1,59 @@
+import React, { useContext } from 'react';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { AuthContext } from '../context/AuthContext';
+
+/**
+ * Ecrã principal apresentado ao vendedor autenticado.
+ */
+export default function DashboardScreen() {
+  // Obtém os dados do vendedor e a função de logout
+  const { vendor, logout } = useContext(AuthContext);
+
+  return (
+    <View style={styles.container}>
+      {/* Título do dashboard */}
+      <Text style={styles.title}>Dashboard</Text>
+      {/* Informação básica do vendedor */}
+      {vendor && (
+        <Text style={styles.info}>
+          {`Bem-vindo, ${vendor.name}! Produto: ${vendor.product}`}
+        </Text>
+      )}
+      {/* Botão para terminar sessão */}
+      <TouchableOpacity style={styles.button} onPress={logout}>
+        <Text style={styles.buttonText}>Logout</Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+/**
+ * Estilos aplicados ao ecrã de dashboard.
+ */
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 16,
+  },
+  title: {
+    fontSize: 24,
+    marginBottom: 16,
+  },
+  info: {
+    fontSize: 16,
+    marginBottom: 24,
+    textAlign: 'center',
+  },
+  button: {
+    backgroundColor: '#000',
+    paddingHorizontal: 20,
+    paddingVertical: 10,
+    borderRadius: 5,
+  },
+  buttonText: {
+    color: '#fff',
+    fontSize: 16,
+  },
+});


### PR DESCRIPTION
## Summary
- add profile icon in map header to open login or dashboard
- create vendor dashboard screen with logout option

## Testing
- `npm test -- --passWithNoTests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b73088d8bc832ea879c4dfe7ee82b9