### PR TITLE
feat: rotate map with device heading (navigation mode), fix pin arrow to always point up

### DIFF
--- a/sunny_sales_web/package-lock.json
+++ b/sunny_sales_web/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "axios": "^1.10.0",
         "leaflet": "^1.9.4",
+        "leaflet-rotate": "^0.2.8",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-icons": "^4.11.0",
@@ -2766,6 +2767,15 @@
       "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
       "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/leaflet-rotate": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/leaflet-rotate/-/leaflet-rotate-0.2.8.tgz",
+      "integrity": "sha512-BHtkn35DuJ377yBNn/7XVuV0oIfwJtmqv/wFQ0Lvh7QuVCAD2wfCK0/m9oA3k/LVOnJG8VEGyf3Duf/wTVzeKQ==",
+      "license": "GPL-3.0",
+      "peerDependencies": {
+        "leaflet": "^1.9.3"
+      }
     },
     "node_modules/levn": {
       "version": "0.4.1",

--- a/sunny_sales_web/package.json
+++ b/sunny_sales_web/package.json
@@ -12,12 +12,13 @@
   "dependencies": {
     "axios": "^1.10.0",
     "leaflet": "^1.9.4",
+    "leaflet-rotate": "^0.2.8",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-icons": "^4.11.0",
     "react-leaflet": "^5.0.0",
     "react-router-dom": "^7.6.3",
-    "recharts": "^3.0.2",
-    "react-icons": "^4.11.0"
+    "recharts": "^3.0.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.29.0",

--- a/sunny_sales_web/src/pages/ModernMapLayout.jsx
+++ b/sunny_sales_web/src/pages/ModernMapLayout.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { MapContainer, TileLayer, Marker, Popup, useMap } from 'react-leaflet';
 import L from 'leaflet';
+import 'leaflet-rotate';
 import axios from 'axios';
 import { BASE_URL } from '../config';
 import LocateButton from '../components/LocateButton';
@@ -31,7 +32,7 @@ function haversineDistance(lat1, lng1, lat2, lng2) {
 function getClientPinHtml(heading) {
   const hasHeading = heading !== null && !isNaN(heading);
   const arrow = hasHeading
-    ? `<svg viewBox="0 0 20 20" width="12" height="12" style="transform:rotate(${heading.toFixed(1)}deg);display:block;flex-shrink:0;"><polygon points="10,1 6.5,14 10,11.5 13.5,14" fill="white"/></svg>`
+    ? `<svg viewBox="0 0 20 20" width="12" height="12" style="display:block;flex-shrink:0;"><polygon points="10,1 6.5,14 10,11.5 13.5,14" fill="white"/></svg>`
     : '';
   return `<div class="user-location-marker"><div class="user-location-pulse"></div><div class="user-location-dot">${arrow}</div></div>`;
 }
@@ -39,9 +40,19 @@ function getClientPinHtml(heading) {
 function getVendorPinHtml(color, heading) {
   const hasHeading = heading !== null && !isNaN(heading);
   const arrow = hasHeading
-    ? `<svg viewBox="0 0 20 20" width="12" height="12" style="transform:rotate(${heading.toFixed(1)}deg);display:block;flex-shrink:0;"><polygon points="10,1 6.5,14 10,11.5 13.5,14" fill="white"/></svg>`
+    ? `<svg viewBox="0 0 20 20" width="12" height="12" style="display:block;flex-shrink:0;"><polygon points="10,1 6.5,14 10,11.5 13.5,14" fill="white"/></svg>`
     : '';
   return `<div class="vendor-location-marker"><div class="vendor-location-dot" style="background:${color}">${arrow}</div></div>`;
+}
+
+function MapBearingController({ bearing }) {
+  const map = useMap();
+  useEffect(() => {
+    if (bearing !== null && !isNaN(bearing)) {
+      map.setBearing(bearing);
+    }
+  }, [map, bearing]);
+  return null;
 }
 
 function ClientAutoFollow({ clientPos, isAutoFollowing, setIsAutoFollowing }) {
@@ -364,7 +375,10 @@ export default function ModernMapLayout() {
             center={[38.7169, -9.1399]}
             zoom={13}
             className="map-container"
+            rotate={true}
+            bearing={0}
           >
+            <MapBearingController bearing={heading} />
             <TileLayer
               url="https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png"
               attribution="&copy; <a href='https://openstreetmap.org'>OpenStreetMap</a> contributors &copy; <a href='https://carto.com/attributions'>CARTO</a>"


### PR DESCRIPTION
- Install leaflet-rotate to enable proper map bearing/rotation with correct coordinate handling
- Add MapBearingController component that calls map.setBearing(heading) so the heading direction always appears at the top of the map (navigation mode)
- Remove arrow rotation from getClientPinHtml/getVendorPinHtml: since markerPane is in leaflet-rotate's norotatePane (icons are not visually rotated), the SVG arrow now always points straight up (toward screen top = toward heading in nav mode)
- Previously the pins rotated to follow device heading on a north-up map; now the map itself rotates and the pin stays fixed pointing to the top of the screen

https://claude.ai/code/session_015mxKjCc6CKxxTm9nTaGv85