### PR TITLE
Redesign locate buttons with custom SVG icon and orange styling

### DIFF
--- a/sunny_sales_web/src/components/LocateButton.jsx
+++ b/sunny_sales_web/src/components/LocateButton.jsx
@@ -36,7 +36,18 @@ export default function LocateButton({ onLocationFound, onClick }) {
   // Renderização do botão de localização
   return (
     <button className="locate-btn" onClick={handleLocate} aria-label="Localizar-me">
-      {locating ? <span className="loader" /> : '📍'}
+      {locating ? (
+        <span className="loader" />
+      ) : (
+        <svg className="locate-icon" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <circle cx="12" cy="12" r="4" stroke="currentColor" strokeWidth="2"/>
+          <circle cx="12" cy="12" r="8.5" stroke="currentColor" strokeWidth="1.6"/>
+          <line x1="12" y1="1" x2="12" y2="4" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round"/>
+          <line x1="12" y1="20" x2="12" y2="23" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round"/>
+          <line x1="1" y1="12" x2="4" y2="12" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round"/>
+          <line x1="20" y1="12" x2="23" y2="12" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round"/>
+        </svg>
+      )}
     </button>
   );
 }

--- a/sunny_sales_web/src/components/VendorLocateButton.jsx
+++ b/sunny_sales_web/src/components/VendorLocateButton.jsx
@@ -18,7 +18,14 @@ export default function VendorLocateButton({ vendor, onLocate }) {
       aria-label="Localizar vendedor"
       disabled={!vendor}
     >
-      {'📍'}
+      <svg className="locate-icon" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <circle cx="12" cy="12" r="4" stroke="currentColor" strokeWidth="2"/>
+        <circle cx="12" cy="12" r="8.5" stroke="currentColor" strokeWidth="1.6"/>
+        <line x1="12" y1="1" x2="12" y2="4" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round"/>
+        <line x1="12" y1="20" x2="12" y2="23" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round"/>
+        <line x1="1" y1="12" x2="4" y2="12" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round"/>
+        <line x1="20" y1="12" x2="23" y2="12" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round"/>
+      </svg>
     </button>
   );
 }

--- a/sunny_sales_web/src/pages/ModernMapLayout.css
+++ b/sunny_sales_web/src/pages/ModernMapLayout.css
@@ -524,31 +524,41 @@ body {
   position: absolute;
   bottom: 20px;
   right: 14px;
-  width: 46px;
-  height: 46px;
-  background: var(--surface);
-  border: 1.5px solid var(--border-strong);
+  width: 50px;
+  height: 50px;
+  background: #F5A623;
+  border: none;
   border-radius: var(--radius-full);
   cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
-  box-shadow: var(--shadow-md);
-  transition: background var(--transition), box-shadow var(--transition), border-color var(--transition), transform var(--transition);
+  box-shadow: 0 4px 14px rgba(245, 166, 35, 0.45);
+  transition: background var(--transition), box-shadow var(--transition), transform var(--transition);
   z-index: 500;
   -webkit-tap-highlight-color: transparent;
   min-height: auto;
   padding: 0;
-  color: var(--primary);
-  font-size: 1.1rem;
+  color: #ffffff;
+}
+
+.locate-btn .locate-icon,
+.vendor-locate-btn .locate-icon {
+  width: 24px;
+  height: 24px;
 }
 
 .locate-btn:hover,
 .vendor-locate-btn:hover {
-  background: var(--primary-light-solid);
-  border-color: var(--primary);
-  box-shadow: var(--shadow-warm);
+  background: #e09615;
+  box-shadow: 0 6px 20px rgba(245, 166, 35, 0.55);
   transform: scale(1.06);
+}
+
+.locate-btn:active,
+.vendor-locate-btn:active {
+  transform: scale(0.96);
+  box-shadow: 0 2px 8px rgba(245, 166, 35, 0.35);
 }
 
 .compass-btn {


### PR DESCRIPTION
## Summary
Redesigned the locate buttons (LocateButton and VendorLocateButton) with a new visual style featuring a custom SVG compass icon, orange color scheme, and improved interactive states.

## Key Changes
- **Icon replacement**: Replaced emoji pin (📍) with a custom SVG compass icon featuring concentric circles and directional lines
- **Color scheme**: Changed button background from theme variables to orange (#F5A623) with white icon color
- **Button styling**: 
  - Increased size from 46px to 50px
  - Removed border (was 1.5px solid)
  - Updated box-shadow to orange-tinted shadow (rgba(245, 166, 35, 0.45))
- **Interactive states**:
  - Hover: Darker orange background (#e09615) with enhanced shadow
  - Active: Added new active state with scale-down effect (0.96) and reduced shadow
- **Icon sizing**: Added explicit 24x24px dimensions for the SVG icon via new CSS class
- **Transition cleanup**: Removed border-color from transition properties (no longer needed)

## Implementation Details
- The SVG icon uses `currentColor` for stroke, allowing it to inherit the button's text color (#ffffff)
- Icon maintains aspect ratio and scales responsively within the button
- Active state provides tactile feedback with scale transformation
- Shadow effects use the same orange color for visual consistency

https://claude.ai/code/session_01HZw6Pb5j7iETSLzS6anoRJ