### PR TITLE
Maximize pin location and direction precision on iOS and Android

### DIFF
--- a/sunny_sales_mobile/app.json
+++ b/sunny_sales_mobile/app.json
@@ -17,7 +17,12 @@
       "**/*"
     ],
     "ios": {
-      "supportsTablet": true
+      "supportsTablet": true,
+      "infoPlist": {
+        "NSLocationWhenInUseUsageDescription": "A sua localização é usada para mostrar a sua posição no mapa e encontrar vendedores próximos.",
+        "NSLocationAlwaysAndWhenInUseUsageDescription": "A sua localização é usada para mostrar a sua posição no mapa e encontrar vendedores próximos.",
+        "NSMotionUsageDescription": "O sensor de movimento é usado para determinar a direção em que está a apontar o telemóvel."
+      }
     },
     "android": {
       "adaptiveIcon": {

--- a/sunny_sales_mobile/src/screens/MapScreen.tsx
+++ b/sunny_sales_mobile/src/screens/MapScreen.tsx
@@ -60,16 +60,20 @@ export default function MapScreen() {
   useEffect(() => {
     let sub: Location.LocationSubscription | null = null;
     let headingSub: Location.LocationSubscription | null = null;
+    // Low-pass filter para suavizar o heading da bússola e reduzir jitter
+    let smoothedHeading: number | null = null;
+    const COMPASS_ALPHA = 0.25; // 0 = sem resposta, 1 = sem suavização
+    const MAX_COMPASS_ACCURACY_DEG = 20; // ignora leituras com precisão inferior a 20°
     (async () => {
       const { status } = await Location.requestForegroundPermissionsAsync();
       if (status !== 'granted') {
         console.log('Permissão de localização negada');
         return;
       }
-      // Localização inicial rápida para mostrar o mapa rapidamente
+      // Localização inicial com máxima precisão
       try {
         const initial = await Location.getCurrentPositionAsync({
-          accuracy: Location.Accuracy.Balanced,
+          accuracy: Location.Accuracy.BestForNavigation,
         });
         setRegion({ latitude: initial.coords.latitude, longitude: initial.coords.longitude });
       } catch (e) {
@@ -87,6 +91,7 @@ export default function MapScreen() {
           // Curso GPS: direção real de deslocamento (válido quando em movimento)
           if (loc.coords.heading != null && loc.coords.heading >= 0) {
             gpsCourseActiveRef.current = true;
+            smoothedHeading = loc.coords.heading;
             setHeading(loc.coords.heading);
           } else {
             gpsCourseActiveRef.current = false;
@@ -95,10 +100,21 @@ export default function MapScreen() {
       );
       // Bússola: usada apenas quando o GPS não fornece curso (ex: dispositivo parado)
       headingSub = await Location.watchHeadingAsync((headingData) => {
-        if (!gpsCourseActiveRef.current) {
-          const h = headingData.trueHeading >= 0 ? headingData.trueHeading : headingData.magHeading;
-          setHeading(h);
+        if (gpsCourseActiveRef.current) return;
+        // Rejeitar leituras com baixa qualidade (accuracy em graus)
+        if (headingData.accuracy > MAX_COMPASS_ACCURACY_DEG) return;
+        const raw = headingData.trueHeading >= 0 ? headingData.trueHeading : headingData.magHeading;
+        if (raw < 0) return;
+        // Interpolação angular para evitar saltos nos 0°/360°
+        if (smoothedHeading === null) {
+          smoothedHeading = raw;
+        } else {
+          let diff = raw - smoothedHeading;
+          if (diff > 180) diff -= 360;
+          if (diff < -180) diff += 360;
+          smoothedHeading = (smoothedHeading + COMPASS_ALPHA * diff + 360) % 360;
         }
+        setHeading(smoothedHeading);
       });
     })();
     return () => {
@@ -225,7 +241,7 @@ export default function MapScreen() {
           function getUserPinHtml(h) {
             var hasH = h != null && !isNaN(h);
             var arrow = hasH
-              ? '<svg viewBox="0 0 20 20" width="12" height="12" style="transform:rotate(' + Math.round(h) + 'deg);display:block;flex-shrink:0;"><polygon points="10,1 6.5,14 10,11.5 13.5,14" fill="white"/></svg>'
+              ? '<svg viewBox="0 0 20 20" width="12" height="12" style="transform:rotate(' + h.toFixed(1) + 'deg);display:block;flex-shrink:0;"><polygon points="10,1 6.5,14 10,11.5 13.5,14" fill="white"/></svg>'
               : '';
             return '<div class="ulm"><div class="ulm-pulse"></div><div class="ulm-dot">' + arrow + '</div></div>';
           }

--- a/sunny_sales_web/src/pages/ModernMapLayout.jsx
+++ b/sunny_sales_web/src/pages/ModernMapLayout.jsx
@@ -20,7 +20,7 @@ const PRODUCT_ICONS = {
 function getClientPinHtml(heading) {
   const hasHeading = heading !== null && !isNaN(heading);
   const arrow = hasHeading
-    ? `<svg viewBox="0 0 20 20" width="12" height="12" style="transform:rotate(${Math.round(heading)}deg);display:block;flex-shrink:0;"><polygon points="10,1 6.5,14 10,11.5 13.5,14" fill="white"/></svg>`
+    ? `<svg viewBox="0 0 20 20" width="12" height="12" style="transform:rotate(${heading.toFixed(1)}deg);display:block;flex-shrink:0;"><polygon points="10,1 6.5,14 10,11.5 13.5,14" fill="white"/></svg>`
     : '';
   return `<div class="user-location-marker"><div class="user-location-pulse"></div><div class="user-location-dot">${arrow}</div></div>`;
 }
@@ -28,7 +28,7 @@ function getClientPinHtml(heading) {
 function getVendorPinHtml(color, heading) {
   const hasHeading = heading !== null && !isNaN(heading);
   const arrow = hasHeading
-    ? `<svg viewBox="0 0 20 20" width="12" height="12" style="transform:rotate(${Math.round(heading)}deg);display:block;flex-shrink:0;"><polygon points="10,1 6.5,14 10,11.5 13.5,14" fill="white"/></svg>`
+    ? `<svg viewBox="0 0 20 20" width="12" height="12" style="transform:rotate(${heading.toFixed(1)}deg);display:block;flex-shrink:0;"><polygon points="10,1 6.5,14 10,11.5 13.5,14" fill="white"/></svg>`
     : '';
   return `<div class="vendor-location-marker"><div class="vendor-location-dot" style="background:${color}">${arrow}</div></div>`;
 }
@@ -43,6 +43,9 @@ export default function ModernMapLayout() {
   const [clientPos, setClientPos] = useState(null);
   const [heading, setHeading] = useState(null);
   const lastHeadingTs = useRef(0);
+  const smoothedHeadingRef = useRef(null);
+  const absEventFiredRef = useRef(false); // true quando deviceorientationabsolute disparou
+  const gpsMovingRef = useRef(false); // true quando GPS fornece heading válido
   const [compassReady, setCompassReady] = useState(false);
   const [showLocateHint, setShowLocateHint] = useState(false);
   // Verifica se o utilizador autenticado é um vendedor. Se sim, ocultamos o
@@ -119,12 +122,14 @@ export default function ModernMapLayout() {
       (pos) => {
         setClientPos({ lat: pos.coords.latitude, lng: pos.coords.longitude });
         const gpsH = pos.coords.heading;
-        if (gpsH != null && !isNaN(gpsH)) {
-          const now = Date.now();
-          if (now - lastHeadingTs.current >= 100) {
-            lastHeadingTs.current = now;
-            setHeading(gpsH);
-          }
+        // GPS heading tem prioridade máxima quando o utilizador está em movimento
+        if (gpsH != null && !isNaN(gpsH) && pos.coords.speed != null && pos.coords.speed > 0.3) {
+          gpsMovingRef.current = true;
+          smoothedHeadingRef.current = gpsH;
+          setHeading(gpsH);
+          lastHeadingTs.current = Date.now();
+        } else {
+          gpsMovingRef.current = false;
         }
       },
       (err) => console.error('Erro localização:', err),
@@ -174,26 +179,59 @@ export default function ModernMapLayout() {
 
   useEffect(() => {
     if (!compassReady) return;
-    const THROTTLE_MS = 100;
-    const onOrientation = (e) => {
+    const THROTTLE_MS = 50;
+    // Low-pass filter para suavizar o heading da bússola e reduzir jitter
+    const COMPASS_ALPHA = 0.25;
+    const MAX_ACCURACY_DEG = 25; // iOS webkitCompassAccuracy em graus
+
+    const applySmoothing = (raw) => {
+      const prev = smoothedHeadingRef.current;
+      if (prev === null) {
+        smoothedHeadingRef.current = raw;
+        return raw;
+      }
+      let diff = raw - prev;
+      if (diff > 180) diff -= 360;
+      if (diff < -180) diff += 360;
+      const next = (prev + COMPASS_ALPHA * diff + 360) % 360;
+      smoothedHeadingRef.current = next;
+      return next;
+    };
+
+    // deviceorientationabsolute: fonte mais fiável em Android (valores absolutos)
+    const onAbsolute = (e) => {
+      if (gpsMovingRef.current) return;
+      if (e.alpha == null) return;
       const now = Date.now();
       if (now - lastHeadingTs.current < THROTTLE_MS) return;
+      lastHeadingTs.current = now;
+      absEventFiredRef.current = true;
+      const raw = (360 - e.alpha) % 360;
+      setHeading(applySmoothing(raw));
+    };
+
+    // deviceorientation: iOS Safari (webkitCompassHeading) e fallback Android
+    const onOrientation = (e) => {
+      if (gpsMovingRef.current) return;
+      // Se deviceorientationabsolute já disparou, ignorar esta fonte (menos precisa)
+      if (absEventFiredRef.current) return;
+      const now = Date.now();
+      if (now - lastHeadingTs.current < THROTTLE_MS) return;
+      // Filtrar leituras iOS com baixa precisão de bússola
+      if (e.webkitCompassAccuracy != null && e.webkitCompassAccuracy >= 0 && e.webkitCompassAccuracy > MAX_ACCURACY_DEG) return;
       lastHeadingTs.current = now;
       if (e.webkitCompassHeading != null) {
-        setHeading(e.webkitCompassHeading);
+        setHeading(applySmoothing(e.webkitCompassHeading));
+      } else if (e.alpha != null && e.absolute) {
+        setHeading(applySmoothing((360 - e.alpha) % 360));
       }
     };
-    const onAbsolute = (e) => {
-      const now = Date.now();
-      if (now - lastHeadingTs.current < THROTTLE_MS) return;
-      lastHeadingTs.current = now;
-      if (e.alpha != null) setHeading((360 - e.alpha) % 360);
-    };
-    window.addEventListener('deviceorientation', onOrientation, true);
+
     window.addEventListener('deviceorientationabsolute', onAbsolute, true);
+    window.addEventListener('deviceorientation', onOrientation, true);
     return () => {
-      window.removeEventListener('deviceorientation', onOrientation, true);
       window.removeEventListener('deviceorientationabsolute', onAbsolute, true);
+      window.removeEventListener('deviceorientation', onOrientation, true);
     };
   }, [compassReady]);
 


### PR DESCRIPTION
- Mobile: initial fix uses BestForNavigation (was Balanced); compass
  readings filtered by accuracy threshold (≤20°); angular low-pass
  filter (α=0.25) smooths heading jitter without delay; SVG arrow uses
  toFixed(1) for sub-degree rotation precision
- Web: deviceorientationabsolute takes priority over deviceorientation
  (more reliable on Android); iOS webkitCompassAccuracy filter (≤25°);
  same low-pass filter applied; GPS heading overrides compass when
  speed > 0.3 m/s; throttle reduced from 100 ms to 50 ms
- app.json: iOS infoPlist entries for NSLocationWhenInUseUsageDescription,
  NSLocationAlwaysAndWhenInUseUsageDescription and NSMotionUsageDescription
  to ensure high-accuracy GPS and motion sensor permissions

https://claude.ai/code/session_01YTz9jAdcg6ATnBMUkvpza1