### PR TITLE
Remove compass button from map; keep permission modal on first visit

### DIFF
--- a/sunny_sales_web/src/pages/ModernMapLayout.jsx
+++ b/sunny_sales_web/src/pages/ModernMapLayout.jsx
@@ -538,18 +538,6 @@ export default function ModernMapLayout() {
             </div>
           )}
 
-          {/* Fallback compass button if modal was dismissed but permission still needed */}
-          {needsCompassPermission && !compassReady && !showCompassModal && (
-            <button
-              className="compass-btn"
-              onClick={() => setShowCompassModal(true)}
-              aria-label="Ativar bússola"
-              title="Ativar bússola"
-            >
-              🧭
-            </button>
-          )}
-
           {/* Nearby vendors badge */}
           {!isVendorLogged && nearbyVendorsCount !== null && (
             <div className="nearby-vendors-badge">


### PR DESCRIPTION
The visible compass button (fallback trigger) is removed from the map UI.
The device orientation permission modal still appears automatically on the
first iOS visit so the compass functionality remains available.