### PR TITLE
Configure database connection pool settings

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -25,6 +25,9 @@ else:
     engine = create_engine(
         DATABASE_URL,
         pool_pre_ping=True,
+        pool_recycle=280,
+        pool_size=5,
+        max_overflow=2,
     )
 
 # Sessão


### PR DESCRIPTION
## Summary
Added connection pool configuration parameters to the SQLAlchemy database engine to improve connection management and stability.

## Key Changes
- **pool_recycle=280**: Recycles connections after 280 seconds to prevent stale connections from being reused, particularly useful for databases with aggressive connection timeouts
- **pool_size=5**: Sets the number of connections to maintain in the pool
- **max_overflow=2**: Allows up to 2 additional connections beyond pool_size when the pool is exhausted

## Implementation Details
These settings enhance database connection reliability by:
- Preventing "connection lost" errors from idle connections being closed by the database server
- Controlling resource usage through explicit pool sizing
- Providing overflow capacity for temporary traffic spikes without unlimited connection growth

https://claude.ai/code/session_01SXx7UcgSLtsrASEHu6Ljrh