### PR TITLE
Apply justified text alignment across InfoPage content

### DIFF
--- a/sunny_sales_web/src/pages/InfoPage.css
+++ b/sunny_sales_web/src/pages/InfoPage.css
@@ -72,6 +72,7 @@
   line-height: 1.65;
   position: relative;
   z-index: 1;
+  text-align: justify;
 }
 
 /* ── Badges row ────────────────────────────────────────── */
@@ -154,6 +155,7 @@
   color: var(--text-secondary);
   line-height: 1.65;
   margin: 0;
+  text-align: justify;
 }
 
 .info-card-list {
@@ -171,6 +173,7 @@
   line-height: 1.5;
   padding-left: 20px;
   position: relative;
+  text-align: justify;
 }
 
 .info-card-list li::before {
@@ -220,6 +223,7 @@
   color: var(--text-secondary);
   line-height: 1.7;
   margin-bottom: 12px;
+  text-align: justify;
 }
 
 /* ── Standard list ─────────────────────────────────────── */
@@ -241,6 +245,7 @@
   border: 1px solid var(--border);
   position: relative;
   line-height: 1.5;
+  text-align: justify;
 }
 
 .info-list li::before {
@@ -312,6 +317,7 @@
   min-height: 40px;
   display: flex;
   align-items: center;
+  text-align: justify;
 }
 
 /* ── CTA block ─────────────────────────────────────────── */
@@ -336,6 +342,7 @@
   opacity: 0.78;
   margin: 0 0 20px;
   line-height: 1.65;
+  text-align: justify;
 }
 
 .info-cta-btn {
@@ -365,7 +372,7 @@
 
 /* ── Footer text ───────────────────────────────────────── */
 .info-footer-text {
-  text-align: center;
+  text-align: justify;
   font-size: 0.95rem;
   color: var(--text-secondary);
   background: var(--surface-warm);
@@ -388,7 +395,7 @@
 }
 
 .info-page-lead {
-  text-align: center;
+  text-align: justify;
   color: var(--text-secondary);
   font-size: 1rem;
   margin-bottom: 2.5rem;


### PR DESCRIPTION
## Summary
Updated text alignment styling throughout the InfoPage component to use justified alignment instead of center or default alignment, improving text readability and visual consistency across the page.

## Key Changes
- Applied `text-align: justify` to 9 text-related CSS classes across the InfoPage stylesheet
- Changed `.info-footer-text` from `text-align: center` to `text-align: justify`
- Changed `.info-page-lead` from `text-align: center` to `text-align: justify`
- Added justified alignment to content sections including:
  - Main description paragraphs
  - Card descriptions and list items
  - Standard list items
  - CTA block text
  - Footer and lead text

## Implementation Details
This change affects multiple text elements throughout the InfoPage, ensuring consistent justified alignment for better text distribution and professional appearance. The modification maintains all other styling properties (line-height, color, margins, etc.) while only updating the text alignment behavior.

https://claude.ai/code/session_01F451nBCMZpxCkq4cdpxiC7