### PR TITLE
Fix auto-follow conflicts with map rotation and user interactions

### DIFF
--- a/sunny_sales_web/src/pages/ModernMapLayout.jsx
+++ b/sunny_sales_web/src/pages/ModernMapLayout.jsx
@@ -59,14 +59,26 @@ function ClientAutoFollow({ clientPos, isAutoFollowing, setIsAutoFollowing }) {
   const map = useMap();
 
   useEffect(() => {
-    const onDragStart = () => setIsAutoFollowing(false);
-    map.on('dragstart', onDragStart);
-    return () => map.off('dragstart', onDragStart);
+    // Use DOM events instead of Leaflet's dragstart, because leaflet-rotate's
+    // setBearing() can internally trigger dragstart, which would break auto-follow
+    // every time the compass heading updates.
+    const onUserInteraction = (e) => {
+      if (e.target.closest('button, a, .leaflet-control')) return;
+      setIsAutoFollowing(false);
+    };
+    const container = map.getContainer();
+    container.addEventListener('mousedown', onUserInteraction);
+    container.addEventListener('touchstart', onUserInteraction, { passive: true });
+    return () => {
+      container.removeEventListener('mousedown', onUserInteraction);
+      container.removeEventListener('touchstart', onUserInteraction);
+    };
   }, [map, setIsAutoFollowing]);
 
   useEffect(() => {
     if (isAutoFollowing && clientPos?.lat && clientPos?.lng) {
-      map.panTo([clientPos.lat, clientPos.lng]);
+      // animate: false prevents pan animation from conflicting with bearing updates
+      map.setView([clientPos.lat, clientPos.lng], map.getZoom(), { animate: false });
     }
   }, [clientPos?.lat, clientPos?.lng, isAutoFollowing, map]);
 
@@ -77,14 +89,22 @@ function VendorAutoFollow({ vendor, isAutoFollowing, setIsAutoFollowing }) {
   const map = useMap();
 
   useEffect(() => {
-    const onDragStart = () => setIsAutoFollowing(false);
-    map.on('dragstart', onDragStart);
-    return () => map.off('dragstart', onDragStart);
+    const onUserInteraction = (e) => {
+      if (e.target.closest('button, a, .leaflet-control')) return;
+      setIsAutoFollowing(false);
+    };
+    const container = map.getContainer();
+    container.addEventListener('mousedown', onUserInteraction);
+    container.addEventListener('touchstart', onUserInteraction, { passive: true });
+    return () => {
+      container.removeEventListener('mousedown', onUserInteraction);
+      container.removeEventListener('touchstart', onUserInteraction);
+    };
   }, [map, setIsAutoFollowing]);
 
   useEffect(() => {
     if (isAutoFollowing && vendor?.current_lat && vendor?.current_lng) {
-      map.panTo([vendor.current_lat, vendor.current_lng]);
+      map.setView([vendor.current_lat, vendor.current_lng], map.getZoom(), { animate: false });
     }
   }, [vendor?.current_lat, vendor?.current_lng, isAutoFollowing, map]);
 


### PR DESCRIPTION
## Summary
Fixed auto-follow functionality to properly handle map interactions and prevent conflicts with the leaflet-rotate plugin's bearing updates.

## Key Changes
- **Replaced Leaflet dragstart events with DOM events**: Changed from listening to Leaflet's `dragstart` event to listening for native `mousedown` and `touchstart` events on the map container. This prevents the auto-follow from being disabled when leaflet-rotate's `setBearing()` internally triggers dragstart during compass heading updates.

- **Added control element detection**: User interaction listeners now check if the event target is a button, link, or Leaflet control element and skip disabling auto-follow for those interactions, allowing users to interact with UI controls without breaking auto-follow.

- **Updated pan animation behavior**: Changed from `map.panTo()` to `map.setView()` with `animate: false` to prevent pan animations from conflicting with bearing/rotation updates from the compass heading.

- **Applied changes to both ClientAutoFollow and VendorAutoFollow components**: Ensured consistent behavior across both auto-follow implementations.

## Implementation Details
- The DOM event listeners use `{ passive: true }` for touchstart to improve scroll performance
- Event delegation via `e.target.closest()` allows flexible control element detection
- Disabling animation on view updates ensures smooth rotation without animation conflicts

https://claude.ai/code/session_016CqgAAeFeXSqeSLjDTGB9T