### PR TITLE
Update filter option hover states with solid primary color

### DIFF
--- a/sunny_sales_web/src/pages/ModernMapLayout.css
+++ b/sunny_sales_web/src/pages/ModernMapLayout.css
@@ -291,8 +291,8 @@ body {
 
 .filter-option:hover {
   border-color: var(--primary);
-  background: var(--primary-light);
-  color: var(--primary);
+  background: var(--primary);
+  color: white;
   transform: none;
   box-shadow: none;
 }
@@ -344,8 +344,8 @@ body {
 
 .filter-distance-opt:hover {
   border-color: var(--primary);
-  background: var(--primary-light);
-  color: var(--primary);
+  background: var(--primary);
+  color: white;
   transform: none;
   box-shadow: none;
 }


### PR DESCRIPTION
## Summary
Updated the hover state styling for filter options to use a solid primary color background with white text instead of a light primary background with primary-colored text.

## Key Changes
- Modified `.filter-option:hover` styles:
  - Changed background from `var(--primary-light)` to `var(--primary)`
  - Changed text color from `var(--primary)` to `white`

- Modified `.filter-distance-opt:hover` styles:
  - Changed background from `var(--primary-light)` to `var(--primary)`
  - Changed text color from `var(--primary)` to `white`

## Implementation Details
These changes improve the visual contrast and clarity of the filter option hover states by using a more prominent solid primary color background with white text, making the interactive elements more visually distinct and easier to read when users interact with them.

https://claude.ai/code/session_01T9d4mmDRQeYdByqa9dUXyG