### PR TITLE
Remove emoji icons from info pages and navigation

### DIFF
--- a/sunny_sales_web/src/App.jsx
+++ b/sunny_sales_web/src/App.jsx
@@ -6,7 +6,7 @@ import {
   NavLink,
   useLocation,
 } from 'react-router-dom';
-import { FiUser, FiMenu, FiX, FiInfo, FiTool, FiDroplet, FiSun } from 'react-icons/fi';
+import { FiUser, FiMenu, FiX, FiSun } from 'react-icons/fi';
 import { useState, useEffect, useRef } from 'react';
 import axios from 'axios';
 import { BASE_URL } from './config';
@@ -109,7 +109,6 @@ function AppLayout() {
             className={({ isActive }) => `nav-link${isActive ? ' active' : ''}`}
             to="/sobre-projeto"
           >
-            <FiInfo size={14} className="nav-link-icon" />
             Sobre o Projeto
           </NavLink>
           <span className="nav-divider">|</span>
@@ -117,7 +116,6 @@ function AppLayout() {
             className={({ isActive }) => `nav-link${isActive ? ' active' : ''}`}
             to="/sustentabilidade"
           >
-            <FiDroplet size={14} className="nav-link-icon" />
             Sustentabilidade
           </NavLink>
           <span className="nav-divider">|</span>
@@ -125,7 +123,6 @@ function AppLayout() {
             className={({ isActive }) => `nav-link${isActive ? ' active' : ''}`}
             to="/implementacao"
           >
-            <FiTool size={14} className="nav-link-icon" />
             Implementar
           </NavLink>
         </div>

--- a/sunny_sales_web/src/index.css
+++ b/sunny_sales_web/src/index.css
@@ -123,7 +123,7 @@ body {
 }
 
 .nav-link {
-  color: rgba(255, 255, 255, 0.72);
+  color: #ffffff;
   text-decoration: none;
   font-size: 0.875rem;
   font-weight: 600;

--- a/sunny_sales_web/src/pages/ImplementarScreen.jsx
+++ b/sunny_sales_web/src/pages/ImplementarScreen.jsx
@@ -8,7 +8,6 @@ export default function ImplementarScreen() {
       <BackHomeButton />
 
       <div className="info-hero">
-        <span className="info-hero-icon">🏛️</span>
         <h1 className="info-hero-title">Implementação do Sunny Sales</h1>
         <p className="info-hero-lead">
           Uma solução tecnológica pronta a usar para <strong>autarquias, juntas de freguesia
@@ -31,7 +30,7 @@ export default function ImplementarScreen() {
 
       <div className="info-cards">
         <div className="info-card accent">
-          <span className="info-card-icon">🏛️</span>
+
           <h3 className="info-card-title">Vantagens para a Autarquia</h3>
           <ul className="info-card-list">
             <li>Organização eficiente da atividade ambulante</li>
@@ -44,7 +43,7 @@ export default function ImplementarScreen() {
         </div>
 
         <div className="info-card">
-          <span className="info-card-icon">🗺️</span>
+
           <h3 className="info-card-title">Recursos Disponibilizados</h3>
           <ul className="info-card-list">
             <li>Mapa digital interativo com vendedores em tempo real</li>

--- a/sunny_sales_web/src/pages/SobreProjeto.jsx
+++ b/sunny_sales_web/src/pages/SobreProjeto.jsx
@@ -8,7 +8,6 @@ export default function SobreProjeto() {
       <BackHomeButton />
 
       <div className="info-hero">
-        <span className="info-hero-icon">🌊</span>
         <h1 className="info-hero-title">Sobre o Projeto</h1>
         <p className="info-hero-lead">
           O <strong>Sunny Sales</strong> conecta vendedores ambulantes de praia a banhistas
@@ -31,7 +30,7 @@ export default function SobreProjeto() {
 
       <div className="info-cards">
         <div className="info-card accent">
-          <span className="info-card-icon">🏖️</span>
+
           <h3 className="info-card-title">Quem Somos</h3>
           <p className="info-card-text">
             Somos uma plataforma digital que valoriza o comércio ambulante tradicional de praia —
@@ -41,7 +40,7 @@ export default function SobreProjeto() {
         </div>
 
         <div className="info-card">
-          <span className="info-card-icon">💡</span>
+
           <h3 className="info-card-title">A Nossa Motivação</h3>
           <p className="info-card-text">
             Os banhistas perdem tempo a procurar vendedores pela areia e os vendedores percorrem
@@ -51,7 +50,7 @@ export default function SobreProjeto() {
         </div>
 
         <div className="info-card">
-          <span className="info-card-icon">✅</span>
+
           <h3 className="info-card-title">Benefícios</h3>
           <ul className="info-card-list">
             <li>Menos tempo a procurar vendedores na praia</li>

--- a/sunny_sales_web/src/pages/Sustentabilidade.jsx
+++ b/sunny_sales_web/src/pages/Sustentabilidade.jsx
@@ -8,7 +8,6 @@ export default function Sustentabilidade() {
       <BackHomeButton />
 
       <div className="info-hero green">
-        <span className="info-hero-icon">🌿</span>
         <h1 className="info-hero-title">Sustentabilidade</h1>
         <p className="info-hero-lead">
           Acreditamos que o futuro do comércio de praia deve ser mais{' '}
@@ -31,7 +30,7 @@ export default function Sustentabilidade() {
 
       <div className="info-cards">
         <div className="info-card">
-          <span className="info-card-icon">🌱</span>
+
           <h3 className="info-card-title">Redução da Pegada Ecológica</h3>
           <p className="info-card-text">
             Ao otimizar os percursos dos vendedores com base na localização real dos clientes,
@@ -41,7 +40,7 @@ export default function Sustentabilidade() {
         </div>
 
         <div className="info-card accent">
-          <span className="info-card-icon">♻️</span>
+
           <h3 className="info-card-title">Embalagens Sustentáveis</h3>
           <p className="info-card-text">
             Incentivamos ativamente os vendedores parceiros a utilizarem sacos biodegradáveis,
@@ -51,7 +50,7 @@ export default function Sustentabilidade() {
         </div>
 
         <div className="info-card">
-          <span className="info-card-icon">🤝</span>
+
           <h3 className="info-card-title">Apoio a Campanhas</h3>
           <p className="info-card-text">
             Divulgamos e colaboramos com iniciativas de limpeza de praias, sensibilização


### PR DESCRIPTION
## Summary
This PR removes emoji icons from the information pages and main navigation, simplifying the UI by relying on text-based navigation and card layouts without decorative emoji elements.

## Key Changes
- **Removed emoji icons from page headers**: Deleted emoji spans (🌊, 🌿, 🏛️) from the hero sections in SobreProjeto, Sustentabilidade, and ImplementarScreen pages
- **Removed emoji icons from info cards**: Removed all emoji icon spans (🏖️, 💡, ✅, 🌱, ♻️, 🤝, 🏛️, 🗺️) from card components across all three info pages
- **Cleaned up navigation imports**: Removed unused Feather icon imports (FiInfo, FiTool, FiDroplet) from App.jsx that were previously used in navigation links
- **Removed navigation link icons**: Deleted icon elements from the "Sobre o Projeto", "Sustentabilidade", and "Implementar" navigation links
- **Improved navigation link visibility**: Changed nav-link color from `rgba(255, 255, 255, 0.72)` to `#ffffff` for better contrast and readability

## Implementation Details
- All emoji removals leave the underlying HTML structure intact (h3 titles, paragraphs, lists remain unchanged)
- The navigation now relies purely on text labels without icon accompaniment
- The color change to navigation links ensures better visibility against the background

https://claude.ai/code/session_01QwEaUCnH4sRq7qiiDqzPXN