### PR TITLE
Replace flyTo with setView for instant map centering

### DIFF
--- a/sunny_sales_web/src/components/LocateButton.jsx
+++ b/sunny_sales_web/src/components/LocateButton.jsx
@@ -20,7 +20,7 @@ export default function LocateButton({ onLocationFound, onClick }) {
         onLocationFound({ lat, lng });
       }
 
-      map.flyTo([lat, lng], 18, { animate: true, duration: 0.5 });
+      map.setView([lat, lng], 18, { animate: false });
     };
 
     const onError = () => {


### PR DESCRIPTION
## Summary
Changed the map navigation behavior in the LocateButton component to use `setView` instead of `flyTo`, providing instant map centering without animation.

## Key Changes
- Replaced `map.flyTo([lat, lng], 18, { animate: true, duration: 0.5 })` with `map.setView([lat, lng], 18, { animate: false })`
- Removed the 0.5-second animation duration when centering the map on the user's location
- Map now instantly centers on the located position instead of animating to it

## Implementation Details
This change improves the user experience by providing immediate visual feedback when the locate button is clicked, eliminating the 500ms animation delay. The `setView` method with `animate: false` is more appropriate for this use case where instant positioning is preferred over a smooth transition.

https://claude.ai/code/session_01HthZk97wKHTyz2Mmy3x1aj