### PR TITLE
feat(map): replace filter sidebar with floating button + bottom sheet

### DIFF
--- a/sunny_sales_web/src/pages/ModernMapLayout.css
+++ b/sunny_sales_web/src/pages/ModernMapLayout.css
@@ -28,93 +28,6 @@ body {
   min-height: 480px;
 }
 
-/* ── Filters sidebar ──────────────────────────────────── */
-
-.filters {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  width: 224px;
-  min-width: 180px;
-  padding: 20px 16px;
-  flex-shrink: 0;
-  background: var(--navy);
-  border-right: 1px solid rgba(255, 255, 255, 0.06);
-}
-
-.filters-header {
-  display: flex;
-  align-items: center;
-  gap: 7px;
-  color: var(--primary);
-  font-size: 0.82rem;
-  font-weight: 800;
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
-  padding-bottom: 12px;
-  border-bottom: 2px solid var(--primary);
-  margin-bottom: 6px;
-}
-
-/* Filter list items */
-.filter-list-item {
-  display: flex;
-  align-items: center;
-  gap: 9px;
-  padding: 10px 12px;
-  border-radius: var(--radius-xs);
-  background: rgba(255, 255, 255, 0.06);
-  border: 1.5px solid rgba(255, 255, 255, 0.08);
-  color: rgba(255, 255, 255, 0.75);
-  font-size: 0.875rem;
-  font-weight: 600;
-  cursor: pointer;
-  transition: background var(--transition), border-color var(--transition), color var(--transition);
-  width: 100%;
-  text-align: left;
-  box-shadow: none;
-  min-height: auto;
-  white-space: nowrap;
-}
-
-.filter-list-item:hover:not(:disabled) {
-  background: rgba(255, 255, 255, 0.12);
-  color: #fff;
-  transform: none;
-  box-shadow: none;
-}
-
-.filter-list-item.active {
-  background: rgba(10, 147, 150, 0.18);
-  border-color: var(--primary);
-  color: var(--primary);
-}
-
-.filter-list-item.active:hover {
-  background: rgba(10, 147, 150, 0.26);
-  transform: none;
-  box-shadow: none;
-}
-
-.filter-list-icon {
-  flex-shrink: 0;
-  opacity: 0.85;
-}
-
-.filters-section-divider {
-  height: 1px;
-  background: rgba(255, 255, 255, 0.10);
-  margin: 10px 0 6px;
-  flex-shrink: 0;
-}
-
-.filter-distance-hint {
-  font-size: 0.72rem;
-  color: rgba(255, 255, 255, 0.45);
-  margin: 6px 2px 0;
-  line-height: 1.4;
-}
-
 /* ── Map area ─────────────────────────────────────────── */
 
 .map-area {
@@ -134,6 +47,321 @@ body {
 .leaflet-container {
   background: transparent;
   font-family: 'Inter', 'Roboto', sans-serif;
+}
+
+/* ── Filter FAB ───────────────────────────────────────── */
+
+.filter-fab {
+  position: absolute;
+  top: 14px;
+  left: 14px;
+  z-index: 500;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 10px 16px;
+  background: var(--surface);
+  border: 1.5px solid var(--border-strong);
+  border-radius: var(--radius-full);
+  color: var(--text);
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.12);
+  transition: background var(--transition), border-color var(--transition), color var(--transition), box-shadow var(--transition);
+  min-height: auto;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.filter-fab:hover {
+  background: var(--primary-light-solid);
+  border-color: var(--primary);
+  color: var(--primary);
+  box-shadow: var(--shadow-warm);
+}
+
+.filter-fab.has-filters {
+  background: var(--primary);
+  border-color: var(--primary);
+  color: white;
+}
+
+.filter-fab.has-filters:hover {
+  background: var(--primary-hover);
+  border-color: var(--primary-hover);
+  color: white;
+}
+
+/* ── Filter overlay ───────────────────────────────────── */
+
+.filter-overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 600;
+  background: rgba(0, 0, 0, 0.38);
+  display: flex;
+  align-items: flex-end;
+  animation: overlayFadeIn 0.2s ease;
+}
+
+@keyframes overlayFadeIn {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+/* ── Filter sheet ─────────────────────────────────────── */
+
+.filter-sheet {
+  width: 100%;
+  max-width: 480px;
+  margin: 0 auto;
+  background: var(--surface);
+  border-radius: var(--radius-xl) var(--radius-xl) 0 0;
+  overflow: hidden;
+  animation: sheetSlideUp 0.28s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+@keyframes sheetSlideUp {
+  from { transform: translateY(100%); }
+  to   { transform: translateY(0); }
+}
+
+.filter-sheet-handle {
+  width: 40px;
+  height: 4px;
+  background: var(--border-strong);
+  border-radius: 2px;
+  margin: 12px auto 0;
+  flex-shrink: 0;
+}
+
+.filter-sheet-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 20px 8px;
+}
+
+.filter-sheet-label {
+  font-size: 0.78rem;
+  font-weight: 700;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.filter-close-btn {
+  width: 28px;
+  height: 28px;
+  min-height: auto;
+  min-width: auto;
+  padding: 0;
+  background: var(--surface-alt);
+  border: none;
+  border-radius: var(--radius-full);
+  font-size: 1.15rem;
+  color: var(--text-secondary);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background var(--transition), color var(--transition);
+  line-height: 1;
+}
+
+.filter-close-btn:hover {
+  background: var(--primary-light);
+  color: var(--primary);
+  transform: none;
+  box-shadow: none;
+}
+
+/* ── Filter sections ──────────────────────────────────── */
+
+.filter-section {
+  padding: 4px 20px 16px;
+}
+
+.filter-section-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 10px;
+}
+
+.filter-section-title {
+  display: flex;
+  align-items: center;
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--text);
+}
+
+.filter-reset-link {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--primary);
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 2px 0;
+  min-height: auto;
+  min-width: auto;
+  transition: color var(--transition);
+}
+
+.filter-reset-link:hover {
+  color: var(--primary-hover);
+  transform: none;
+  box-shadow: none;
+}
+
+/* Product toggle options */
+.filter-option {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 12px 14px;
+  margin-bottom: 8px;
+  background: var(--surface-alt);
+  border: 1.5px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--text);
+  font-size: 0.9rem;
+  font-weight: 500;
+  cursor: pointer;
+  text-align: left;
+  transition: background var(--transition), border-color var(--transition), color var(--transition);
+  min-height: auto;
+}
+
+.filter-option:last-child {
+  margin-bottom: 0;
+}
+
+.filter-option:hover {
+  border-color: var(--primary);
+  background: var(--primary-light);
+  color: var(--primary);
+  transform: none;
+  box-shadow: none;
+}
+
+.filter-option.active {
+  background: var(--primary-light);
+  border-color: var(--primary);
+  color: var(--primary);
+}
+
+.filter-option-icon {
+  flex-shrink: 0;
+  opacity: 0.85;
+}
+
+.filter-check {
+  margin-left: auto;
+  flex-shrink: 0;
+}
+
+.filter-divider {
+  height: 1px;
+  background: var(--border);
+  margin: 0 20px 12px;
+}
+
+/* Distance pill options */
+.filter-distance-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.filter-distance-opt {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  padding: 9px 18px;
+  background: var(--surface-alt);
+  border: 1.5px solid var(--border);
+  border-radius: var(--radius-full);
+  color: var(--text);
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background var(--transition), border-color var(--transition), color var(--transition);
+  min-height: auto;
+}
+
+.filter-distance-opt:hover {
+  border-color: var(--primary);
+  background: var(--primary-light);
+  color: var(--primary);
+  transform: none;
+  box-shadow: none;
+}
+
+.filter-distance-opt.active {
+  background: var(--primary-light);
+  border-color: var(--primary);
+  color: var(--primary);
+}
+
+.filter-distance-hint {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  margin: 8px 0 0;
+  line-height: 1.4;
+}
+
+/* ── Filter sheet footer ──────────────────────────────── */
+
+.filter-sheet-footer {
+  display: flex;
+  gap: 12px;
+  padding: 14px 20px max(16px, env(safe-area-inset-bottom, 16px));
+  border-top: 1px solid var(--border);
+}
+
+.filter-reset-all-btn {
+  flex: 1;
+  padding: 13px 12px;
+  background: var(--primary-light);
+  border: 1.5px solid var(--primary);
+  border-radius: var(--radius-sm);
+  color: var(--primary);
+  font-size: 0.9rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: background var(--transition);
+  min-height: auto;
+}
+
+.filter-reset-all-btn:hover {
+  background: var(--primary-light-solid);
+  transform: none;
+  box-shadow: none;
+}
+
+.filter-apply-btn {
+  flex: 1.6;
+  padding: 13px 12px;
+  background: var(--primary);
+  border: 1.5px solid var(--primary);
+  border-radius: var(--radius-sm);
+  color: white;
+  font-size: 0.9rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: background var(--transition), border-color var(--transition);
+  min-height: auto;
+}
+
+.filter-apply-btn:hover {
+  background: var(--primary-hover);
+  border-color: var(--primary-hover);
+  transform: none;
+  box-shadow: none;
 }
 
 /* ── Vendor card popup ────────────────────────────────── */
@@ -365,47 +593,9 @@ body {
     border-radius: var(--radius-md);
   }
 
-  .filters {
-    width: 100%;
-    min-width: 0;
-    flex-direction: row;
-    flex-wrap: nowrap;
-    justify-content: flex-start;
-    overflow-x: auto;
-    -webkit-overflow-scrolling: touch;
-    scrollbar-width: none;
-    padding: 10px 14px;
-    gap: 4px;
-    border-right: none;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
-    align-items: center;
-  }
-
-  .filters::-webkit-scrollbar { display: none; }
-
-  .filters-header {
-    display: none;
-  }
-
-  .filter-list-item {
-    flex-shrink: 0;
-    width: auto;
-  }
-
-  .filters-section-divider {
-    width: 1px;
-    height: 28px;
-    margin: 0 4px;
-    align-self: center;
-  }
-
-  .filter-distance-hint {
-    display: none;
-  }
-
   .map-area {
     width: 100%;
-    height: calc(100svh - 200px);
+    height: calc(100svh - 160px);
     min-height: 300px;
   }
 
@@ -423,6 +613,10 @@ body {
     from { opacity: 0; transform: translateX(-50%) translateY(18px); }
     to   { opacity: 1; transform: translateX(-50%) translateY(0); }
   }
+
+  .filter-sheet {
+    max-width: 100%;
+  }
 }
 
 @media (max-width: 480px) {
@@ -430,9 +624,6 @@ body {
     width: calc(100% - 20px);
     max-width: none;
     bottom: 12px;
-  }
-  .filters {
-    padding: 8px 10px;
   }
 }
 

--- a/sunny_sales_web/src/pages/ModernMapLayout.jsx
+++ b/sunny_sales_web/src/pages/ModernMapLayout.jsx
@@ -7,7 +7,7 @@ import LocateButton from '../components/LocateButton';
 import VendorLocateButton from '../components/VendorLocateButton';
 import LocateHint from '../components/LocateHint';
 import BeachConditions from '../components/BeachConditions';
-import { FiUsers, FiSettings, FiGlobe, FiMapPin } from 'react-icons/fi';
+import { FiSettings, FiGlobe, FiMapPin, FiFilter, FiCheck } from 'react-icons/fi';
 import { GiIceCreamCone } from 'react-icons/gi';
 import './ModernMapLayout.css';
 
@@ -51,7 +51,6 @@ function getVendorPinHtml(color, heading) {
   return `<div class="vendor-location-marker"><div class="vendor-location-dot" style="background:${color}">${arrow}</div></div>`;
 }
 
-// Layout principal com mapa e lista de vendedores online
 export default function ModernMapLayout() {
   const [vendors, setVendors] = useState([]);
   const PRODUCTS = ['Bolas de Berlim', 'Gelados', 'Acessórios de Praia'];
@@ -59,19 +58,50 @@ export default function ModernMapLayout() {
   const [maxDistance, setMaxDistance] = useState(null);
   const [selected, setSelected] = useState(null);
 
+  const [filterOpen, setFilterOpen] = useState(false);
+  const [pendingProducts, setPendingProducts] = useState([...PRODUCTS]);
+  const [pendingDistance, setPendingDistance] = useState(null);
+
   const [clientPos, setClientPos] = useState(null);
   const [heading, setHeading] = useState(null);
   const lastHeadingTs = useRef(0);
   const smoothedHeadingRef = useRef(null);
-  const absEventFiredRef = useRef(false); // true quando deviceorientationabsolute disparou
-  const gpsMovingRef = useRef(false); // true quando GPS fornece heading válido
+  const absEventFiredRef = useRef(false);
+  const gpsMovingRef = useRef(false);
   const [compassReady, setCompassReady] = useState(false);
   const [showLocateHint, setShowLocateHint] = useState(false);
-  // Verifica se o utilizador autenticado é um vendedor. Se sim, ocultamos o
-  // pin de cliente para evitar marcadores duplicados no mapa.
   const isVendorLogged = !!localStorage.getItem('user');
 
   const mapRef = useRef(null);
+
+  // Active filter count: deselected products + distance set
+  const activeFilterCount =
+    (PRODUCTS.length - selectedProducts.length) + (maxDistance !== null ? 1 : 0);
+  const pendingFilterCount =
+    (PRODUCTS.length - pendingProducts.length) + (pendingDistance !== null ? 1 : 0);
+
+  const openFilters = () => {
+    setPendingProducts([...selectedProducts]);
+    setPendingDistance(maxDistance);
+    setFilterOpen(true);
+  };
+
+  const applyFilters = () => {
+    setSelectedProducts([...pendingProducts]);
+    setMaxDistance(pendingDistance);
+    setFilterOpen(false);
+  };
+
+  const resetPending = () => {
+    setPendingProducts([...PRODUCTS]);
+    setPendingDistance(null);
+  };
+
+  const togglePendingProduct = (p) => {
+    setPendingProducts((prev) =>
+      prev.includes(p) ? prev.filter((v) => v !== p) : [...prev, p]
+    );
+  };
 
   useEffect(() => {
     if (!isVendorLogged) {
@@ -106,11 +136,9 @@ export default function ModernMapLayout() {
   }, [isVendorLogged]);
 
   useEffect(() => {
-    // Constrói o URL do WebSocket substituindo http por ws
     const wsUrl = BASE_URL.replace(/^http/, 'ws') + '/ws/locations';
     const ws = new WebSocket(wsUrl);
 
-    // Recebe atualizações de localização em tempo real e atualiza o estado
     ws.onmessage = (event) => {
       const data = JSON.parse(event.data);
       setVendors((prev) => {
@@ -129,7 +157,6 @@ export default function ModernMapLayout() {
       });
     };
 
-    // Fecha a ligação quando o componente é desmontado
     return () => {
       ws.close();
     };
@@ -141,7 +168,6 @@ export default function ModernMapLayout() {
       (pos) => {
         setClientPos({ lat: pos.coords.latitude, lng: pos.coords.longitude });
         const gpsH = pos.coords.heading;
-        // GPS heading tem prioridade máxima quando o utilizador está em movimento
         if (gpsH != null && !isNaN(gpsH) && pos.coords.speed != null && pos.coords.speed > 0.3) {
           gpsMovingRef.current = true;
           smoothedHeadingRef.current = gpsH;
@@ -176,7 +202,6 @@ export default function ModernMapLayout() {
         const result = await DeviceOrientationEvent.requestPermission();
         if (result === 'granted') setCompassReady(true);
       } catch {
-        // Need a user gesture – attach a one-time touchstart listener
         touchListener = async () => {
           try {
             const r = await DeviceOrientationEvent.requestPermission();
@@ -199,9 +224,8 @@ export default function ModernMapLayout() {
   useEffect(() => {
     if (!compassReady) return;
     const THROTTLE_MS = 50;
-    // Low-pass filter para suavizar o heading da bússola e reduzir jitter
     const COMPASS_ALPHA = 0.25;
-    const MAX_ACCURACY_DEG = 25; // iOS webkitCompassAccuracy em graus
+    const MAX_ACCURACY_DEG = 25;
 
     const applySmoothing = (raw) => {
       const prev = smoothedHeadingRef.current;
@@ -217,7 +241,6 @@ export default function ModernMapLayout() {
       return next;
     };
 
-    // deviceorientationabsolute: fonte mais fiável em Android (valores absolutos)
     const onAbsolute = (e) => {
       if (gpsMovingRef.current) return;
       if (e.alpha == null) return;
@@ -229,14 +252,11 @@ export default function ModernMapLayout() {
       setHeading(applySmoothing(raw));
     };
 
-    // deviceorientation: iOS Safari (webkitCompassHeading) e fallback Android
     const onOrientation = (e) => {
       if (gpsMovingRef.current) return;
-      // Se deviceorientationabsolute já disparou, ignorar esta fonte (menos precisa)
       if (absEventFiredRef.current) return;
       const now = Date.now();
       if (now - lastHeadingTs.current < THROTTLE_MS) return;
-      // Filtrar leituras iOS com baixa precisão de bússola
       if (e.webkitCompassAccuracy != null && e.webkitCompassAccuracy >= 0 && e.webkitCompassAccuracy > MAX_ACCURACY_DEG) return;
       lastHeadingTs.current = now;
       if (e.webkitCompassHeading != null) {
@@ -265,11 +285,9 @@ export default function ModernMapLayout() {
       const stored = localStorage.getItem('user');
       if (stored) {
         const { id } = JSON.parse(stored);
-
         const vendorId = Number(id);
         loggedVendor =
           activeVendors.find((v) => Number(v.id) === vendorId) || null;
-
       }
     } catch (e) {
       console.error('Erro ao ler vendedor logado:', e);
@@ -293,14 +311,6 @@ export default function ModernMapLayout() {
     });
   }
 
-  // Alterna a seleção de um produto no filtro
-  const toggleProduct = (p) => {
-    setSelectedProducts((prev) =>
-      prev.includes(p) ? prev.filter((v) => v !== p) : [...prev, p]
-    );
-  };
-
-  // Centraliza o mapa no vendedor selecionado
   const focusVendor = (v) => {
     setSelected(v);
     if (mapRef.current) {
@@ -312,145 +322,202 @@ export default function ModernMapLayout() {
   return (
     <div className="modern-layout">
       <div className="map-wrapper">
-        {!isVendorLogged && (
-          <div className="filters">
-            <div className="filters-header">
-              <FiUsers size={15} />
-              VENDEDORES
-            </div>
-            {PRODUCTS.map((p) => {
-              const Icon = PRODUCT_ICONS[p];
-              const active = selectedProducts.includes(p);
+        <main className="map-area">
+          <MapContainer
+            ref={mapRef}
+            center={[38.7169, -9.1399]}
+            zoom={13}
+            className="map-container"
+          >
+            <TileLayer
+              url="https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png"
+              attribution="&copy; <a href='https://openstreetmap.org'>OpenStreetMap</a> contributors &copy; <a href='https://carto.com/attributions'>CARTO</a>"
+              subdomains="abcd"
+              maxZoom={19}
+            />
+            {!isVendorLogged && clientPos && (
+              <Marker
+                position={[clientPos.lat, clientPos.lng]}
+                icon={L.divIcon({
+                  className: 'client-pin',
+                  html: getClientPinHtml(heading),
+                  iconSize: [50, 50],
+                  iconAnchor: [25, 25],
+                })}
+              >
+                <Popup>Você está aqui</Popup>
+              </Marker>
+            )}
+            {filteredVendors.map((v) => {
+              const isOwn = loggedVendor && Number(v.id) === Number(loggedVendor.id);
+              const pinColor = v.pin_color || '#FFB6C1';
               return (
-                <button
-                  key={p}
-                  className={`filter-list-item${active ? ' active' : ''}`}
-                  onClick={() => toggleProduct(p)}
-                >
-                  {Icon && <Icon size={15} className="filter-list-icon" />}
-                  <span>{p}</span>
-                </button>
+                <Marker
+                  key={v.id}
+                  position={[v.current_lat, v.current_lng]}
+                  icon={L.divIcon({
+                    className: isOwn ? 'vendor-own-pin' : 'vendor-pin',
+                    html: isOwn
+                      ? getVendorPinHtml(pinColor, heading)
+                      : `<div style="background:${pinColor};width:16px;height:16px;border-radius:50%;"></div>`,
+                    iconSize: isOwn ? [50, 50] : [16, 16],
+                    iconAnchor: isOwn ? [25, 25] : [8, 8],
+                  })}
+                  eventHandlers={{
+                    click: () => focusVendor(v),
+                  }}
+                />
               );
             })}
 
-            <div className="filters-section-divider" />
-
-            <div className="filters-header">
-              <FiMapPin size={15} />
-              DISTÂNCIA
-            </div>
-            {DISTANCE_OPTIONS.map((opt) => (
-              <button
-                key={opt.label}
-                className={`filter-list-item${maxDistance === opt.value ? ' active' : ''}`}
-                onClick={() => setMaxDistance(opt.value)}
-              >
-                <span>{opt.label}</span>
-              </button>
-            ))}
-            {maxDistance !== null && !clientPos && (
-              <p className="filter-distance-hint">
-                Ative a localização para filtrar por distância
-              </p>
+            {!isVendorLogged && (
+              <>
+                <LocateButton
+                  onLocationFound={setClientPos}
+                  onClick={() => setShowLocateHint(false)}
+                />
+                {showLocateHint && (
+                  <LocateHint onClose={() => setShowLocateHint(false)} />
+                )}
+              </>
             )}
-          </div>
-        )}
 
-        <main className="map-area">
-        <MapContainer
-          ref={mapRef}
-          center={[38.7169, -9.1399]}
-          zoom={13}
-          className="map-container"
-        >
-          <TileLayer
-            url="https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png"
-            attribution="&copy; <a href='https://openstreetmap.org'>OpenStreetMap</a> contributors &copy; <a href='https://carto.com/attributions'>CARTO</a>"
-            subdomains="abcd"
-            maxZoom={19}
-          />
-          {!isVendorLogged && clientPos && (
-            <Marker
-              position={[clientPos.lat, clientPos.lng]}
-              icon={L.divIcon({
-                className: 'client-pin',
-                html: getClientPinHtml(heading),
-                iconSize: [50, 50],
-                iconAnchor: [25, 25],
-              })}
-            >
-              <Popup>Você está aqui</Popup>
-            </Marker>
-          )}
-          {filteredVendors.map((v) => {
-            const isOwn = loggedVendor && Number(v.id) === Number(loggedVendor.id);
-            const pinColor = v.pin_color || '#FFB6C1';
-            return (
-              <Marker
-                key={v.id}
-                position={[v.current_lat, v.current_lng]}
-                icon={L.divIcon({
-                  className: isOwn ? 'vendor-own-pin' : 'vendor-pin',
-                  html: isOwn
-                    ? getVendorPinHtml(pinColor, heading)
-                    : `<div style="background:${pinColor};width:16px;height:16px;border-radius:50%;"></div>`,
-                  iconSize: isOwn ? [50, 50] : [16, 16],
-                  iconAnchor: isOwn ? [25, 25] : [8, 8],
-                })}
-                eventHandlers={{
-                  click: () => focusVendor(v),
-                }}
-              />
-            );
-          })}
+            {isVendorLogged && loggedVendor && (
+              <VendorLocateButton vendor={loggedVendor} />
+            )}
+          </MapContainer>
 
+          {/* Floating filter button */}
           {!isVendorLogged && (
-            <>
-              <LocateButton
-                onLocationFound={setClientPos}
-                onClick={() => setShowLocateHint(false)}
-              />
-              {showLocateHint && (
-                <LocateHint onClose={() => setShowLocateHint(false)} />
-              )}
-            </>
-          )}
-
-
-          {isVendorLogged && loggedVendor && (
-            <VendorLocateButton vendor={loggedVendor} />
-          )}
-
-
-        </MapContainer>
-
-        {selected && (
-          <div className="vendor-card">
             <button
-              className="close-btn"
-              onClick={() => setSelected(null)}
-              aria-label="Fechar"
+              className={`filter-fab${activeFilterCount > 0 ? ' has-filters' : ''}`}
+              onClick={openFilters}
+              aria-label="Abrir filtros"
             >
-              ×
+              <FiFilter size={16} />
+              <span>Filtrar{activeFilterCount > 0 ? ` (${activeFilterCount})` : ''}</span>
             </button>
-            {selected.profile_photo ? (
-              <img
-                src={`${BASE_URL}/${selected.profile_photo}`}
-                alt={selected.name}
-                className="card-photo"
-              />
-            ) : (
-              <div
-                className="card-photo"
-                style={{ background: selected.pin_color || '#ccc' }}
-              />
-            )}
-            <h4 className="card-name">{selected.name}</h4>
-          </div>
-        )}
-      </main>
+          )}
+
+          {/* Filter bottom sheet */}
+          {filterOpen && !isVendorLogged && (
+            <div className="filter-overlay" onClick={() => setFilterOpen(false)}>
+              <div className="filter-sheet" onClick={(e) => e.stopPropagation()}>
+                <div className="filter-sheet-handle" />
+                <div className="filter-sheet-header">
+                  <span className="filter-sheet-label">Filtrar por:</span>
+                  <button
+                    className="filter-close-btn"
+                    onClick={() => setFilterOpen(false)}
+                    aria-label="Fechar"
+                  >
+                    ×
+                  </button>
+                </div>
+
+                {/* Products section */}
+                <div className="filter-section">
+                  <div className="filter-section-row">
+                    <span className="filter-section-title">Vendedores</span>
+                    <button
+                      className="filter-reset-link"
+                      onClick={() => setPendingProducts([...PRODUCTS])}
+                    >
+                      Repor
+                    </button>
+                  </div>
+                  {PRODUCTS.map((p) => {
+                    const Icon = PRODUCT_ICONS[p];
+                    const active = pendingProducts.includes(p);
+                    return (
+                      <button
+                        key={p}
+                        className={`filter-option${active ? ' active' : ''}`}
+                        onClick={() => togglePendingProduct(p)}
+                      >
+                        {Icon && <Icon size={16} className="filter-option-icon" />}
+                        <span>{p}</span>
+                        {active && <FiCheck size={14} className="filter-check" />}
+                      </button>
+                    );
+                  })}
+                </div>
+
+                <div className="filter-divider" />
+
+                {/* Distance section */}
+                <div className="filter-section">
+                  <div className="filter-section-row">
+                    <span className="filter-section-title">
+                      <FiMapPin size={14} style={{ marginRight: 6 }} />
+                      Distância
+                    </span>
+                    <button
+                      className="filter-reset-link"
+                      onClick={() => setPendingDistance(null)}
+                    >
+                      Repor
+                    </button>
+                  </div>
+                  <div className="filter-distance-row">
+                    {DISTANCE_OPTIONS.map((opt) => (
+                      <button
+                        key={opt.label}
+                        className={`filter-distance-opt${pendingDistance === opt.value ? ' active' : ''}`}
+                        onClick={() => setPendingDistance(opt.value)}
+                      >
+                        {pendingDistance === opt.value && <FiCheck size={12} />}
+                        {opt.label}
+                      </button>
+                    ))}
+                  </div>
+                  {pendingDistance !== null && !clientPos && (
+                    <p className="filter-distance-hint">
+                      Ative a localização para filtrar por distância
+                    </p>
+                  )}
+                </div>
+
+                {/* Footer */}
+                <div className="filter-sheet-footer">
+                  <button className="filter-reset-all-btn" onClick={resetPending}>
+                    Repor Tudo
+                  </button>
+                  <button className="filter-apply-btn" onClick={applyFilters}>
+                    Aplicar Filtros{pendingFilterCount > 0 ? ` (${pendingFilterCount})` : ''}
+                  </button>
+                </div>
+              </div>
+            </div>
+          )}
+
+          {selected && (
+            <div className="vendor-card">
+              <button
+                className="close-btn"
+                onClick={() => setSelected(null)}
+                aria-label="Fechar"
+              >
+                ×
+              </button>
+              {selected.profile_photo ? (
+                <img
+                  src={`${BASE_URL}/${selected.profile_photo}`}
+                  alt={selected.name}
+                  className="card-photo"
+                />
+              ) : (
+                <div
+                  className="card-photo"
+                  style={{ background: selected.pin_color || '#ccc' }}
+                />
+              )}
+              <h4 className="card-name">{selected.name}</h4>
+            </div>
+          )}
+        </main>
+      </div>
+      <BeachConditions />
     </div>
-    <BeachConditions />
-  </div>
   );
 }


### PR DESCRIPTION
The vendor/distance filter sidebar is replaced by a floating "Filtrar"
button on the map that opens a slide-up bottom sheet panel. The panel
shows Vendedores toggles and Distância pill buttons, with individual
Reset and a footer with Repor Tudo / Aplicar Filtros(N). Filters only
apply when the user taps the apply button. Active filter count is shown
on the FAB badge using the site's teal theme (#0A9396).

https://claude.ai/code/session_011hxNzbHXHPoaQXrmfr6wUY