### PR TITLE
fix: corrigir direção de rotação do mapa com bússola

### DIFF
--- a/sunny_sales_web/src/pages/ModernMapLayout.jsx
+++ b/sunny_sales_web/src/pages/ModernMapLayout.jsx
@@ -306,7 +306,7 @@ export default function ModernMapLayout() {
       if (now - lastHeadingTs.current < THROTTLE_MS) return;
       lastHeadingTs.current = now;
       absEventFiredRef.current = true;
-      const raw = (360 - e.alpha) % 360;
+      const raw = e.alpha % 360;
       setHeading(applySmoothing(raw));
     };
 
@@ -320,7 +320,7 @@ export default function ModernMapLayout() {
       if (e.webkitCompassHeading != null) {
         setHeading(applySmoothing(e.webkitCompassHeading));
       } else if (e.alpha != null && e.absolute) {
-        setHeading(applySmoothing((360 - e.alpha) % 360));
+        setHeading(applySmoothing(e.alpha % 360));
       }
     };
 


### PR DESCRIPTION
O e.alpha do deviceorientationabsolute no Android já é um bearing no
sentido dos ponteiros do relógio (0=Norte, 90=Este). A fórmula anterior
(360 - alpha) invertia a direção, fazendo o mapa rodar ao contrário do
telemóvel.

https://claude.ai/code/session_01L8XoaB1ihwEqEHrbxFVH8t