### PR TITLE
Improve map bearing animation and compass permission UX

### DIFF
--- a/sunny_sales_web/src/pages/ModernMapLayout.css
+++ b/sunny_sales_web/src/pages/ModernMapLayout.css
@@ -576,6 +576,89 @@ body {
   transform: scale(1.06);
 }
 
+/* ── Compass permission modal ─────────────────────────── */
+
+.compass-modal-overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 1400;
+  background: rgba(0, 0, 0, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  animation: overlayFadeIn 0.2s ease;
+}
+
+.compass-modal {
+  background: var(--surface);
+  border-radius: var(--radius-xl);
+  padding: 28px 24px 24px;
+  max-width: 320px;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.22);
+  animation: sheetSlideUp 0.26s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.compass-modal-icon {
+  font-size: 2.4rem;
+  margin-bottom: 12px;
+  line-height: 1;
+}
+
+.compass-modal-title {
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--text);
+  margin: 0 0 10px;
+}
+
+.compass-modal-desc {
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+  line-height: 1.5;
+  margin: 0 0 20px;
+}
+
+.compass-allow-btn {
+  width: 100%;
+  padding: 13px 0;
+  background: var(--primary);
+  color: white;
+  border: none;
+  border-radius: var(--radius-lg);
+  font-size: 0.95rem;
+  font-weight: 700;
+  cursor: pointer;
+  margin-bottom: 10px;
+  transition: background var(--transition), transform var(--transition);
+  min-height: auto;
+}
+
+.compass-allow-btn:hover {
+  background: var(--primary-hover);
+  transform: scale(1.02);
+}
+
+.compass-skip-btn {
+  background: none;
+  border: none;
+  color: var(--text-secondary);
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  padding: 6px 0;
+  min-height: auto;
+}
+
+.compass-skip-btn:hover {
+  color: var(--text);
+}
+
 /* ── Loader ───────────────────────────────────────────── */
 
 .loader {

--- a/sunny_sales_web/src/pages/ModernMapLayout.jsx
+++ b/sunny_sales_web/src/pages/ModernMapLayout.jsx
@@ -45,13 +45,34 @@ function getVendorPinHtml(color, heading) {
   return `<div class="vendor-location-marker"><div class="vendor-location-dot" style="background:${color}">${arrow}</div></div>`;
 }
 
-function MapBearingController({ bearing }) {
+function MapBearingController({ targetBearingRef }) {
   const map = useMap();
   useEffect(() => {
-    if (bearing !== null && !isNaN(bearing)) {
-      map.setBearing(bearing);
-    }
-  }, [map, bearing]);
+    const current = { val: null };
+    let rafId;
+    const LERP = 0.18;
+
+    const tick = () => {
+      const target = targetBearingRef.current;
+      if (target !== null && !isNaN(target)) {
+        if (current.val === null) {
+          current.val = target;
+          map.setBearing(target);
+        } else {
+          let diff = target - current.val;
+          if (diff > 180) diff -= 360;
+          if (diff < -180) diff += 360;
+          if (Math.abs(diff) > 0.08) {
+            current.val = (current.val + diff * LERP + 360) % 360;
+            map.setBearing(current.val);
+          }
+        }
+      }
+      rafId = requestAnimationFrame(tick);
+    };
+    rafId = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(rafId);
+  }, [map, targetBearingRef]);
   return null;
 }
 
@@ -125,11 +146,12 @@ export default function ModernMapLayout() {
   const [clientPos, setClientPos] = useState(null);
   const [heading, setHeading] = useState(null);
   const lastHeadingTs = useRef(0);
-  const smoothedHeadingRef = useRef(null);
+  const targetBearingRef = useRef(null);
   const absEventFiredRef = useRef(false);
   const gpsMovingRef = useRef(false);
   const [compassReady, setCompassReady] = useState(false);
   const [needsCompassPermission, setNeedsCompassPermission] = useState(false);
+  const [showCompassModal, setShowCompassModal] = useState(false);
   const [showLocateHint, setShowLocateHint] = useState(false);
   const isVendorLogged = !!localStorage.getItem('user');
 
@@ -233,7 +255,7 @@ export default function ModernMapLayout() {
         if (gpsH != null && !isNaN(gpsH) && pos.coords.speed != null && pos.coords.speed > 0.3) {
           gpsMovingRef.current = true;
           const mappedGpsH = (360 - gpsH) % 360;
-          smoothedHeadingRef.current = mappedGpsH;
+          targetBearingRef.current = mappedGpsH;
           setHeading(mappedGpsH);
           lastHeadingTs.current = Date.now();
         } else {
@@ -248,7 +270,7 @@ export default function ModernMapLayout() {
 
   // iOS 13+ requires a user gesture to call requestPermission for DeviceOrientationEvent.
   // Try immediately (works when permission was already granted in a previous visit);
-  // if that throws (first visit), show the compass button so the user can tap it.
+  // if that fails (first visit), auto-show the compass permission modal.
   useEffect(() => {
     if (
       typeof DeviceOrientationEvent === 'undefined' ||
@@ -260,11 +282,18 @@ export default function ModernMapLayout() {
 
     DeviceOrientationEvent.requestPermission()
       .then((result) => {
-        if (result === 'granted') setCompassReady(true);
-        else setNeedsCompassPermission(true);
+        if (result === 'granted') {
+          setCompassReady(true);
+        } else {
+          setNeedsCompassPermission(true);
+          const dismissed = localStorage.getItem('compass_modal_dismissed');
+          if (!dismissed) setShowCompassModal(true);
+        }
       })
       .catch(() => {
         setNeedsCompassPermission(true);
+        const dismissed = localStorage.getItem('compass_modal_dismissed');
+        if (!dismissed) setShowCompassModal(true);
       });
   }, []);
 
@@ -277,28 +306,23 @@ export default function ModernMapLayout() {
       }
     } catch (e) {
       console.error('Erro ao pedir permissão da bússola:', e);
+    } finally {
+      setShowCompassModal(false);
+      localStorage.setItem('compass_modal_dismissed', 'true');
     }
+  };
+
+  const dismissCompassModal = () => {
+    setShowCompassModal(false);
+    localStorage.setItem('compass_modal_dismissed', 'true');
   };
 
   useEffect(() => {
     if (!compassReady) return;
-    const THROTTLE_MS = 50;
-    const COMPASS_ALPHA = 0.25;
+    const THROTTLE_MS = 16; // ~60fps for targetBearingRef; state update throttled separately
+    const MARKER_THROTTLE_MS = 100;
     const MAX_ACCURACY_DEG = 50;
-
-    const applySmoothing = (raw) => {
-      const prev = smoothedHeadingRef.current;
-      if (prev === null) {
-        smoothedHeadingRef.current = raw;
-        return raw;
-      }
-      let diff = raw - prev;
-      if (diff > 180) diff -= 360;
-      if (diff < -180) diff += 360;
-      const next = (prev + COMPASS_ALPHA * diff + 360) % 360;
-      smoothedHeadingRef.current = next;
-      return next;
-    };
+    let lastMarkerTs = 0;
 
     const onAbsolute = (e) => {
       if (gpsMovingRef.current) return;
@@ -308,7 +332,11 @@ export default function ModernMapLayout() {
       lastHeadingTs.current = now;
       absEventFiredRef.current = true;
       const raw = e.alpha % 360;
-      setHeading(applySmoothing(raw));
+      targetBearingRef.current = raw;
+      if (now - lastMarkerTs > MARKER_THROTTLE_MS) {
+        lastMarkerTs = now;
+        setHeading(raw);
+      }
     };
 
     const onOrientation = (e) => {
@@ -318,10 +346,18 @@ export default function ModernMapLayout() {
       if (now - lastHeadingTs.current < THROTTLE_MS) return;
       if (e.webkitCompassAccuracy != null && e.webkitCompassAccuracy >= 0 && e.webkitCompassAccuracy > MAX_ACCURACY_DEG) return;
       lastHeadingTs.current = now;
+      let raw = null;
       if (e.webkitCompassHeading != null) {
-        setHeading(applySmoothing((360 - e.webkitCompassHeading) % 360));
+        raw = (360 - e.webkitCompassHeading) % 360;
       } else if (e.alpha != null && e.absolute) {
-        setHeading(applySmoothing(e.alpha % 360));
+        raw = e.alpha % 360;
+      }
+      if (raw !== null) {
+        targetBearingRef.current = raw;
+        if (now - lastMarkerTs > MARKER_THROTTLE_MS) {
+          lastMarkerTs = now;
+          setHeading(raw);
+        }
       }
     };
 
@@ -396,7 +432,7 @@ export default function ModernMapLayout() {
             rotate={true}
             bearing={0}
           >
-            <MapBearingController bearing={heading} />
+            <MapBearingController targetBearingRef={targetBearingRef} />
             <TileLayer
               url="https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png"
               attribution="&copy; <a href='https://openstreetmap.org'>OpenStreetMap</a> contributors &copy; <a href='https://carto.com/attributions'>CARTO</a>"
@@ -473,11 +509,30 @@ export default function ModernMapLayout() {
             )}
           </MapContainer>
 
-          {/* Compass permission button — only shown on iOS before permission is granted */}
-          {needsCompassPermission && !compassReady && (
+          {/* Compass permission modal — shown automatically on first iOS visit */}
+          {showCompassModal && (
+            <div className="compass-modal-overlay" onClick={dismissCompassModal}>
+              <div className="compass-modal" onClick={(e) => e.stopPropagation()}>
+                <div className="compass-modal-icon">🧭</div>
+                <h3 className="compass-modal-title">Orientação Automática</h3>
+                <p className="compass-modal-desc">
+                  Para o mapa rodar conforme a direção que estás a olhar, precisa de acesso à bússola do dispositivo.
+                </p>
+                <button className="compass-allow-btn" onClick={requestCompassPermission}>
+                  Permitir Bússola
+                </button>
+                <button className="compass-skip-btn" onClick={dismissCompassModal}>
+                  Agora não
+                </button>
+              </div>
+            </div>
+          )}
+
+          {/* Fallback compass button if modal was dismissed but permission still needed */}
+          {needsCompassPermission && !compassReady && !showCompassModal && (
             <button
               className="compass-btn"
-              onClick={requestCompassPermission}
+              onClick={() => setShowCompassModal(true)}
               aria-label="Ativar bússola"
               title="Ativar bússola"
             >


### PR DESCRIPTION
## Summary
This PR refactors the map bearing (compass) system to use smooth interpolated animations and improves the compass permission request flow with an auto-showing modal on first visit.

## Key Changes

- **Smooth bearing animation**: Moved bearing smoothing logic from the compass event handlers into `MapBearingController` component, which now uses `requestAnimationFrame` to continuously interpolate between current and target bearing values using linear interpolation (LERP). This provides fluid map rotation that follows device orientation.

- **Compass permission modal**: Replaced the simple compass button with an auto-showing modal on first iOS visit when permission is needed. The modal includes:
  - Descriptive explanation of why compass access is needed
  - "Allow" and "Skip for now" buttons
  - Persistent dismissal state via localStorage to avoid re-showing on subsequent visits
  - Fallback button still available if user dismisses the modal

- **Refactored heading state management**:
  - Renamed `smoothedHeadingRef` to `targetBearingRef` for clarity
  - Separated concerns: `targetBearingRef` updates at high frequency (~60fps) for smooth animation, while `heading` state updates throttled to ~100ms for UI marker updates
  - Removed local smoothing function from compass event handlers

- **Improved throttling**: Adjusted throttle timing from 50ms to 16ms for target bearing updates (allowing 60fps animation) while keeping marker state updates at 100ms to reduce re-renders.

- **Added modal styling**: New CSS for compass permission modal with overlay, animations, and responsive button styling matching the app's design system.

## Implementation Details

The bearing animation now works by:
1. Compass events update `targetBearingRef.current` at high frequency
2. `MapBearingController` runs a continuous animation loop via `requestAnimationFrame`
3. Each frame interpolates from current bearing toward target bearing with LERP factor of 0.18
4. Handles bearing wraparound (0-360°) correctly with diff normalization
5. Stops interpolating when difference is < 0.08° to avoid jitter

The compass permission flow now:
1. Auto-requests permission on mount (iOS 13+)
2. If denied/failed, auto-shows modal (unless previously dismissed)
3. User can grant permission via modal or dismiss to use fallback button
4. Dismissal state persists in localStorage

https://claude.ai/code/session_01Qr1RuZPqyVG9D1gJBcNsMo