### PR TITLE
Remove email confirmation requirement and disable email sending

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -338,8 +338,6 @@ def login(credentials: schemas.UserLogin, db: Session = Depends(get_db)):
     )
     if not vendor or not pwd_context.verify(credentials.password, vendor.hashed_password):
         raise HTTPException(status_code=400, detail="Incorrect email or password")
-    if not vendor.email_confirmed:
-        raise HTTPException(status_code=400, detail="Email not confirmed")
     return vendor
 
 # --------------------------
@@ -377,8 +375,6 @@ async def generate_token(
     vendor = db.query(models.Vendor).filter(models.Vendor.email == email).first()
     if not vendor or not pwd_context.verify(password, vendor.hashed_password):
         raise HTTPException(status_code=400, detail="Incorrect email or password")
-    if not vendor.email_confirmed:
-        raise HTTPException(status_code=400, detail="Email not confirmed")
     token = create_access_token({"sub": vendor.id})
     session = models.VendorSession(
         vendor_id=vendor.id, token=token, user_agent=request.headers.get("user-agent")
@@ -465,18 +461,11 @@ async def create_vendor(
         product=product,
         profile_photo=public_path,
         pin_color="#FFB6C1",
-        confirmation_token=token_urlsafe(32),
+        email_confirmed=True,
     )
     db.add(new_vendor)
     db.commit()
     db.refresh(new_vendor)
-
-    confirm_link = f"{os.getenv('BASE_URL', 'http://localhost:8000')}/confirm-email/{new_vendor.confirmation_token}"
-    send_email(
-        new_vendor.email,
-        "Confirme o seu registro",
-        f"Clique no link para confirmar sua conta:\n{confirm_link}",
-    )
     return new_vendor
 
 
@@ -508,18 +497,13 @@ async def password_reset_request(
     if not email:
         raise HTTPException(status_code=422, detail="Email is required")
     vendor = db.query(models.Vendor).filter(models.Vendor.email == email).first()
+    reset_link = None
     if vendor:
         vendor.password_reset_token = token_urlsafe(32)
         vendor.password_reset_expires = utcnow() + timedelta(hours=1)
         db.commit()
         reset_link = f"{os.getenv('BASE_URL', 'http://localhost:8000')}/password-reset/{vendor.password_reset_token}"
-        send_email(
-            vendor.email,
-            "Redefinição de senha",
-            f"Clique no link para alterar sua senha:\n{reset_link}",
-        )
-    # Sempre retornar 200 para não revelar se o email existe
-    return {"message": "E-mail de recuperação enviado"}
+    return {"message": "Link de recuperação gerado (modo de teste)", "reset_link": reset_link}
 
 
 @app.post("/password-reset/{token}")


### PR DESCRIPTION
## Summary
This PR removes the email confirmation workflow from the vendor authentication and registration flows, and disables email sending functionality. Vendors are now automatically confirmed upon registration, and authentication no longer requires email verification.

## Key Changes
- **Removed email confirmation checks** from login and token generation endpoints - vendors can now authenticate without confirming their email
- **Disabled email confirmation workflow** in vendor registration:
  - Removed generation and storage of `confirmation_token`
  - Set `email_confirmed=True` by default for new vendors
  - Removed confirmation email sending logic
- **Disabled password reset email sending** while keeping the token generation logic:
  - Password reset tokens are still generated and stored
  - Email sending is removed, but reset link is now returned in the response for testing purposes
  - Changed response to indicate "test mode" with the reset link exposed in the API response

## Notable Implementation Details
- The password reset endpoint now returns the reset link directly in the response (`reset_link` field), which is suitable for development/testing but should not be used in production
- Email confirmation is no longer part of the vendor lifecycle - all new vendors are immediately confirmed
- The `confirmation_token` field is no longer used in the vendor creation flow

https://claude.ai/code/session_013XvBqtJ28uRC4NKKvKPXQA