### PR TITLE
Fix Hermes private class fields syntax error

### DIFF
--- a/sunny_sales_mobile/app.json
+++ b/sunny_sales_mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "sunny_sales_mobile",
     "slug": "sunny_sales_mobile",
-    "sdkVersion": "54.0.0",
+    "sdkVersion": "56.0.0",
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",

--- a/sunny_sales_mobile/babel.config.js
+++ b/sunny_sales_mobile/babel.config.js
@@ -2,5 +2,10 @@ module.exports = function (api) {
   api.cache(true);
   return {
     presets: ['babel-preset-expo'],
+    plugins: [
+      '@babel/plugin-transform-class-properties',
+      '@babel/plugin-transform-private-methods',
+      '@babel/plugin-transform-private-field-destructuring',
+    ],
   };
 };

--- a/sunny_sales_mobile/package.json
+++ b/sunny_sales_mobile/package.json
@@ -31,6 +31,9 @@
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",
+    "@babel/plugin-transform-class-properties": "^7.24.1",
+    "@babel/plugin-transform-private-field-destructuring": "^7.24.1",
+    "@babel/plugin-transform-private-methods": "^7.24.1",
     "@types/react": "~18.3.12",
     "jest": "^29.2.1",
     "jest-expo": "^56.0.4",


### PR DESCRIPTION
Add Babel plugins to transpile private class fields/methods so Hermes
doesn't crash with "private are not supported". Also fix sdkVersion
mismatch (54 → 56) to match the installed expo package version.

https://claude.ai/code/session_01HEEFkWnuveJdS59gm6C6ho