### PR TITLE
Remove emoji icons from info badges and product filters

### DIFF
--- a/sunny_sales_web/src/pages/ImplementarScreen.jsx
+++ b/sunny_sales_web/src/pages/ImplementarScreen.jsx
@@ -17,15 +17,9 @@ export default function ImplementarScreen() {
       </div>
 
       <div className="info-badges">
-        <div className="info-badge">
-          <span className="info-badge-value">⚡</span> Implementação rápida
-        </div>
-        <div className="info-badge">
-          <span className="info-badge-value">📊</span> Estatísticas incluídas
-        </div>
-        <div className="info-badge">
-          <span className="info-badge-value">🔗</span> Acesso via QR Code
-        </div>
+        <div className="info-badge">Implementação rápida</div>
+        <div className="info-badge">Estatísticas incluídas</div>
+        <div className="info-badge">Acesso via QR Code</div>
       </div>
 
       <div className="info-cards">

--- a/sunny_sales_web/src/pages/ModernMapLayout.css
+++ b/sunny_sales_web/src/pages/ModernMapLayout.css
@@ -260,7 +260,7 @@ body {
 }
 
 .filter-reset-link:hover {
-  color: var(--primary-hover);
+  color: white;
   transform: none;
   box-shadow: none;
 }

--- a/sunny_sales_web/src/pages/ModernMapLayout.jsx
+++ b/sunny_sales_web/src/pages/ModernMapLayout.jsx
@@ -7,15 +7,8 @@ import LocateButton from '../components/LocateButton';
 import VendorLocateButton from '../components/VendorLocateButton';
 import LocateHint from '../components/LocateHint';
 import BeachConditions from '../components/BeachConditions';
-import { FiSettings, FiGlobe, FiMapPin, FiFilter, FiCheck } from 'react-icons/fi';
-import { GiIceCreamCone } from 'react-icons/gi';
+import { FiMapPin, FiFilter, FiCheck } from 'react-icons/fi';
 import './ModernMapLayout.css';
-
-const PRODUCT_ICONS = {
-  'Bolas de Berlim': FiSettings,
-  'Gelados': GiIceCreamCone,
-  'Acessórios de Praia': FiGlobe,
-};
 
 const DISTANCE_OPTIONS = [
   { label: 'Todos', value: null },
@@ -482,7 +475,6 @@ export default function ModernMapLayout() {
                     </button>
                   </div>
                   {PRODUCTS.map((p) => {
-                    const Icon = PRODUCT_ICONS[p];
                     const active = pendingProducts.includes(p);
                     return (
                       <button
@@ -490,7 +482,6 @@ export default function ModernMapLayout() {
                         className={`filter-option${active ? ' active' : ''}`}
                         onClick={() => togglePendingProduct(p)}
                       >
-                        {Icon && <Icon size={16} className="filter-option-icon" />}
                         <span>{p}</span>
                         {active && <FiCheck size={14} className="filter-check" />}
                       </button>

--- a/sunny_sales_web/src/pages/SobreProjeto.jsx
+++ b/sunny_sales_web/src/pages/SobreProjeto.jsx
@@ -17,15 +17,9 @@ export default function SobreProjeto() {
       </div>
 
       <div className="info-badges">
-        <div className="info-badge">
-          <span className="info-badge-value">🏖️</span> Praias portuguesas
-        </div>
-        <div className="info-badge">
-          <span className="info-badge-value">📍</span> Localização em tempo real
-        </div>
-        <div className="info-badge">
-          <span className="info-badge-value">📱</span> Web &amp; Mobile
-        </div>
+        <div className="info-badge">Praias portuguesas</div>
+        <div className="info-badge">Localização em tempo real</div>
+        <div className="info-badge">Web &amp; Mobile</div>
       </div>
 
       <div className="info-cards">

--- a/sunny_sales_web/src/pages/Sustentabilidade.jsx
+++ b/sunny_sales_web/src/pages/Sustentabilidade.jsx
@@ -17,15 +17,9 @@ export default function Sustentabilidade() {
       </div>
 
       <div className="info-badges">
-        <div className="info-badge">
-          <span className="info-badge-value">🌱</span> Emissões reduzidas
-        </div>
-        <div className="info-badge">
-          <span className="info-badge-value">♻️</span> Embalagens eco-friendly
-        </div>
-        <div className="info-badge">
-          <span className="info-badge-value">🌊</span> Praias mais limpas
-        </div>
+        <div className="info-badge">Emissões reduzidas</div>
+        <div className="info-badge">Embalagens eco-friendly</div>
+        <div className="info-badge">Praias mais limpas</div>
       </div>
 
       <div className="info-cards">


### PR DESCRIPTION
## Summary
This PR simplifies the UI by removing emoji icons and their associated icon library imports from info badges across multiple pages and product filter options in the map layout.

## Key Changes
- **Info Badges Simplification**: Removed emoji icons (⚡, 📊, 🔗, 🏖️, 📍, 📱, 🌱, ♻️, 🌊) and their wrapping `<span>` elements from info badges in:
  - `ImplementarScreen.jsx`
  - `SobreProjeto.jsx`
  - `Sustentabilidade.jsx`

- **Product Filter Icons Removal**: 
  - Removed unused icon imports (`FiSettings`, `FiGlobe`, `GiIceCreamCone`) from `ModernMapLayout.jsx`
  - Deleted the `PRODUCT_ICONS` mapping object that associated product names with icon components
  - Removed icon rendering logic from product filter buttons, keeping only the product name text and check indicator

- **Minor Style Fix**: Updated `.filter-reset-link:hover` color from `var(--primary-hover)` to `white` in `ModernMapLayout.css`

## Implementation Details
The changes maintain the same functionality while reducing visual complexity. Badge text remains intact and readable without the emoji decorations. Product filters now display as simple text-based options with the existing check indicator for active selections.

https://claude.ai/code/session_01TUvLjSddyRn5jTRgsSTZst