### PR TITLE
Improve visual design and content of SobreProjeto, Sustentabilidade, and ImplementarScreen pages

### DIFF
--- a/sunny_sales_web/src/pages/ImplementarScreen.jsx
+++ b/sunny_sales_web/src/pages/ImplementarScreen.jsx
@@ -6,22 +6,40 @@ export default function ImplementarScreen() {
   return (
     <div className="info-page">
       <BackHomeButton />
-      <h2 className="info-page-title">Implementação do Sunny Sales</h2>
-      <p className="info-page-lead">
-        Uma solução tecnológica para <strong>autarquias, juntas de freguesia e entidades
-        gestoras do litoral</strong> que pretendem modernizar a experiência balnear.
-      </p>
+
+      <div className="info-hero">
+        <span className="info-hero-icon">🏛️</span>
+        <h1 className="info-hero-title">Implementação do Sunny Sales</h1>
+        <p className="info-hero-lead">
+          Uma solução tecnológica pronta a usar para <strong>autarquias, juntas de freguesia
+          e entidades gestoras do litoral</strong> que pretendem modernizar a experiência
+          balnear.
+        </p>
+      </div>
+
+      <div className="info-badges">
+        <div className="info-badge">
+          <span className="info-badge-value">⚡</span> Implementação rápida
+        </div>
+        <div className="info-badge">
+          <span className="info-badge-value">📊</span> Estatísticas incluídas
+        </div>
+        <div className="info-badge">
+          <span className="info-badge-value">🔗</span> Acesso via QR Code
+        </div>
+      </div>
 
       <div className="info-cards">
         <div className="info-card accent">
           <span className="info-card-icon">🏛️</span>
           <h3 className="info-card-title">Vantagens para a Autarquia</h3>
           <ul className="info-card-list">
-            <li>Organização da atividade ambulante.</li>
-            <li>Promoção do comércio local e sustentável.</li>
-            <li>Melhoria da experiência dos veraneantes.</li>
-            <li>Redução da circulação desnecessária.</li>
-            <li>Reforço da imagem de inovação.</li>
+            <li>Organização eficiente da atividade ambulante</li>
+            <li>Promoção do comércio local e sustentável</li>
+            <li>Melhoria clara da experiência dos veraneantes</li>
+            <li>Redução da circulação desnecessária na praia</li>
+            <li>Reforço da imagem de inovação e modernidade</li>
+            <li>Dados e estatísticas de utilização em tempo real</li>
           </ul>
         </div>
 
@@ -29,28 +47,59 @@ export default function ImplementarScreen() {
           <span className="info-card-icon">🗺️</span>
           <h3 className="info-card-title">Recursos Disponibilizados</h3>
           <ul className="info-card-list">
-            <li>Mapa digital com vendedores em tempo real.</li>
-            <li>Filtros por tipo de produto.</li>
-            <li>Acesso via QR Code.</li>
-            <li>Página personalizada por localidade.</li>
-            <li>Estatísticas de utilização.</li>
+            <li>Mapa digital interativo com vendedores em tempo real</li>
+            <li>Filtros por tipo de produto e categorias</li>
+            <li>Acesso imediato via QR Code sem instalação</li>
+            <li>Página personalizada por localidade ou praia</li>
+            <li>Dashboard com estatísticas de utilização</li>
+            <li>Suporte técnico e atualizações contínuas</li>
           </ul>
         </div>
       </div>
 
       <div className="info-section">
         <h3 className="info-section-title">Processo de Implementação</h3>
-        <ul className="info-list">
-          <li data-bullet="1">Envie um e-mail para <strong>suporte@sunnysales.com</strong>.</li>
-          <li data-bullet="2">Agendaremos uma demonstração breve, presencial ou online.</li>
-          <li data-bullet="3">Em poucos dias, a praia pode ser integrada no sistema.</li>
+        <ul className="info-timeline">
+          <li>
+            <div className="info-timeline-number">1</div>
+            <div className="info-timeline-body">
+              <strong>Contacto inicial</strong> — Envie um e-mail para{' '}
+              <a
+                href="mailto:suporte@sunnysales.com"
+                style={{ color: 'var(--primary)', fontWeight: 600 }}
+              >
+                suporte@sunnysales.com
+              </a>{' '}
+              com o nome da praia e município.
+            </div>
+          </li>
+          <li>
+            <div className="info-timeline-number">2</div>
+            <div className="info-timeline-body">
+              <strong>Demonstração</strong> — Agendaremos uma apresentação breve, presencial
+              ou online, adaptada à realidade da vossa praia e necessidades locais.
+            </div>
+          </li>
+          <li>
+            <div className="info-timeline-number">3</div>
+            <div className="info-timeline-body">
+              <strong>Integração</strong> — Em poucos dias, a praia fica integrada no sistema,
+              com QR Codes e acesso configurado para os vendedores locais.
+            </div>
+          </li>
         </ul>
       </div>
 
-      <p className="info-footer-text">
-        <strong>Estamos disponíveis para parcerias, protocolos institucionais e ações conjuntas.</strong>
-        <br />Participe na transformação digital das praias portuguesas.
-      </p>
+      <div className="info-cta">
+        <div className="info-cta-title">Pronto para modernizar a sua praia?</div>
+        <p className="info-cta-text">
+          Estamos disponíveis para parcerias, protocolos institucionais e ações conjuntas.<br />
+          Faça parte da transformação digital das praias portuguesas.
+        </p>
+        <a href="mailto:suporte@sunnysales.com" className="info-cta-btn">
+          ✉️&nbsp; Entrar em contacto
+        </a>
+      </div>
     </div>
   );
 }

--- a/sunny_sales_web/src/pages/InfoPage.css
+++ b/sunny_sales_web/src/pages/InfoPage.css
@@ -6,6 +6,378 @@
   font-family: 'Inter', 'Roboto', sans-serif;
 }
 
+/* ── Hero ──────────────────────────────────────────────── */
+.info-hero {
+  background: linear-gradient(135deg, var(--primary) 0%, var(--primary-dark) 100%);
+  border-radius: var(--radius-xl);
+  padding: 36px 28px 32px;
+  margin-bottom: 1.75rem;
+  color: white;
+  text-align: center;
+  position: relative;
+  overflow: hidden;
+}
+
+.info-hero::before {
+  content: '';
+  position: absolute;
+  top: -60px;
+  right: -60px;
+  width: 220px;
+  height: 220px;
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: 50%;
+  pointer-events: none;
+}
+
+.info-hero::after {
+  content: '';
+  position: absolute;
+  bottom: -80px;
+  left: -40px;
+  width: 200px;
+  height: 200px;
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 50%;
+  pointer-events: none;
+}
+
+.info-hero.green {
+  background: linear-gradient(135deg, #2d6a4f 0%, #1b4332 100%);
+}
+
+.info-hero-icon {
+  font-size: 2.8rem;
+  display: block;
+  margin-bottom: 12px;
+  position: relative;
+  z-index: 1;
+}
+
+.info-hero-title {
+  font-size: clamp(1.55rem, 5vw, 2.3rem);
+  font-weight: 800;
+  margin: 0 0 10px;
+  color: white;
+  letter-spacing: -0.5px;
+  position: relative;
+  z-index: 1;
+}
+
+.info-hero-lead {
+  font-size: 0.975rem;
+  opacity: 0.9;
+  max-width: 530px;
+  margin: 0 auto;
+  line-height: 1.65;
+  position: relative;
+  z-index: 1;
+}
+
+/* ── Badges row ────────────────────────────────────────── */
+.info-badges {
+  display: flex;
+  gap: 10px;
+  justify-content: center;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.info-badge {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-full);
+  padding: 7px 16px;
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  box-shadow: var(--shadow-sm);
+  font-size: 0.82rem;
+  color: var(--text-secondary);
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+.info-badge-value {
+  font-size: 0.95rem;
+  font-weight: 800;
+  color: var(--primary);
+}
+
+/* ── Cards grid ────────────────────────────────────────── */
+.info-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 16px;
+  margin-bottom: 2rem;
+}
+
+.info-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-top: 3px solid transparent;
+  border-radius: var(--radius-xl);
+  padding: 24px 20px;
+  box-shadow: var(--shadow-sm);
+  transition: box-shadow var(--transition), transform var(--transition),
+    border-top-color var(--transition);
+}
+
+.info-card:hover {
+  box-shadow: var(--shadow-warm);
+  transform: translateY(-3px);
+  border-top-color: var(--primary);
+}
+
+.info-card-icon {
+  font-size: 1.5rem;
+  margin-bottom: 14px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 50px;
+  height: 50px;
+  background: var(--primary-light);
+  border-radius: var(--radius-md);
+  flex-shrink: 0;
+}
+
+.info-card-title {
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--text);
+  margin: 0 0 10px;
+}
+
+.info-card-text {
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+  line-height: 1.65;
+  margin: 0;
+}
+
+.info-card-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.info-card-list li {
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+  line-height: 1.5;
+  padding-left: 20px;
+  position: relative;
+}
+
+.info-card-list li::before {
+  content: '✓';
+  position: absolute;
+  left: 0;
+  color: var(--primary);
+  font-weight: 700;
+  font-size: 0.8rem;
+}
+
+/* Accent card */
+.info-card.accent {
+  background: var(--primary-light-solid);
+  border-color: rgba(10, 147, 150, 0.25);
+  border-top-color: transparent;
+}
+
+.info-card.accent:hover {
+  border-top-color: var(--primary);
+}
+
+/* ── Section blocks ────────────────────────────────────── */
+.info-section {
+  margin-bottom: 2rem;
+}
+
+.info-section-title {
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: var(--text);
+  margin: 0 0 14px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.info-section-title::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: var(--border);
+}
+
+.info-text {
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+  line-height: 1.7;
+  margin-bottom: 12px;
+}
+
+/* ── Standard list ─────────────────────────────────────── */
+.info-list {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.info-list li {
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+  padding: 10px 14px 10px 42px;
+  border-radius: var(--radius-md);
+  background: var(--surface-alt);
+  border: 1px solid var(--border);
+  position: relative;
+  line-height: 1.5;
+}
+
+.info-list li::before {
+  content: attr(data-bullet);
+  position: absolute;
+  left: 14px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--primary);
+  font-weight: 700;
+}
+
+/* ── Timeline (numbered steps) ─────────────────────────── */
+.info-timeline {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  position: relative;
+}
+
+.info-timeline::before {
+  content: '';
+  position: absolute;
+  left: 19px;
+  top: 44px;
+  bottom: 20px;
+  width: 2px;
+  background: linear-gradient(to bottom, var(--primary), rgba(10, 147, 150, 0.08));
+  z-index: 0;
+}
+
+.info-timeline li {
+  display: flex;
+  gap: 16px;
+  align-items: flex-start;
+  position: relative;
+}
+
+.info-timeline-number {
+  width: 40px;
+  height: 40px;
+  min-width: 40px;
+  border-radius: 50%;
+  background: var(--primary);
+  color: white;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 800;
+  font-size: 0.95rem;
+  z-index: 1;
+  box-shadow: 0 2px 10px rgba(10, 147, 150, 0.35);
+  flex-shrink: 0;
+}
+
+.info-timeline-body {
+  flex: 1;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: 12px 16px;
+  box-shadow: var(--shadow-xs);
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+  line-height: 1.55;
+  min-height: 40px;
+  display: flex;
+  align-items: center;
+}
+
+/* ── CTA block ─────────────────────────────────────────── */
+.info-cta {
+  background: linear-gradient(135deg, var(--navy) 0%, var(--navy-light) 100%);
+  border-radius: var(--radius-xl);
+  padding: 32px 28px;
+  text-align: center;
+  color: white;
+  margin-top: 1.5rem;
+}
+
+.info-cta-title {
+  font-size: 1.15rem;
+  font-weight: 700;
+  margin: 0 0 8px;
+  color: white;
+}
+
+.info-cta-text {
+  font-size: 0.9rem;
+  opacity: 0.78;
+  margin: 0 0 20px;
+  line-height: 1.65;
+}
+
+.info-cta-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  background: var(--secondary);
+  color: white;
+  font-weight: 700;
+  font-size: 0.95rem;
+  padding: 12px 26px;
+  border-radius: var(--radius-full);
+  text-decoration: none;
+  border: none;
+  cursor: pointer;
+  transition: background var(--transition), transform var(--transition),
+    box-shadow var(--transition);
+  box-shadow: 0 4px 16px rgba(238, 155, 0, 0.4);
+  min-height: auto;
+}
+
+.info-cta-btn:hover {
+  background: var(--secondary-hover);
+  transform: translateY(-2px);
+  box-shadow: 0 6px 24px rgba(238, 155, 0, 0.5);
+}
+
+/* ── Footer text ───────────────────────────────────────── */
+.info-footer-text {
+  text-align: center;
+  font-size: 0.95rem;
+  color: var(--text-secondary);
+  background: var(--surface-warm);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 18px 24px;
+  margin-top: 1rem;
+  font-style: italic;
+  line-height: 1.65;
+}
+
+/* ── Legacy title/lead (kept for compatibility) ────────── */
 .info-page-title {
   font-size: clamp(1.5rem, 5vw, 2.2rem);
   font-weight: 800;
@@ -26,154 +398,38 @@
   line-height: 1.6;
 }
 
-/* Cards grid */
-.info-cards {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-  gap: 18px;
-  margin-bottom: 2rem;
-}
-
-.info-card {
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-xl);
-  padding: 22px 20px;
-  box-shadow: var(--shadow-sm);
-  transition: box-shadow var(--transition), transform var(--transition);
-}
-
-.info-card:hover {
-  box-shadow: var(--shadow-warm);
-  transform: translateY(-2px);
-}
-
-.info-card-icon {
-  font-size: 2rem;
-  margin-bottom: 10px;
-  display: block;
-}
-
-.info-card-title {
-  font-size: 1rem;
-  font-weight: 700;
-  color: var(--text);
-  margin: 0 0 10px;
-}
-
-.info-card-text {
-  font-size: 0.875rem;
-  color: var(--text-secondary);
-  line-height: 1.6;
-  margin: 0;
-}
-
-.info-card-list {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-
-.info-card-list li {
-  font-size: 0.875rem;
-  color: var(--text-secondary);
-  line-height: 1.5;
-  padding-left: 18px;
-  position: relative;
-}
-
-.info-card-list li::before {
-  content: '✓';
-  position: absolute;
-  left: 0;
-  color: var(--primary);
-  font-weight: 700;
-  font-size: 0.8rem;
-}
-
-/* Accent card */
-.info-card.accent {
-  background: var(--primary-light-solid);
-  border-color: rgba(10, 147, 150, 0.3);
-}
-
-/* Section blocks */
-.info-section {
-  margin-bottom: 2rem;
-}
-
-.info-section-title {
-  font-size: 1.05rem;
-  font-weight: 700;
-  color: var(--text);
-  margin: 0 0 12px;
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
-.info-section-title::after {
-  content: '';
-  flex: 1;
-  height: 1px;
-  background: var(--border);
-}
-
-.info-text {
-  font-size: 0.9rem;
-  color: var(--text-secondary);
-  line-height: 1.7;
-  margin-bottom: 12px;
-}
-
-.info-list {
-  list-style: none;
-  padding: 0;
-  margin: 0 0 12px;
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-
-.info-list li {
-  font-size: 0.9rem;
-  color: var(--text-secondary);
-  padding: 8px 12px 8px 36px;
-  border-radius: var(--radius-sm);
-  background: var(--surface-alt);
-  border: 1px solid var(--border);
-  position: relative;
-  line-height: 1.5;
-}
-
-.info-list li::before {
-  content: attr(data-bullet);
-  position: absolute;
-  left: 12px;
-  color: var(--primary);
-  font-weight: 700;
-}
-
-.info-footer-text {
-  text-align: center;
-  font-size: 0.95rem;
-  color: var(--text-secondary);
-  background: var(--surface-warm);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-lg);
-  padding: 16px 20px;
-  margin-top: 1rem;
-  font-style: italic;
-}
-
+/* ── Responsive ─────────────────────────────────────────── */
 @media (max-width: 480px) {
   .info-page {
     padding: 0 0.75rem 2rem;
   }
+
   .info-cards {
     grid-template-columns: 1fr;
+  }
+
+  .info-hero {
+    padding: 28px 20px 24px;
+  }
+
+  .info-hero-icon {
+    font-size: 2.2rem;
+  }
+
+  .info-cta {
+    padding: 24px 20px;
+  }
+
+  .info-timeline::before {
+    display: none;
+  }
+
+  .info-badges {
+    gap: 8px;
+  }
+
+  .info-badge {
+    font-size: 0.78rem;
+    padding: 6px 12px;
   }
 }

--- a/sunny_sales_web/src/pages/SobreProjeto.jsx
+++ b/sunny_sales_web/src/pages/SobreProjeto.jsx
@@ -6,29 +6,47 @@ export default function SobreProjeto() {
   return (
     <div className="info-page">
       <BackHomeButton />
-      <h2 className="info-page-title">Sobre o Projeto</h2>
-      <p className="info-page-lead">
-        O <strong>Sunny Sales</strong> conecta vendedores ambulantes de praia a banhistas
-        através de um mapa interativo em tempo real.
-      </p>
+
+      <div className="info-hero">
+        <span className="info-hero-icon">🌊</span>
+        <h1 className="info-hero-title">Sobre o Projeto</h1>
+        <p className="info-hero-lead">
+          O <strong>Sunny Sales</strong> conecta vendedores ambulantes de praia a banhistas
+          através de um mapa interativo em tempo real — unindo tradição, tecnologia e
+          sustentabilidade nas praias portuguesas.
+        </p>
+      </div>
+
+      <div className="info-badges">
+        <div className="info-badge">
+          <span className="info-badge-value">🏖️</span> Praias portuguesas
+        </div>
+        <div className="info-badge">
+          <span className="info-badge-value">📍</span> Localização em tempo real
+        </div>
+        <div className="info-badge">
+          <span className="info-badge-value">📱</span> Web &amp; Mobile
+        </div>
+      </div>
 
       <div className="info-cards">
         <div className="info-card accent">
           <span className="info-card-icon">🏖️</span>
           <h3 className="info-card-title">Quem Somos</h3>
           <p className="info-card-text">
-            Conectamos vendedores ambulantes (bolas de Berlim, gelados, acessórios) a
-            banhistas integrando tradição e tecnologia para valorizar o comércio local.
+            Somos uma plataforma digital que valoriza o comércio ambulante tradicional de praia —
+            desde bolas de Berlim e gelados até acessórios e bebidas. Integramos tradição e
+            tecnologia para que nenhum vendedor ou banhista fique sem se encontrar.
           </p>
         </div>
 
         <div className="info-card">
           <span className="info-card-icon">💡</span>
-          <h3 className="info-card-title">Motivação</h3>
+          <h3 className="info-card-title">A Nossa Motivação</h3>
           <p className="info-card-text">
-            Os consumidores têm dificuldade em encontrar vendedores. O Sunny Sales mostra
-            os vendedores mais próximos, os produtos disponíveis e simplifica a experiência
-            na praia.
+            Os banhistas perdem tempo a procurar vendedores pela areia e os vendedores percorrem
+            longas distâncias sem saber onde estão os clientes. O Sunny Sales resolve este
+            problema em tempo real, tornando a experiência mais prática para todos.
           </p>
         </div>
 
@@ -36,15 +54,45 @@ export default function SobreProjeto() {
           <span className="info-card-icon">✅</span>
           <h3 className="info-card-title">Benefícios</h3>
           <ul className="info-card-list">
-            <li>Evita procurar vendedores pela praia.</li>
-            <li>Direciona vendedores ao público interessado.</li>
-            <li>Promove organização e sustentabilidade balnear.</li>
+            <li>Menos tempo a procurar vendedores na praia</li>
+            <li>Vendedores direcionados ao público certo</li>
+            <li>Menos deslocações desnecessárias</li>
+            <li>Comércio local mais organizado e visível</li>
+            <li>Promoção da sustentabilidade balnear</li>
           </ul>
         </div>
       </div>
 
+      <div className="info-section">
+        <h3 className="info-section-title">Como Funciona</h3>
+        <ul className="info-timeline">
+          <li>
+            <div className="info-timeline-number">1</div>
+            <div className="info-timeline-body">
+              O vendedor abre a aplicação e ativa a localização — fica imediatamente visível
+              no mapa para todos os banhistas nas proximidades.
+            </div>
+          </li>
+          <li>
+            <div className="info-timeline-number">2</div>
+            <div className="info-timeline-body">
+              O banhista acede ao mapa, filtra por tipo de produto e vê os vendedores mais
+              próximos em tempo real.
+            </div>
+          </li>
+          <li>
+            <div className="info-timeline-number">3</div>
+            <div className="info-timeline-body">
+              O vendedor passa e o banhista recebe o produto sem ter de se levantar — mais
+              prático e eficiente para ambos.
+            </div>
+          </li>
+        </ul>
+      </div>
+
       <p className="info-footer-text">
-        O Sunny Sales promove praticidade, sustentabilidade e a valorização do comércio local.
+        O Sunny Sales promove praticidade, sustentabilidade e a valorização do comércio local
+        nas praias portuguesas.
       </p>
     </div>
   );

--- a/sunny_sales_web/src/pages/Sustentabilidade.jsx
+++ b/sunny_sales_web/src/pages/Sustentabilidade.jsx
@@ -6,19 +6,37 @@ export default function Sustentabilidade() {
   return (
     <div className="info-page">
       <BackHomeButton />
-      <h2 className="info-page-title">Sustentabilidade</h2>
-      <p className="info-page-lead">
-        Acreditamos que o futuro do comércio de praia deve ser mais{' '}
-        <strong>eficiente, consciente e ecológico</strong>.
-      </p>
+
+      <div className="info-hero green">
+        <span className="info-hero-icon">🌿</span>
+        <h1 className="info-hero-title">Sustentabilidade</h1>
+        <p className="info-hero-lead">
+          Acreditamos que o futuro do comércio de praia deve ser mais{' '}
+          <strong>eficiente, consciente e ecológico</strong>. Cada decisão conta para
+          um litoral mais saudável e praias mais limpas.
+        </p>
+      </div>
+
+      <div className="info-badges">
+        <div className="info-badge">
+          <span className="info-badge-value">🌱</span> Emissões reduzidas
+        </div>
+        <div className="info-badge">
+          <span className="info-badge-value">♻️</span> Embalagens eco-friendly
+        </div>
+        <div className="info-badge">
+          <span className="info-badge-value">🌊</span> Praias mais limpas
+        </div>
+      </div>
 
       <div className="info-cards">
         <div className="info-card">
           <span className="info-card-icon">🌱</span>
           <h3 className="info-card-title">Redução da Pegada Ecológica</h3>
           <p className="info-card-text">
-            A plataforma ajuda os vendedores a evitar deslocações desnecessárias,
-            reduzindo o esforço físico e o impacto ambiental.
+            Ao otimizar os percursos dos vendedores com base na localização real dos clientes,
+            reduzimos as deslocações desnecessárias, diminuindo o esforço físico e o impacto
+            ambiental de cada jornada de trabalho.
           </p>
         </div>
 
@@ -26,8 +44,9 @@ export default function Sustentabilidade() {
           <span className="info-card-icon">♻️</span>
           <h3 className="info-card-title">Embalagens Sustentáveis</h3>
           <p className="info-card-text">
-            Incentivamos a utilização de sacos biodegradáveis, embalagens reutilizáveis
-            e materiais amigos do ambiente.
+            Incentivamos ativamente os vendedores parceiros a utilizarem sacos biodegradáveis,
+            embalagens reutilizáveis e materiais amigos do ambiente. A plataforma destaca os
+            vendedores com práticas sustentáveis certificadas.
           </p>
         </div>
 
@@ -36,7 +55,8 @@ export default function Sustentabilidade() {
           <h3 className="info-card-title">Apoio a Campanhas</h3>
           <p className="info-card-text">
             Divulgamos e colaboramos com iniciativas de limpeza de praias, sensibilização
-            ambiental e educação para a sustentabilidade.
+            ambiental e educação para a sustentabilidade. Juntos, construímos praias
+            melhores para as gerações futuras.
           </p>
         </div>
       </div>
@@ -44,14 +64,31 @@ export default function Sustentabilidade() {
       <div className="info-section">
         <h3 className="info-section-title">Consciencialização dos Banhistas</h3>
         <ul className="info-list">
-          <li data-bullet="✓">Recolher o lixo após a permanência na praia.</li>
-          <li data-bullet="✓">Utilizar cinzeiros portáteis.</li>
-          <li data-bullet="✓">Preferir protetor solar com menor impacto ambiental.</li>
+          <li data-bullet="✓">
+            Recolher todo o lixo após a permanência na praia — incluindo beatas e plásticos
+            pequenos muitas vezes esquecidos.
+          </li>
+          <li data-bullet="✓">
+            Utilizar cinzeiros portáteis para evitar a contaminação da areia e do mar.
+          </li>
+          <li data-bullet="✓">
+            Preferir protetor solar com fórmulas de menor impacto nos ecossistemas marinhos
+            e recifes de coral.
+          </li>
+          <li data-bullet="✓">
+            Evitar plásticos descartáveis e optar por garrafas, canecas e utensílios
+            reutilizáveis.
+          </li>
+          <li data-bullet="✓">
+            Participar em ações de limpeza de praia organizadas pela comunidade local —
+            cada gesto faz diferença.
+          </li>
         </ul>
       </div>
 
       <p className="info-footer-text">
-        O objetivo é promover praias mais limpas, vendedores mais responsáveis e um verão sustentável.
+        O objetivo é promover <strong>praias mais limpas</strong>, vendedores mais responsáveis
+        e um verão verdadeiramente sustentável para toda a costa portuguesa.
       </p>
     </div>
   );


### PR DESCRIPTION
- Add hero banners with gradient backgrounds (teal for Sobre/Implementar, green for Sustentabilidade)
- Add badge rows with key highlights on each page
- Redesign cards with top-border accent on hover and icon in rounded background
- Replace numbered list in ImplementarScreen with a visual timeline (numbered circles + connecting line)
- Add dark navy CTA block with email link in ImplementarScreen
- Expand and improve copy on all three pages with richer, more specific content
- Add "Como Funciona" timeline section to SobreProjeto
- Expand beachgoer tips list in Sustentabilidade to five items
- Update InfoPage.css with new component classes (hero, badges, timeline, CTA)

https://claude.ai/code/session_01MBbGqEPEv4kqrHdpraqHaT