### PR TITLE
fix: add missing DB column migrations and fix multipart Content-Type

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -47,8 +47,17 @@ def get_db():
 # Pequena migração automática para adicionar colunas recentes
 def ensure_latest_schema():
     inspector = inspect(engine)
-    if "vendors" in inspector.get_table_names():
-        columns = [c["name"] for c in inspector.get_columns("vendors")]
-        if "session_token" not in columns:
-            with engine.begin() as conn:  # begin() cria transação e faz commit automático
-                conn.execute(text("ALTER TABLE vendors ADD COLUMN session_token TEXT"))
+    tables = inspector.get_table_names()
+    if "vendors" in tables:
+        columns = {c["name"] for c in inspector.get_columns("vendors")}
+        migrations = [
+            ("session_token", "ALTER TABLE vendors ADD COLUMN session_token TEXT"),
+            ("email_confirmed", "ALTER TABLE vendors ADD COLUMN email_confirmed BOOLEAN DEFAULT false"),
+            ("confirmation_token", "ALTER TABLE vendors ADD COLUMN confirmation_token TEXT"),
+            ("password_reset_token", "ALTER TABLE vendors ADD COLUMN password_reset_token TEXT"),
+            ("password_reset_expires", "ALTER TABLE vendors ADD COLUMN password_reset_expires TIMESTAMP"),
+        ]
+        with engine.begin() as conn:
+            for col, stmt in migrations:
+                if col not in columns:
+                    conn.execute(text(stmt))

--- a/sunny_sales_web/src/pages/VendorRegister.jsx
+++ b/sunny_sales_web/src/pages/VendorRegister.jsx
@@ -66,12 +66,8 @@ export default function VendorRegister() {
     formData.append('profile_photo', file);
 
     try {
-      await axios.post(`${BASE_URL}/vendors/`, formData, {
-        headers: {
-          'Content-Type': 'multipart/form-data',
-        },
-      });
-      setSuccess('Registo efetuado com sucesso!');
+      await axios.post(`${BASE_URL}/vendors/`, formData);
+      setSuccess('Registo efetuado com sucesso! Verifique o seu email para confirmar a conta.');
       setName('');
       setEmail('');
       setPassword('');


### PR DESCRIPTION
ensure_latest_schema now adds email_confirmed, confirmation_token,
password_reset_token and password_reset_expires if missing from the
vendors table, so existing production PostgreSQL databases get the
columns required by the email confirmation flow.

Remove the explicit Content-Type: multipart/form-data header from the
registration form — axios sets it automatically with the correct boundary,
and overriding it without the boundary causes the server to reject the
request with 400 (missing boundary). Also restore the success message
instructing the user to verify their email before logging in.

https://claude.ai/code/session_019jdzJ2s5ABaAfLEmcFjr7y