### PR TITLE
Fix filter menu z-index and product selection UX

### DIFF
--- a/sunny_sales_web/src/pages/ModernMapLayout.css
+++ b/sunny_sales_web/src/pages/ModernMapLayout.css
@@ -97,7 +97,7 @@ body {
 .filter-overlay {
   position: absolute;
   inset: 0;
-  z-index: 950;
+  z-index: 1200;
   background: rgba(0, 0, 0, 0.38);
   display: flex;
   align-items: flex-end;

--- a/sunny_sales_web/src/pages/ModernMapLayout.jsx
+++ b/sunny_sales_web/src/pages/ModernMapLayout.jsx
@@ -54,12 +54,12 @@ function getVendorPinHtml(color, heading) {
 export default function ModernMapLayout() {
   const [vendors, setVendors] = useState([]);
   const PRODUCTS = ['Bolas de Berlim', 'Gelados', 'Acessórios de Praia'];
-  const [selectedProducts, setSelectedProducts] = useState([...PRODUCTS]);
+  const [selectedProducts, setSelectedProducts] = useState([]);
   const [maxDistance, setMaxDistance] = useState(null);
   const [selected, setSelected] = useState(null);
 
   const [filterOpen, setFilterOpen] = useState(false);
-  const [pendingProducts, setPendingProducts] = useState([...PRODUCTS]);
+  const [pendingProducts, setPendingProducts] = useState([]);
   const [pendingDistance, setPendingDistance] = useState(null);
 
   const [clientPos, setClientPos] = useState(null);
@@ -74,11 +74,11 @@ export default function ModernMapLayout() {
 
   const mapRef = useRef(null);
 
-  // Active filter count: deselected products + distance set
+  // Active filter count: selected products + distance set
   const activeFilterCount =
-    (PRODUCTS.length - selectedProducts.length) + (maxDistance !== null ? 1 : 0);
+    selectedProducts.length + (maxDistance !== null ? 1 : 0);
   const pendingFilterCount =
-    (PRODUCTS.length - pendingProducts.length) + (pendingDistance !== null ? 1 : 0);
+    pendingProducts.length + (pendingDistance !== null ? 1 : 0);
 
   const openFilters = () => {
     setPendingProducts([...selectedProducts]);
@@ -93,7 +93,7 @@ export default function ModernMapLayout() {
   };
 
   const resetPending = () => {
-    setPendingProducts([...PRODUCTS]);
+    setPendingProducts([]);
     setPendingDistance(null);
   };
 
@@ -299,7 +299,7 @@ export default function ModernMapLayout() {
     filteredVendors = loggedVendor ? [loggedVendor] : [];
   } else {
     filteredVendors = activeVendors.filter((v) => {
-      if (!selectedProducts.includes(v.product)) return false;
+      if (selectedProducts.length > 0 && !selectedProducts.includes(v.product)) return false;
       if (maxDistance !== null && clientPos) {
         const dist = haversineDistance(
           clientPos.lat, clientPos.lng,
@@ -421,7 +421,7 @@ export default function ModernMapLayout() {
                     <span className="filter-section-title">Vendedores</span>
                     <button
                       className="filter-reset-link"
-                      onClick={() => setPendingProducts([...PRODUCTS])}
+                      onClick={() => setPendingProducts([])}
                     >
                       Repor
                     </button>


### PR DESCRIPTION
- Raise filter-overlay z-index from 950 to 1200 so it covers Leaflet zoom
  controls and attribution text (Leaflet sets its controls to z-index 1000)
- Change product filter to empty-selection = show-all model: items start
  unselected (white) and the user clicks to include specific types; previously
  all items defaulted to selected (blue) which confused users into thinking
  they had actively chosen a type they hadn't touched

https://claude.ai/code/session_01LTpUtb63rMPb81LjM89ePK