### PR TITLE
Reduce Leaflet attribution control font size

### DIFF
--- a/sunny_sales_web/src/pages/ModernMapLayout.css
+++ b/sunny_sales_web/src/pages/ModernMapLayout.css
@@ -54,6 +54,10 @@ body {
   font-family: 'Inter', 'Roboto', sans-serif;
 }
 
+.leaflet-control-attribution {
+  font-size: 0.6rem !important;
+}
+
 /* ── Nearby vendors badge ─────────────────────────────── */
 
 .nearby-vendors-badge {


### PR DESCRIPTION
## Summary
Reduced the font size of the Leaflet map attribution control to improve the visual layout and reduce visual clutter on the map interface.

## Key Changes
- Added CSS rule to target `.leaflet-control-attribution` element
- Set font size to `0.6rem` with `!important` flag to override Leaflet's default styling
- This makes the attribution text more compact and less prominent on the map

## Implementation Details
The change uses `!important` to ensure the custom font size takes precedence over Leaflet's default styles, which is necessary since Leaflet applies its own styling to the attribution control.

https://claude.ai/code/session_01SQnWQQAqMjkZ3iHYggSkBm