### PR TITLE
fix: prevent Leaflet zoom controls from overlapping mobile nav menu

### DIFF
--- a/sunny_sales_web/src/index.css
+++ b/sunny_sales_web/src/index.css
@@ -74,7 +74,7 @@ body {
   background: var(--navy);
   border-bottom: 1px solid rgba(255, 255, 255, 0.08);
   box-shadow: 0 2px 16px rgba(0, 0, 0, 0.25);
-  z-index: 1000;
+  z-index: 1100;
   gap: 16px;
 }
 
@@ -200,7 +200,7 @@ body {
   inset: 0;
   background: rgba(0,0,0,0.32);
   backdrop-filter: blur(4px);
-  z-index: 990;
+  z-index: 1040;
   opacity: 0;
   pointer-events: none;
   transition: opacity var(--transition-slow);
@@ -607,7 +607,7 @@ h2 {
     box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3);
     padding: 12px 16px 20px;
     gap: 4px;
-    z-index: 995;
+    z-index: 1050;
     animation: fadeIn 0.2s ease;
   }
 


### PR DESCRIPTION
Leaflet's control pane uses z-index 1000 by default, causing the +/-
zoom buttons to render on top of the mobile dropdown navigation.
Raise navbar to 1100, nav-links to 1050, and nav-overlay to 1040 so
the menu always appears above map controls on mobile.

https://claude.ai/code/session_01E9E1vRV2WnzvvvQYyHP99A