### PR TITLE
Build frontend during startup and improve backend URL resolution

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,2 +1,14 @@
 #!/bin/bash
-uvicorn backend.app.main:app --host 0.0.0.0 --port 10000
+set -e
+
+# Build do frontend (se node_modules ainda não existe, instala dependências)
+if [ -d "sunny_sales_web" ]; then
+  echo "A compilar o frontend..."
+  cd sunny_sales_web
+  npm install --prefer-offline --no-audit --no-fund
+  npm run build
+  cd ..
+  echo "Frontend compilado com sucesso."
+fi
+
+exec uvicorn backend.app.main:app --host 0.0.0.0 --port 10000

--- a/sunny_sales_web/src/config.js
+++ b/sunny_sales_web/src/config.js
@@ -1,4 +1,5 @@
 // (em português) URL base do backend.
 // Pode ser definida pela variável de ambiente `VITE_BASE_URL` quando
-// iniciar o Vite. Caso não seja fornecida, assume localhost.
-export const BASE_URL = import.meta.env.VITE_BASE_URL || 'http://localhost:8000';
+// iniciar o Vite. Caso não seja fornecida, usa a origem atual da página
+// (funciona em produção onde frontend e backend partilham o mesmo servidor).
+export const BASE_URL = import.meta.env.VITE_BASE_URL || (typeof window !== 'undefined' ? window.location.origin : 'http://localhost:8000');


### PR DESCRIPTION
## Summary
This PR improves the application startup process and backend URL configuration to better support production deployments where the frontend and backend share the same server.

## Key Changes
- **Enhanced start.sh**: Added automatic frontend build step during application startup
  - Checks if the `sunny_sales_web` directory exists
  - Installs dependencies and builds the frontend before starting the backend
  - Uses `exec` to replace the shell process with the uvicorn server
  
- **Improved BASE_URL configuration**: Updated frontend API endpoint resolution
  - Falls back to `window.location.origin` instead of hardcoded localhost
  - Enables seamless operation in production where frontend and backend are served from the same origin
  - Maintains support for `VITE_BASE_URL` environment variable override

## Implementation Details
- The frontend build is only attempted if the `sunny_sales_web` directory exists, making the script flexible for different deployment scenarios
- npm install uses `--prefer-offline`, `--no-audit`, and `--no-fund` flags for faster, cleaner builds
- The BASE_URL now intelligently detects the server origin at runtime, eliminating the need for environment-specific configuration in many cases

https://claude.ai/code/session_01Btt4X7vwhuLzvot17K96iq