### PR TITLE
fix: corrigir erros de validação no registo de vendedor

### DIFF
--- a/sunny_sales_web/src/pages/VendorRegister.jsx
+++ b/sunny_sales_web/src/pages/VendorRegister.jsx
@@ -46,8 +46,13 @@ export default function VendorRegister() {
       return;
     }
 
-    if (password.length < 8 || password.toLowerCase() === password) {
-      setError('A palavra-passe deve ter pelo menos 8 caracteres e uma letra maiúscula');
+    if (!photo) {
+      setError('É necessária uma foto de perfil.');
+      return;
+    }
+
+    if (password.length < 8 || password.toLowerCase() === password || !/\d/.test(password)) {
+      setError('A palavra-passe deve ter pelo menos 8 caracteres, uma letra maiúscula e um número');
       return;
     }
 
@@ -57,10 +62,8 @@ export default function VendorRegister() {
     formData.append('password', password);
     formData.append('product', product);
 
-    if (photo) {
-      const file = new File([photo], 'profile.jpg', { type: 'image/jpeg' });
-      formData.append('profile_photo', file);
-    }
+    const file = new File([photo], 'profile.jpg', { type: 'image/jpeg' });
+    formData.append('profile_photo', file);
 
     try {
       await axios.post(`${BASE_URL}/vendors/`, formData, {


### PR DESCRIPTION
- Adicionar validação obrigatória da foto de perfil antes de submeter
  (a foto não era adicionada ao FormData se null, causando 422 no backend)
- Corrigir validação da palavra-passe para incluir verificação de dígito,
  alinhando o frontend com a validação do backend
- Garantir que profile_photo é sempre enviado (remover bloco if desnecessário)

https://claude.ai/code/session_012Nfv2mJTkW4jJqv3fzx1VM