### PR TITLE
Update map tile layer from light_all to voyager theme

### DIFF
--- a/sunny_sales_web/public/resort-map.html
+++ b/sunny_sales_web/public/resort-map.html
@@ -31,7 +31,7 @@
     <script>
         // Exemplo de inicialização do mapa (pode ser removido se já existir no projeto)
         var map = L.map('map').setView([38.7169, -9.1399], 13);
-        L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png', {
+        L.tileLayer('https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}.png', {
             attribution: '&copy; <a href="https://openstreetmap.org">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>',
             subdomains: 'abcd',
             maxZoom: 19

--- a/sunny_sales_web/src/pages/ModernMapLayout.css
+++ b/sunny_sales_web/src/pages/ModernMapLayout.css
@@ -50,7 +50,7 @@ body {
 }
 
 .leaflet-container {
-  background: transparent;
+  background: #aad3df;
   font-family: 'Inter', 'Roboto', sans-serif;
 }
 

--- a/sunny_sales_web/src/pages/ModernMapLayout.jsx
+++ b/sunny_sales_web/src/pages/ModernMapLayout.jsx
@@ -434,7 +434,7 @@ export default function ModernMapLayout() {
           >
             <MapBearingController targetBearingRef={targetBearingRef} />
             <TileLayer
-              url="https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png"
+              url="https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}.png"
               attribution="&copy; <a href='https://openstreetmap.org'>OpenStreetMap</a> contributors &copy; <a href='https://carto.com/attributions'>CARTO</a>"
               subdomains="abcd"
               maxZoom={19}

--- a/sunny_sales_web/src/pages/RouteDetail.jsx
+++ b/sunny_sales_web/src/pages/RouteDetail.jsx
@@ -25,7 +25,7 @@ export default function RouteDetail() {
       <div className="route-map">
         <MapContainer center={initial} zoom={15} style={{ width: '100%', height: '100%' }}>
           <TileLayer
-            url="https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png"
+            url="https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}.png"
             attribution="&copy; <a href='https://openstreetmap.org'>OpenStreetMap</a> contributors &copy; <a href='https://carto.com/attributions'>CARTO</a>"
             subdomains="abcd"
             maxZoom={19}


### PR DESCRIPTION
## Summary
Updated the map tile layer across the application from CARTO's `light_all` theme to the `voyager` theme for improved visual presentation and styling consistency.

## Key Changes
- **Tile Layer URL Updates**: Changed the tile layer URL from `https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png` to `https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}.png` in three locations:
  - `public/resort-map.html` (Leaflet map initialization)
  - `src/pages/ModernMapLayout.jsx` (React Leaflet component)
  - `src/pages/RouteDetail.jsx` (Route detail map)

- **Map Container Background**: Updated the Leaflet container background color in `src/pages/ModernMapLayout.css` from `transparent` to `#aad3df` (light blue) to complement the voyager theme

## Implementation Details
The voyager theme provides a more detailed and visually rich map style compared to the light_all theme, with better contrast and additional map features. The background color change ensures the map container has an appropriate fallback color while tiles are loading.

https://claude.ai/code/session_011Zm97frupYzUyr2AEVow31