### PR TITLE
Update footer to Teal Ocean and add active states with white text

### DIFF
--- a/sunny_sales_web/src/components/Footer.css
+++ b/sunny_sales_web/src/components/Footer.css
@@ -6,7 +6,7 @@
   width: 100%;
   height: var(--footer-h, 44px);
   overflow: hidden;
-  background: var(--navy, #0f2744);
+  background: var(--primary, #0A9396);
   padding-bottom: env(safe-area-inset-bottom, 0px);
   border-top: 1px solid rgba(255, 255, 255, 0.08);
 }
@@ -29,7 +29,7 @@
 }
 
 .footer-icon {
-  color: var(--secondary, #EE9B00);
+  color: rgba(255, 255, 255, 0.9);
   flex-shrink: 0;
   opacity: 0.9;
 }

--- a/sunny_sales_web/src/pages/VendorDashboard.css
+++ b/sunny_sales_web/src/pages/VendorDashboard.css
@@ -125,6 +125,13 @@
   box-shadow: none;
 }
 
+.vd-menu-item:active {
+  background: var(--primary);
+  color: #fff;
+  transform: none;
+  box-shadow: none;
+}
+
 .vd-menu-item-label {
   flex: 1;
 }
@@ -148,6 +155,14 @@
 
 .vd-menu-item:hover .vd-menu-icon {
   color: var(--primary-dark);
+}
+
+.vd-menu-item:active .vd-menu-icon {
+  color: #fff;
+}
+
+.vd-menu-item:active .vd-menu-chevron {
+  color: rgba(255, 255, 255, 0.7);
 }
 
 .vd-menu-divider {
@@ -530,6 +545,14 @@
   background: var(--surface-warm);
 }
 
+.vd-quick-item:active {
+  background: var(--primary);
+  border-color: var(--primary);
+  color: #fff;
+  transform: translateY(0);
+  box-shadow: var(--shadow-sm);
+}
+
 .vd-quick-icon {
   width: 40px;
   height: 40px;
@@ -546,6 +569,15 @@
 
 .vd-quick-item:hover .vd-quick-icon {
   background: rgba(10, 147, 150, 0.22);
+}
+
+.vd-quick-item:active .vd-quick-icon {
+  background: rgba(255, 255, 255, 0.22);
+  color: #fff;
+}
+
+.vd-quick-item:active .vd-quick-label {
+  color: #fff;
 }
 
 .vd-quick-label {


### PR DESCRIPTION
- Footer background changed from navy (#0f2744) to Teal Ocean (#0A9396)
- Footer icon colour updated to white for contrast on teal background
- Dashboard quick-action cards get teal bg + white text on :active
- Hamburger menu items get teal bg + white text on :active

https://claude.ai/code/session_01LsdXrj2778dUbVdv95UMox