### PR TITLE
fix: corrigir orientação do mapa no iOS (webkitCompassHeading 180° invertido)

### DIFF
--- a/sunny_sales_web/src/pages/ModernMapLayout.jsx
+++ b/sunny_sales_web/src/pages/ModernMapLayout.jsx
@@ -232,8 +232,9 @@ export default function ModernMapLayout() {
         const gpsH = pos.coords.heading;
         if (gpsH != null && !isNaN(gpsH) && pos.coords.speed != null && pos.coords.speed > 0.3) {
           gpsMovingRef.current = true;
-          smoothedHeadingRef.current = gpsH;
-          setHeading(gpsH);
+          const mappedGpsH = (360 - gpsH) % 360;
+          smoothedHeadingRef.current = mappedGpsH;
+          setHeading(mappedGpsH);
           lastHeadingTs.current = Date.now();
         } else {
           gpsMovingRef.current = false;
@@ -318,7 +319,7 @@ export default function ModernMapLayout() {
       if (e.webkitCompassAccuracy != null && e.webkitCompassAccuracy >= 0 && e.webkitCompassAccuracy > MAX_ACCURACY_DEG) return;
       lastHeadingTs.current = now;
       if (e.webkitCompassHeading != null) {
-        setHeading(applySmoothing(e.webkitCompassHeading));
+        setHeading(applySmoothing((360 - e.webkitCompassHeading) % 360));
       } else if (e.alpha != null && e.absolute) {
         setHeading(applySmoothing(e.alpha % 360));
       }


### PR DESCRIPTION
O webkitCompassHeading (iOS) e pos.coords.heading (GPS) reportam o
bearing no sentido horário (0=N, 90=E), mas leaflet-rotate aplica
setBearing como rotação CSS clockwise, o que requer o complemento
(360 - heading) para colocar a direção correta no topo do ecrã.

O alpha do deviceorientationabsolute (Android) já está em convenção
CCW, compatível com setBearing, por isso não é alterado.

https://claude.ai/code/session_01JgC36SFeZuiiKTydo7Rbgf