### PR TITLE
Fix map filter button position, z-index layering, and selected filter text color

### DIFF
--- a/sunny_sales_web/src/pages/ModernMapLayout.css
+++ b/sunny_sales_web/src/pages/ModernMapLayout.css
@@ -54,8 +54,8 @@ body {
 .filter-fab {
   position: absolute;
   top: 14px;
-  left: 14px;
-  z-index: 500;
+  right: 14px;
+  z-index: 900;
   display: flex;
   align-items: center;
   gap: 7px;
@@ -97,7 +97,7 @@ body {
 .filter-overlay {
   position: absolute;
   inset: 0;
-  z-index: 600;
+  z-index: 950;
   background: rgba(0, 0, 0, 0.38);
   display: flex;
   align-items: flex-end;
@@ -249,9 +249,9 @@ body {
 }
 
 .filter-option.active {
-  background: var(--primary-light);
+  background: var(--primary);
   border-color: var(--primary);
-  color: var(--primary);
+  color: white;
 }
 
 .filter-option-icon {
@@ -302,9 +302,9 @@ body {
 }
 
 .filter-distance-opt.active {
-  background: var(--primary-light);
+  background: var(--primary);
   border-color: var(--primary);
-  color: var(--primary);
+  color: white;
 }
 
 .filter-distance-hint {


### PR DESCRIPTION
- Move filter FAB button from top-left to top-right of the map
- Raise filter overlay z-index (600→950) so it renders above Leaflet zoom controls (z-index 800) and attribution bar
- Raise filter FAB z-index (500→900) to stay above Leaflet controls when overlay is closed
- Selected vendor/distance filter options now use solid primary background with white text instead of light teal

https://claude.ai/code/session_019CC1BsT5wD8JWjWN2V7byh