### PR TITLE
fix: corrigir sobreposição do botão de menu e áreas pretas na foto de perfil

### DIFF
--- a/sunny_sales_web/src/components/ImageCropper.jsx
+++ b/sunny_sales_web/src/components/ImageCropper.jsx
@@ -6,7 +6,19 @@ export default function ImageCropper({ src, onCancel, onComplete }) {
   const imgRef = useRef(null);
   const containerSize = 300; // tamanho da área de corte
   const [scale, setScale] = useState(1);
+  const [minScale, setMinScale] = useState(0.1);
   const [position, setPosition] = useState({ x: 0, y: 0 });
+
+  const handleImageLoad = (e) => {
+    const img = e.target;
+    const computed = Math.max(containerSize / img.naturalWidth, containerSize / img.naturalHeight);
+    setMinScale(computed);
+    setScale(computed);
+    setPosition({
+      x: (containerSize - img.naturalWidth * computed) / 2,
+      y: (containerSize - img.naturalHeight * computed) / 2,
+    });
+  };
   const [dragging, setDragging] = useState(false);
   const lastPos = useRef({ x: 0, y: 0 });
 
@@ -78,14 +90,18 @@ export default function ImageCropper({ src, onCancel, onComplete }) {
             ref={imgRef}
             src={src}
             alt="crop"
-            style={{ transform: `translate(${position.x}px, ${position.y}px) scale(${scale})` }}
+            onLoad={handleImageLoad}
+            style={{
+              transform: `translate(${position.x}px, ${position.y}px) scale(${scale})`,
+              transformOrigin: '0 0',
+            }}
           />
         </div>
         <input
           type="range"
-          min="0.5"
-          max="2"
-          step="0.1"
+          min={minScale}
+          max={Math.max(3, minScale * 10)}
+          step={minScale / 10}
           value={scale}
           onChange={(e) => setScale(Number(e.target.value))}
         />

--- a/sunny_sales_web/src/pages/VendorDashboard.css
+++ b/sunny_sales_web/src/pages/VendorDashboard.css
@@ -8,10 +8,6 @@
 /* ── Menu toggle button ──────────────────────────────── */
 
 .vd-menu-toggle {
-  position: fixed;
-  top: calc(var(--navbar-h, 64px) + 14px);
-  left: 14px;
-  z-index: 1100;
   background: var(--primary);
   color: #fff;
   border: none;
@@ -26,6 +22,7 @@
   justify-content: center;
   box-shadow: var(--shadow-warm);
   cursor: pointer;
+  flex-shrink: 0;
   transition: background var(--transition), transform var(--transition), box-shadow var(--transition);
 }
 
@@ -178,6 +175,13 @@
   gap: 2px;
   padding: 4px 2px 0;
   animation: fadeIn 0.3s ease;
+}
+
+.vd-greeting-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
 }
 
 .vd-greeting-time {

--- a/sunny_sales_web/src/pages/VendorDashboard.jsx
+++ b/sunny_sales_web/src/pages/VendorDashboard.jsx
@@ -157,17 +157,6 @@ export default function VendorDashboard() {
 
   return (
     <div className="vd-wrapper">
-      {/* Side menu toggle */}
-      <button
-        ref={menuButtonRef}
-        className="vd-menu-toggle"
-        onClick={() => setMenuOpen((o) => !o)}
-        aria-label="Menu"
-        aria-expanded={menuOpen}
-      >
-        {menuOpen ? <FiX size={20} /> : <FiMenu size={20} />}
-      </button>
-
       {/* Side menu overlay */}
       {menuOpen && (
         <div className="vd-overlay" onClick={() => setMenuOpen(false)} aria-hidden="true" />
@@ -219,8 +208,21 @@ export default function VendorDashboard() {
         {/* Greeting */}
         {vendor && (
           <div className="vd-greeting">
-            <span className="vd-greeting-time">{getGreeting()},</span>
-            <h2 className="vd-greeting-name">{vendor.name.split(' ')[0]}</h2>
+            <div className="vd-greeting-row">
+              <div>
+                <span className="vd-greeting-time">{getGreeting()},</span>
+                <h2 className="vd-greeting-name">{vendor.name.split(' ')[0]}</h2>
+              </div>
+              <button
+                ref={menuButtonRef}
+                className="vd-menu-toggle"
+                onClick={() => setMenuOpen((o) => !o)}
+                aria-label="Menu"
+                aria-expanded={menuOpen}
+              >
+                {menuOpen ? <FiX size={20} /> : <FiMenu size={20} />}
+              </button>
+            </div>
           </div>
         )}
 


### PR DESCRIPTION
- Move o botão de menu de posição fixed para dentro da secção de
  saudação, eliminando a sobreposição com o texto "Boa tarde, Miguel"
- Corrige o ImageCropper: calcula escala mínima ao carregar a imagem
  para garantir que preenche sempre a área de corte (evita áreas pretas
  em JPEG), centra a imagem e corrige o transform-origin para '0 0'
  de forma consistente com a lógica de canvas

https://claude.ai/code/session_017udUMr7zjifE41ju4WkJuy