### PR TITLE
Remove tide forecast functionality from BeachConditions

### DIFF
--- a/sunny_sales_web/src/components/BeachConditions.css
+++ b/sunny_sales_web/src/components/BeachConditions.css
@@ -84,61 +84,6 @@
   color: var(--text);
 }
 
-.bc-tides {
-  margin-top: 10px;
-  border-top: 1px solid var(--border);
-  padding-top: 10px;
-}
-
-.bc-tides-title {
-  font-size: 0.78rem;
-  font-weight: 600;
-  color: var(--text-secondary);
-  margin-bottom: 8px;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-}
-
-.bc-tides-grid {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 8px;
-}
-
-.bc-tide-item {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  border-radius: var(--radius-sm);
-  padding: 8px 12px;
-  border: 1px solid var(--border);
-}
-
-.bc-tide-high {
-  background: #e8f4fd;
-}
-
-.bc-tide-low {
-  background: #fef9e7;
-}
-
-.bc-tide-label {
-  font-size: 0.75rem;
-  color: var(--text-secondary);
-  font-weight: 500;
-}
-
-.bc-tide-time {
-  font-size: 1.05rem;
-  font-weight: 700;
-  color: var(--text);
-}
-
-.bc-tide-height {
-  font-size: 0.78rem;
-  color: var(--text-secondary);
-}
-
 .bc-warning {
   font-size: 0.72rem;
   color: var(--text-muted);

--- a/sunny_sales_web/src/components/BeachConditions.jsx
+++ b/sunny_sales_web/src/components/BeachConditions.jsx
@@ -1,41 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import './BeachConditions.css';
 
-// Estações maregráficas do IPMA com coordenadas aproximadas
-const TIDE_STATIONS = [
-  { id: 1110600, name: "Viana do Castelo", lat: 41.69, lon: -8.84 },
-  { id: 1131200, name: "Leixões",           lat: 41.18, lon: -8.70 },
-  { id: 1141900, name: "Aveiro",            lat: 40.64, lon: -8.75 },
-  { id: 1160700, name: "Figueira da Foz",   lat: 40.15, lon: -8.86 },
-  { id: 1182300, name: "Nazaré",            lat: 39.60, lon: -9.08 },
-  { id: 1110800, name: "Cascais",           lat: 38.70, lon: -9.42 },
-  { id: 1114300, name: "Lisboa",            lat: 38.71, lon: -9.14 },
-  { id: 1115600, name: "Setúbal",           lat: 38.52, lon: -8.90 },
-  { id: 1112200, name: "Sines",             lat: 37.96, lon: -8.88 },
-  { id: 1121000, name: "Lagos",             lat: 37.10, lon: -8.67 },
-  { id: 1124200, name: "Faro",              lat: 37.02, lon: -7.93 },
-  { id: 1131700, name: "Vila Real de Sto. António", lat: 37.19, lon: -7.41 },
-];
-
-function haversineKm(lat1, lon1, lat2, lon2) {
-  const R = 6371;
-  const dLat = ((lat2 - lat1) * Math.PI) / 180;
-  const dLon = ((lon2 - lon1) * Math.PI) / 180;
-  const a =
-    Math.sin(dLat / 2) ** 2 +
-    Math.cos((lat1 * Math.PI) / 180) *
-      Math.cos((lat2 * Math.PI) / 180) *
-      Math.sin(dLon / 2) ** 2;
-  return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
-}
-
-function nearestStation(lat, lon) {
-  return TIDE_STATIONS.reduce((best, s) => {
-    const d = haversineKm(lat, lon, s.lat, s.lon);
-    return d < best.dist ? { station: s, dist: d } : best;
-  }, { station: TIDE_STATIONS[0], dist: Infinity }).station;
-}
-
 // Widget "Condições de Praia" baseado na localização do utilizador
 export default function BeachConditions() {
 
@@ -44,7 +9,6 @@ export default function BeachConditions() {
   const [selected, setSelected] = useState(null);
 
   const [weather, setWeather] = useState(null);
-  const [tides, setTides] = useState(null);
   const [error, setError] = useState(null);
   const [loading, setLoading] = useState(true);
 
@@ -120,37 +84,6 @@ export default function BeachConditions() {
           humidity: wData.current?.relative_humidity_2m,
           uvMax: wData.daily?.uv_index_max?.[0],
         });
-
-        // Marés via IPMA — estação mais próxima da praia selecionada
-        const station = nearestStation(selected.lat, selected.lon);
-        const tideUrl = `https://api.ipma.pt/open-data/forecast/oceanography/daily/hp-daily-tide-forecast-day0.json`;
-        const tRes = await fetch(tideUrl);
-        const tData = await tRes.json();
-        // A resposta tem um array "data"; cada elemento tem globalIdLocal e tides[]
-        const stationData = tData?.data?.find(
-          (d) => d.globalIdLocal === station.id
-        );
-        if (stationData?.tides) {
-          const now = new Date();
-          const nowMinutes = now.getHours() * 60 + now.getMinutes();
-          const toMinutes = (hora) => {
-            const [h, m] = hora.split(':').map(Number);
-            return h * 60 + m;
-          };
-          // Próximas marés: filtra as que ainda não passaram, ordena por hora
-          const upcoming = stationData.tides
-            .filter((t) => toMinutes(t.hora) >= nowMinutes)
-            .sort((a, b) => toMinutes(a.hora) - toMinutes(b.hora));
-          const nextHigh = upcoming.find((t) => t.level === 'PM');
-          const nextLow  = upcoming.find((t) => t.level === 'BM');
-          setTides({
-            stationName: station.name,
-            nextHigh: nextHigh ? { hora: nextHigh.hora, altura: nextHigh.altura } : null,
-            nextLow:  nextLow  ? { hora: nextLow.hora,  altura: nextLow.altura  } : null,
-          });
-        } else {
-          setTides(null);
-        }
       } catch (e) {
         setError('Erro ao carregar dados.');
       } finally {
@@ -208,32 +141,9 @@ export default function BeachConditions() {
           <div>UV máx: {weather.uvMax}</div>
         </div>
 
-        {tides && (
-          <div className="bc-tides">
-            <div className="bc-tides-title">
-              Marés — {tides.stationName}
-            </div>
-            <div className="bc-tides-grid">
-              <div className="bc-tide-item bc-tide-high">
-                <span className="bc-tide-label">🌊 Maré cheia</span>
-                {tides.nextHigh
-                  ? <><span className="bc-tide-time">{tides.nextHigh.hora}</span><span className="bc-tide-height">{tides.nextHigh.altura} m</span></>
-                  : <span className="bc-tide-time">—</span>
-                }
-              </div>
-              <div className="bc-tide-item bc-tide-low">
-                <span className="bc-tide-label">🏖️ Maré vazia</span>
-                {tides.nextLow
-                  ? <><span className="bc-tide-time">{tides.nextLow.hora}</span><span className="bc-tide-height">{tides.nextLow.altura} m</span></>
-                  : <span className="bc-tide-time">—</span>
-                }
-              </div>
-            </div>
-          </div>
-        )}
       </div>
       <p className="bc-warning">
-        Estimativa para uso recreativo; não usar para navegação. Marés: IPMA.
+        Estimativa para uso recreativo; não usar para navegação.
       </p>
     </div>
   );


### PR DESCRIPTION
## Summary
This PR removes the tide forecast feature from the BeachConditions component, including all related logic, UI elements, and styling.

## Key Changes
- **Removed tide station data and utilities**: Deleted the `TIDE_STATIONS` constant and helper functions (`haversineKm`, `nearestStation`) that were used to find the nearest tide station based on user location
- **Removed tide API integration**: Eliminated the IPMA tide forecast API call and data processing logic that fetched and parsed tide information
- **Removed tide state management**: Deleted the `tides` state variable and its setter
- **Removed tide UI rendering**: Deleted the entire tide display section including the grid layout showing next high and low tide times and heights
- **Removed tide-related CSS**: Deleted all styling classes for tide display (`.bc-tides`, `.bc-tides-title`, `.bc-tides-grid`, `.bc-tide-item`, `.bc-tide-high`, `.bc-tide-low`, `.bc-tide-label`, `.bc-tide-time`, `.bc-tide-height`)
- **Updated disclaimer**: Simplified the warning text to remove reference to IPMA as the tide data source

## Implementation Details
The component now focuses solely on weather data from the Open-Meteo API. The removal is clean with no orphaned code or broken references remaining.

https://claude.ai/code/session_018wJhKETfMCvKr81J2JHG2a