### PR TITLE
Add nearby vendors badge to map layout

### DIFF
--- a/sunny_sales_web/src/pages/ModernMapLayout.css
+++ b/sunny_sales_web/src/pages/ModernMapLayout.css
@@ -54,6 +54,31 @@ body {
   font-family: 'Inter', 'Roboto', sans-serif;
 }
 
+/* ── Nearby vendors badge ─────────────────────────────── */
+
+.nearby-vendors-badge {
+  position: absolute;
+  bottom: 16px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  background: rgba(255, 255, 255, 0.92);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  border: 1.5px solid var(--border-strong);
+  border-radius: 999px;
+  padding: 7px 14px;
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--text);
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.12);
+  pointer-events: none;
+  white-space: nowrap;
+}
+
 /* ── Leaflet zoom controls (+/-) — canto superior esquerdo ── */
 
 .map-container .leaflet-top.leaflet-left {

--- a/sunny_sales_web/src/pages/ModernMapLayout.jsx
+++ b/sunny_sales_web/src/pages/ModernMapLayout.jsx
@@ -324,6 +324,12 @@ export default function ModernMapLayout() {
     }
   }
 
+  const nearbyVendorsCount = (!isVendorLogged && clientPos)
+    ? activeVendors.filter((v) =>
+        haversineDistance(clientPos.lat, clientPos.lng, v.current_lat, v.current_lng) <= 100
+      ).length
+    : null;
+
   let filteredVendors = [];
   if (isVendorLogged) {
     filteredVendors = loggedVendor ? [loggedVendor] : [];
@@ -434,6 +440,18 @@ export default function ModernMapLayout() {
               </>
             )}
           </MapContainer>
+
+          {/* Nearby vendors badge */}
+          {!isVendorLogged && nearbyVendorsCount !== null && (
+            <div className="nearby-vendors-badge">
+              <FiMapPin size={13} />
+              {nearbyVendorsCount === 0
+                ? 'Nenhum vendedor na sua área'
+                : nearbyVendorsCount === 1
+                  ? '1 vendedor na sua área'
+                  : `${nearbyVendorsCount} vendedores na sua área`}
+            </div>
+          )}
 
           {/* Floating filter button */}
           {!isVendorLogged && (


### PR DESCRIPTION
## Summary
Added a floating badge component that displays the count of nearby vendors within a 100km radius of the client's current position on the map.

## Key Changes
- **CSS styling**: Added `.nearby-vendors-badge` class with glassmorphism design (frosted glass effect with backdrop blur, rounded pill shape, and shadow)
- **Logic**: Implemented `nearbyVendorsCount` calculation that filters active vendors by distance using the haversine formula, only displayed when user is not logged in as a vendor
- **UI component**: Added a floating badge below the map that shows:
  - "Nenhum vendedor na sua área" (No vendors in your area) when count is 0
  - "1 vendedor na sua área" (1 vendor in your area) when count is 1
  - "{count} vendedores na sua área" ({count} vendors in your area) for multiple vendors
  - Includes a map pin icon from the FiMapPin component

## Implementation Details
- Badge is positioned absolutely at the bottom center of the map container with `z-index: 1000`
- Only renders for non-vendor users (`!isVendorLogged`) when client position is available
- Uses `pointer-events: none` to prevent interaction interference with map controls
- Implements responsive text with `white-space: nowrap` to maintain single-line display
- Styled with modern glassmorphism: semi-transparent white background, blur effect, and subtle shadow

https://claude.ai/code/session_01BQpkZQeGUeNpHkaBj3xWMr