### PR TITLE
Fix map button alignment: override main padding and use flex for Leaflet container height

### DIFF
--- a/sunny_sales_web/src/pages/ModernMapLayout.css
+++ b/sunny_sales_web/src/pages/ModernMapLayout.css
@@ -35,11 +35,16 @@ body {
   flex: 1;
   height: 70vh;
   min-height: 380px;
+  padding: 0;
+  text-align: left;
+  display: flex;
+  flex-direction: column;
 }
 
 .map-container {
+  flex: 1;
+  min-height: 0;
   width: 100%;
-  height: 100%;
   border-radius: 0;
   background: transparent;
 }


### PR DESCRIPTION
The global CSS rule `main { padding: 2rem }` in index.css was applying
32px of padding to <main className="map-area">, which caused the Leaflet
container to be inset 32px from the map edges. This misaligned the zoom
controls (positioned relative to the Leaflet container) by 32px below
the filter button (positioned relative to .map-area).

Fix .map-area with padding: 0 and display: flex/flex-direction: column,
and .map-container with flex: 1 / min-height: 0 instead of height: 100%,
which was fragile in flex contexts and gave height: 0 in some browsers.

https://claude.ai/code/session_01H9TKi1uiyGNRBW5GSK42WP