### PR TITLE
style: make resort header transparent

### DIFF
--- a/sunny_sales_web/public/resort-style.css
+++ b/sunny_sales_web/public/resort-style.css
@@ -18,9 +18,9 @@ body {
     width: 100%;
     height: 60px;
 
-    background: #4090ab;
+    background: transparent; /* (em português) Torna o cabeçalho transparente */
 
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+    box-shadow: none; /* (em português) Remove a sombra escura do cabeçalho */
     display: flex;
     align-items: center;
     padding: 0 1rem;


### PR DESCRIPTION
## Summary
- make resort page header transparent and remove shadow

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bd85cb2a98832ea327d0673b6ef300