### PR TITLE
Melhorias de responsividade mobile em toda a aplicação web

### DIFF
--- a/sunny_sales_web/src/App.css
+++ b/sunny_sales_web/src/App.css
@@ -5,7 +5,7 @@
   /* Expande para toda a largura no desktop e adapta-se em ecrãs menores */
   width: 100%;
   margin: 0;
-  padding: 2rem;
+  padding: 0;
   text-align: center;
 }
 

--- a/sunny_sales_web/src/components/BeachConditions.css
+++ b/sunny_sales_web/src/components/BeachConditions.css
@@ -3,11 +3,13 @@
 .bc-container {
   border: 1px solid #ccc;
   padding: 1rem;
-  width: 80%;
+  width: min(80%, 500px);
+  max-width: 100%;
   font-size: 0.9rem;
   background: #fff;
   border-radius: 8px;
   margin-top: 1rem;
+  box-sizing: border-box;
 }
 
 
@@ -39,9 +41,20 @@
 }
 
 @media (min-width: 640px) {
-
   .bc-content {
     flex-direction: row;
+  }
+}
 
+@media (max-width: 480px) {
+  .bc-container {
+    width: 95%;
+    padding: 0.75rem;
+    font-size: 0.85rem;
+  }
+
+  .bc-selector select {
+    font-size: 16px;
+    min-height: 44px;
   }
 }

--- a/sunny_sales_web/src/components/Footer.css
+++ b/sunny_sales_web/src/components/Footer.css
@@ -1,13 +1,14 @@
 /* (em português) Estilos do rodapé fixo com mensagens de sustentabilidade */
 .footer-wrapper {
   position: fixed;
-  z-index: 500; /* (em português) Abaixo do cabeçalho para não o sobrepor */
-  bottom: 0; /* (em português) Mantém o rodapé no fundo da página */
+  z-index: 500;
+  bottom: 0;
   left: 0;
   width: 100%;
   height: 40px;
   overflow: hidden;
   background-color: var(--footer-color);
+  padding-bottom: env(safe-area-inset-bottom, 0px);
 }
 
 .footer-message {
@@ -19,7 +20,17 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  padding: 0 1rem;
+  box-sizing: border-box;
   color: #fff;
   font-weight: bold;
+  font-size: 0.8rem;
+  text-align: center;
   z-index: 1;
+}
+
+@media (max-width: 480px) {
+  .footer-message {
+    font-size: 0.7rem;
+  }
 }

--- a/sunny_sales_web/src/components/ImageCropper.css
+++ b/sunny_sales_web/src/components/ImageCropper.css
@@ -9,6 +9,8 @@
   align-items: center;
   justify-content: center;
   z-index: 1000;
+  padding: 1rem;
+  box-sizing: border-box;
 }
 
 .cropper-box {
@@ -18,12 +20,18 @@
   flex-direction: column;
   align-items: center;
   gap: 8px;
+  max-width: 100%;
+  max-height: 90vh;
+  overflow: auto;
+  border-radius: 8px;
 }
 
 .cropper-area {
   position: relative;
   overflow: hidden;
   cursor: grab;
+  max-width: calc(100vw - 2rem);
+  touch-action: none;
 }
 
 .cropper-area img {
@@ -37,4 +45,6 @@
 .cropper-actions {
   display: flex;
   gap: 10px;
+  flex-wrap: wrap;
+  justify-content: center;
 }

--- a/sunny_sales_web/src/index.css
+++ b/sunny_sales_web/src/index.css
@@ -22,13 +22,14 @@
 body {
   margin: 0;
   padding: 0;
-  
 
   background-color: var(--bg-color);
   background-image: none;
   background-repeat: no-repeat;
   background-size: cover;
   overflow-x: hidden;
+  -webkit-text-size-adjust: 100%;
+  touch-action: manipulation;
 }
 
 /* Container central para limitar a largura do conteúdo */
@@ -198,8 +199,9 @@ h2 {
 }
 
 .form-container {
-  width: 350px;
-  height: 500px;
+  width: min(350px, 90vw);
+  height: auto;
+  min-height: 400px;
   background-color: #fff;
   box-shadow: rgba(0, 0, 0, 0.35) 0px 5px 15px;
   border-radius: 10px;
@@ -364,6 +366,7 @@ button {
   color: var(--secondary-color) !important;
   font-size: 1rem;
   padding: 0.5em 1.2em;
+  min-height: 44px;
   background-color: var(--primary-color) !important;
   display: flex;
   justify-content: center;
@@ -371,6 +374,8 @@ button {
   align-items: center;
   gap: 0.6em;
   font-weight: bold;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
 }
 
 /* Utilizado para destacar botoes de acoes principais em laranja */
@@ -458,12 +463,22 @@ input[type='checkbox'] {
     top: 100%;
     left: 0;
     width: 100%;
-    background-color: transparent;
+    background-color: var(--bg-color);
     padding: 1rem 2rem;
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.08);
+    box-sizing: border-box;
+    z-index: 999;
   }
 
   .nav-links.open {
     display: flex;
+  }
+
+  .nav-link {
+    padding: 0.5rem 0;
+    min-height: 44px;
+    display: flex;
+    align-items: center;
   }
 
   .menu-toggle {
@@ -479,15 +494,41 @@ input[type='checkbox'] {
   @media (max-width: 480px) {
   .form-container,
   .form-container.login-container {
-    width: 90%;
+    width: 92%;
+    padding: 16px 20px;
   }
   .nav-logo {
     font-size: 24px;
   }
-    .navbar {
-      padding: 10px 20px;
-    }
+  .navbar {
+    padding: 10px 16px;
   }
+  .form-box {
+    width: 100%;
+    padding: 0 1rem;
+    box-sizing: border-box;
+  }
+  h2 {
+    font-size: 1.5rem;
+  }
+}
+
+@media (max-width: 375px) {
+  .navbar {
+    padding: 8px 12px;
+  }
+  .nav-logo {
+    font-size: 20px;
+  }
+}
+
+/* Suporte para dispositivos com notch (safe area) */
+@supports (padding: max(0px)) {
+  .navbar {
+    padding-left: max(20px, env(safe-area-inset-left));
+    padding-right: max(20px, env(safe-area-inset-right));
+  }
+}
 
 /* === Estilos para formulários de autenticação === */
 .auth-form {
@@ -645,6 +686,8 @@ input[type='checkbox'] {
   gap: 0.5rem;
   background-color: var(--clr-alpha);
   outline: 2px solid var(--bg-dark);
+  font-size: 16px;
+  min-height: 44px;
 }
 
 .form input[type="email"]:focus,

--- a/sunny_sales_web/src/pages/ModernMapLayout.css
+++ b/sunny_sales_web/src/pages/ModernMapLayout.css
@@ -60,7 +60,9 @@ body {
   flex-direction: column;
   gap: 0.75rem;
   width: 200px;
+  min-width: 160px;
   padding: 1rem;
+  flex-shrink: 0;
 }
 
 .filters-title {
@@ -181,7 +183,7 @@ body {
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  width: 180px;
+  width: 200px;
   padding: 1rem;
   background: var(--bg-color);
   border: 1px solid #dee2e6;
@@ -237,19 +239,57 @@ body {
   .filters {
     width: 100%;
     flex-direction: row;
-    justify-content: center;
-    margin-bottom: 0.5rem;
+    flex-wrap: nowrap;
+    justify-content: flex-start;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: none;
+    margin-bottom: 0.25rem;
+    padding: 0.5rem 1rem;
+    gap: 0.5rem;
+    min-width: 0;
+  }
+  .filters::-webkit-scrollbar {
+    display: none;
+  }
+  .filters-title {
+    display: none;
   }
   .map-area {
     width: 100%;
-    height: 60vh;
+    height: calc(100svh - 160px);
+    min-height: 300px;
     margin: 0;
+    padding: 0;
+  }
+  .vendor-card {
+    top: auto;
+    bottom: 1.5rem;
+    left: 50%;
+    transform: translateX(-50%);
+    width: calc(100% - 2rem);
+    max-width: 320px;
+  }
+  @keyframes fadeSlide {
+    from {
+      opacity: 0;
+      transform: translateX(-50%) translateY(20px);
+    }
+    to {
+      opacity: 1;
+      transform: translateX(-50%) translateY(0);
+    }
   }
 }
 
 @media (max-width: 480px) {
   .vendor-card {
-    width: 90%;
+    width: calc(100% - 1.5rem);
+    max-width: none;
+    bottom: 1rem;
+  }
+  .filters {
+    padding: 0.5rem 0.75rem;
   }
 }
 
@@ -258,8 +298,8 @@ body {
   position: absolute;
   bottom: 2rem;
   right: 1rem;
-  width: 44.8px;
-  height: 44.8px;
+  width: 48px;
+  height: 48px;
   background: var(--secondary-color);
   border: none;
   border-radius: 50%;
@@ -270,6 +310,7 @@ body {
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
   transition: transform 0.2s;
   z-index: 500;
+  -webkit-tap-highlight-color: transparent;
 }
 
 .locate-btn:hover {
@@ -281,8 +322,8 @@ body {
   position: absolute;
   bottom: 2rem;
   right: 1rem;
-  width: 44.8px;
-  height: 44.8px;
+  width: 48px;
+  height: 48px;
   background: var(--secondary-color);
   border: none;
   border-radius: 50%;
@@ -293,6 +334,7 @@ body {
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
   transition: transform 0.2s;
   z-index: 500;
+  -webkit-tap-highlight-color: transparent;
 }
 
 .vendor-locate-btn:hover {

--- a/sunny_sales_web/src/pages/VendorDashboard.css
+++ b/sunny_sales_web/src/pages/VendorDashboard.css
@@ -2,8 +2,9 @@
 .vendor-switch {
   position: relative;
   display: inline-block;
-  width: 50px;
-  height: 24px;
+  width: 56px;
+  height: 28px;
+  flex-shrink: 0;
 }
 
 .vendor-switch input {
@@ -27,10 +28,10 @@
 .vendor-switch .slider:before {
   position: absolute;
   content: '';
-  height: 20px;
-  width: 20px;
-  left: 2px;
-  bottom: 2px;
+  height: 22px;
+  width: 22px;
+  left: 3px;
+  bottom: 3px;
   background-color: #fff;
   transition: 0.4s;
   border-radius: 50%;
@@ -41,5 +42,13 @@
 }
 
 .vendor-switch input:checked + .slider:before {
-  transform: translateX(26px);
+  transform: translateX(28px);
+}
+
+/* Responsividade do painel lateral do vendedor */
+@media (max-width: 480px) {
+  .vendor-switch {
+    width: 52px;
+    height: 26px;
+  }
 }

--- a/sunny_sales_web/src/pages/VendorDashboard.jsx
+++ b/sunny_sales_web/src/pages/VendorDashboard.jsx
@@ -222,12 +222,14 @@ export default function VendorDashboard() {
   );
 }
 
+const isMobile = () => typeof window !== 'undefined' && window.innerWidth <= 600;
+
 const styles = {
   wrapper: {
     position: 'relative',
   },
   container: {
-    padding: '2rem',
+    padding: '1.5rem 1rem',
     maxWidth: '600px',
     margin: '0 auto',
     textAlign: 'center',
@@ -235,6 +237,7 @@ const styles = {
   },
   title: {
     marginBottom: '1rem',
+    fontSize: 'clamp(1.2rem, 5vw, 1.75rem)',
   },
   photo: {
     width: 100,
@@ -257,6 +260,7 @@ const styles = {
     borderRadius: '12px',
     marginBottom: '1rem',
     textAlign: 'left',
+    wordBreak: 'break-word',
   },
   logoutButton: {
     width: 'auto',
@@ -265,48 +269,58 @@ const styles = {
     borderRadius: 12,
     backgroundColor: '#FCB454',
     border: 'none',
-    padding: '0.5rem 1rem',
+    padding: '0.75rem 1.5rem',
     cursor: 'pointer',
     fontWeight: 'bold',
     color: '#fff',
+    minHeight: '44px',
   },
   toggleContainer: {
     display: 'flex',
     alignItems: 'center',
-    gap: '0.5rem',
+    gap: '0.75rem',
     justifyContent: 'center',
-    margin: '12px auto',
+    margin: '16px auto',
   },
   // (em português) Texto que mostra o estado atual da localização
   switchLabel: {
     fontWeight: 'bold',
+    fontSize: '1rem',
   },
   menuButton: {
     position: 'fixed',
     top: '8rem',
-    left: '1rem',
+    left: '0.75rem',
     zIndex: 1100,
     backgroundColor: '#FCB454',
     color: '#fff',
     border: 'none',
-    padding: '0.5rem 1rem',
+    padding: '0.6rem 1rem',
     cursor: 'pointer',
     fontSize: '1.2rem',
     borderRadius: '50%',
+    width: '48px',
+    height: '48px',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    boxShadow: '0 2px 8px rgba(0,0,0,0.2)',
   },
   sideMenu: {
     position: 'fixed',
     top: '100px',
     left: 0,
     height: 'calc(100% - 100px)',
-    width: '250px',
+    width: 'min(280px, 85vw)',
     backgroundColor: '#f8f8f8',
-    boxShadow: '2px 0 5px rgba(0,0,0,0.1)',
+    boxShadow: '2px 0 8px rgba(0,0,0,0.15)',
     padding: '1rem',
+    paddingBottom: 'max(1rem, env(safe-area-inset-bottom))',
     boxSizing: 'border-box',
     transform: 'translateX(-100%)',
     transition: 'transform 0.3s ease-in-out',
     zIndex: 900,
+    overflowY: 'auto',
   },
   sideMenuOpen: {
     transform: 'translateX(0)',
@@ -318,7 +332,7 @@ const styles = {
     alignItems: 'stretch',
   },
   menuButtonItem: {
-    padding: '0.75rem 1rem',
+    padding: '0.85rem 1rem',
     backgroundColor: '#FCB454',
     color: 'white',
     border: 'none',
@@ -326,6 +340,8 @@ const styles = {
     fontWeight: 'bold',
     cursor: 'pointer',
     textAlign: 'left',
+    minHeight: '44px',
+    fontSize: '0.95rem',
   },
   divider: {
     height: '1px',


### PR DESCRIPTION
- Previne o auto-zoom do iOS nos inputs (font-size: 16px, min-height: 44px)
- Mapa usa altura dinâmica (100svh) e filtros com scroll horizontal em mobile
- Vendor card aparece no fundo do mapa em vez do centro (mais acessível em mobile)
- Menu lateral do vendedor com largura adaptativa (85vw máximo) e safe area
- Navbar mobile com fundo sólido, sombra e links com altura de toque adequada
- Botões com min-height: 44px e touch-action para melhor resposta táctil
- Footer com safe area para dispositivos com notch e texto responsivo
- ImageCropper adaptado ao viewport mobile com touch-action: none
- BeachConditions com largura fluida e select com tamanho de toque correto
- form-container usa min() para adaptar entre desktop e mobile sem overflow

https://claude.ai/code/session_01ESZPQs15Uq35KkDzu3xiVU