### PR TITLE
fix: use Railway PORT env var, add Procfile, and fix mobile crop

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: bash start.sh

--- a/start.sh
+++ b/start.sh
@@ -11,4 +11,4 @@ if [ -d "sunny_sales_web" ]; then
   echo "Frontend compilado com sucesso."
 fi
 
-exec uvicorn backend.app.main:app --host 0.0.0.0 --port 10000
+exec uvicorn backend.app.main:app --host 0.0.0.0 --port "${PORT:-10000}"

--- a/sunny_sales_web/src/components/ImageCropper.jsx
+++ b/sunny_sales_web/src/components/ImageCropper.jsx
@@ -10,18 +10,27 @@ export default function ImageCropper({ src, onCancel, onComplete }) {
   const [dragging, setDragging] = useState(false);
   const lastPos = useRef({ x: 0, y: 0 });
 
+  const getCoords = (e) => {
+    if (e.touches && e.touches.length > 0) {
+      return { x: e.touches[0].clientX, y: e.touches[0].clientY };
+    }
+    return { x: e.clientX, y: e.clientY };
+  };
+
   const startDrag = (e) => {
     e.preventDefault();
     setDragging(true);
-    lastPos.current = { x: e.clientX, y: e.clientY };
+    const coords = getCoords(e);
+    lastPos.current = coords;
   };
 
   const onDrag = (e) => {
     if (!dragging) return;
-    const dx = e.clientX - lastPos.current.x;
-    const dy = e.clientY - lastPos.current.y;
+    const coords = getCoords(e);
+    const dx = coords.x - lastPos.current.x;
+    const dy = coords.y - lastPos.current.y;
     setPosition((prev) => ({ x: prev.x + dx, y: prev.y + dy }));
-    lastPos.current = { x: e.clientX, y: e.clientY };
+    lastPos.current = coords;
   };
 
   const endDrag = () => {
@@ -50,12 +59,20 @@ export default function ImageCropper({ src, onCancel, onComplete }) {
   };
 
   return (
-    <div className="cropper-overlay" onMouseMove={onDrag} onMouseUp={endDrag} onMouseLeave={endDrag}>
+    <div
+      className="cropper-overlay"
+      onMouseMove={onDrag}
+      onMouseUp={endDrag}
+      onMouseLeave={endDrag}
+      onTouchMove={onDrag}
+      onTouchEnd={endDrag}
+    >
       <div className="cropper-box">
         <div
           className="cropper-area"
           style={{ width: containerSize, height: containerSize }}
           onMouseDown={startDrag}
+          onTouchStart={startDrag}
         >
           <img
             ref={imgRef}


### PR DESCRIPTION
- Procfile: add web entry so Railway runs start.sh (builds frontend
  then starts backend), ensuring frontend and API share the same origin
  and POST /vendors/ reaches FastAPI instead of a static file server
- start.sh: use ${PORT:-10000} so the app binds to the port Railway
  assigns via the PORT env var
- ImageCropper: add touch event handlers (onTouchStart/Move/End) so
  users on iOS/Android can drag to reposition the crop area

https://claude.ai/code/session_01792VoLLSkxvAKo17Hzeb3C