### PR TITLE
Redesign seller account settings and add payment methods

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -56,6 +56,7 @@ def ensure_latest_schema():
             ("confirmation_token", "ALTER TABLE vendors ADD COLUMN confirmation_token TEXT"),
             ("password_reset_token", "ALTER TABLE vendors ADD COLUMN password_reset_token TEXT"),
             ("password_reset_expires", "ALTER TABLE vendors ADD COLUMN password_reset_expires TIMESTAMP"),
+            ("payment_methods", "ALTER TABLE vendors ADD COLUMN payment_methods TEXT"),
         ]
         with engine.begin() as conn:
             for col, stmt in migrations:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -551,6 +551,7 @@ async def update_vendor_profile(
     product: str = Form(None),
     profile_photo: UploadFile = File(None),
     pin_color: str = Form(None),
+    payment_methods: str = Form(None),
     db: Session = Depends(get_db),
     current_vendor: models.Vendor = Depends(get_current_vendor),
 ):
@@ -586,6 +587,8 @@ async def update_vendor_profile(
             _delete_file(old_photo_path)
     if pin_color:
         vendor.pin_color = pin_color
+    if payment_methods is not None:
+        vendor.payment_methods = payment_methods
 
     db.commit()
     db.refresh(vendor)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -33,6 +33,7 @@ class Vendor(Base):
     # Token da sessão atualmente ativa. Quando um novo token é gerado,
     # o valor anterior é substituído para garantir apenas uma sessão por vendedor
     session_token = Column(String, nullable=True, index=True)
+    payment_methods = Column(String, nullable=True)  # e.g. "Numerário,MB Way,Cartão"
 
     routes = relationship("Route", back_populates="vendor")
     sessions = relationship(

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -47,6 +47,7 @@ class VendorOut(BaseModel):
     subscription_active: Optional[bool] = None
     subscription_valid_until: Optional[datetime] = None
     last_seen: Optional[str] = None
+    payment_methods: Optional[str] = None
     # Configuração para permitir criação a partir de objetos ORM
     model_config = ConfigDict(from_attributes=True)
 

--- a/sunny_sales_web/src/pages/ManageAccount.css
+++ b/sunny_sales_web/src/pages/ManageAccount.css
@@ -1,0 +1,441 @@
+/* ── Wrapper ─────────────────────────────────────────── */
+
+.ma-wrapper {
+  min-height: 60vh;
+  padding-bottom: 3rem;
+}
+
+.ma-container {
+  max-width: 520px;
+  margin: 0 auto;
+  padding: 0 1rem 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.ma-title {
+  font-size: clamp(1.4rem, 5vw, 1.75rem);
+  font-weight: 800;
+  color: var(--text);
+  letter-spacing: -0.3px;
+  margin: 0 0 4px;
+}
+
+.ma-form {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+/* ── Photo section ───────────────────────────────────── */
+
+.ma-photo-section {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 16px 0 4px;
+}
+
+.ma-avatar-btn {
+  position: relative;
+  width: 96px;
+  height: 96px;
+  border-radius: 50%;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  background: transparent;
+  flex-shrink: 0;
+  box-shadow: var(--shadow-warm);
+  min-height: auto;
+}
+
+.ma-avatar {
+  width: 96px;
+  height: 96px;
+  border-radius: 50%;
+  object-fit: cover;
+  border: 3px solid var(--primary-light-solid);
+  display: block;
+}
+
+.ma-avatar-placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--primary-light-solid);
+  color: var(--primary-dark);
+  font-size: 2rem;
+  font-weight: 800;
+  border: 3px solid var(--primary-light-solid);
+}
+
+.ma-avatar-overlay {
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  background: rgba(0, 0, 0, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  transition: opacity var(--transition);
+}
+
+.ma-avatar-btn:hover .ma-avatar-overlay,
+.ma-avatar-btn:focus .ma-avatar-overlay {
+  opacity: 1;
+}
+
+.ma-avatar-cam {
+  color: #fff;
+  font-size: 1.5rem;
+}
+
+.ma-photo-hint {
+  font-size: 0.78rem;
+  color: var(--text-muted);
+}
+
+/* ── Alerts ──────────────────────────────────────────── */
+
+.ma-alert {
+  border-radius: var(--radius-md);
+  padding: 12px 16px;
+  font-size: 0.875rem;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  animation: fadeIn 0.2s ease;
+}
+
+.ma-alert-error {
+  background: rgba(239, 68, 68, 0.10);
+  color: #c62828;
+  border: 1px solid rgba(239, 68, 68, 0.25);
+}
+
+.ma-alert-success {
+  background: rgba(76, 175, 80, 0.10);
+  color: #2e7d32;
+  border: 1px solid rgba(76, 175, 80, 0.25);
+}
+
+/* ── Cards ───────────────────────────────────────────── */
+
+.ma-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-xl);
+  padding: 20px;
+  box-shadow: var(--shadow-sm);
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.ma-card-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.ma-card-toggle {
+  background: transparent;
+  border: none;
+  padding: 0;
+  width: 100%;
+  cursor: pointer;
+  min-height: auto;
+  box-shadow: none;
+  justify-content: space-between;
+}
+
+.ma-card-toggle:hover,
+.ma-card-toggle:active {
+  background: transparent;
+  transform: none;
+  box-shadow: none;
+  color: inherit;
+}
+
+.ma-card-header-left {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.ma-card-icon {
+  color: var(--primary);
+  font-size: 1.05rem;
+  flex-shrink: 0;
+}
+
+.ma-card-title {
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: var(--text);
+}
+
+.ma-card-desc {
+  font-size: 0.82rem;
+  color: var(--text-muted);
+  margin: -6px 0 0;
+}
+
+.ma-toggle-icon {
+  color: var(--text-muted);
+  font-size: 1rem;
+  flex-shrink: 0;
+}
+
+.ma-card-body {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  animation: fadeIn 0.22s ease;
+}
+
+/* ── Fields ──────────────────────────────────────────── */
+
+.ma-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.ma-label {
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--text-muted);
+}
+
+.ma-input {
+  background: var(--surface-alt);
+  border: 1.5px solid var(--border-strong);
+  border-radius: var(--radius-sm);
+  padding: 12px 14px;
+  font-size: 0.9rem;
+  font-family: inherit;
+  color: var(--text);
+  outline: none;
+  transition: border-color var(--transition), box-shadow var(--transition);
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.ma-input::placeholder {
+  color: var(--text-muted);
+}
+
+.ma-input:focus {
+  border-color: var(--primary);
+  box-shadow: 0 0 0 3px rgba(10, 147, 150, 0.12);
+  background: var(--surface);
+}
+
+/* ── Product chips ───────────────────────────────────── */
+
+.ma-product-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.ma-product-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: var(--surface-alt);
+  border: 1.5px solid var(--border-strong);
+  border-radius: var(--radius-full);
+  padding: 8px 16px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  cursor: pointer;
+  min-height: auto;
+  box-shadow: none;
+  transition: all var(--transition);
+}
+
+.ma-product-chip:hover {
+  border-color: var(--primary);
+  color: var(--primary-dark);
+  background: var(--primary-light);
+  transform: none;
+  box-shadow: none;
+}
+
+.ma-product-chip.selected {
+  background: var(--primary);
+  border-color: var(--primary);
+  color: #fff;
+  box-shadow: var(--shadow-warm);
+}
+
+.ma-chip-check {
+  font-size: 0.85rem;
+}
+
+/* ── Color picker ────────────────────────────────────── */
+
+.ma-color-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.ma-color-input {
+  width: 44px;
+  height: 44px;
+  border-radius: var(--radius-sm);
+  border: 1.5px solid var(--border-strong);
+  padding: 3px;
+  cursor: pointer;
+  background: transparent;
+  flex-shrink: 0;
+}
+
+.ma-color-preview {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  border: 2px solid rgba(0, 0, 0, 0.08);
+  flex-shrink: 0;
+  box-shadow: var(--shadow-xs);
+}
+
+.ma-color-value {
+  font-size: 0.82rem;
+  color: var(--text-muted);
+  font-family: 'Courier New', monospace;
+  letter-spacing: 0.03em;
+}
+
+/* ── Payment method chips ────────────────────────────── */
+
+.ma-payment-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.ma-payment-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  background: var(--surface-alt);
+  border: 1.5px solid var(--border-strong);
+  border-radius: var(--radius-md);
+  padding: 11px 15px;
+  font-size: 0.88rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  cursor: pointer;
+  min-height: auto;
+  box-shadow: none;
+  transition: all var(--transition);
+}
+
+.ma-payment-chip:hover {
+  border-color: var(--primary);
+  color: var(--primary-dark);
+  background: var(--primary-light);
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-xs);
+}
+
+.ma-payment-chip.active {
+  background: var(--primary);
+  border-color: var(--primary);
+  color: #fff;
+  box-shadow: var(--shadow-warm);
+}
+
+.ma-payment-chip.active:hover {
+  background: var(--primary-hover);
+  border-color: var(--primary-hover);
+  color: #fff;
+}
+
+.ma-payment-icon {
+  font-size: 1rem;
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+}
+
+.ma-payment-label {
+  line-height: 1;
+}
+
+.ma-payment-check {
+  font-size: 0.85rem;
+  flex-shrink: 0;
+  opacity: 0.9;
+}
+
+/* ── Save button ─────────────────────────────────────── */
+
+.ma-save-btn {
+  background: var(--primary);
+  color: #fff;
+  border: none;
+  border-radius: var(--radius-full);
+  padding: 14px 32px;
+  font-size: 0.95rem;
+  font-weight: 700;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  box-shadow: var(--shadow-warm);
+  transition: background var(--transition), box-shadow var(--transition), transform var(--transition);
+  width: 100%;
+  margin-top: 4px;
+}
+
+.ma-save-btn:hover:not(:disabled) {
+  background: var(--primary-hover);
+  box-shadow: var(--shadow-warm-lg);
+  transform: translateY(-1px);
+}
+
+.ma-save-btn:active:not(:disabled) {
+  transform: translateY(0);
+}
+
+.ma-save-btn:disabled {
+  opacity: 0.65;
+  cursor: not-allowed;
+}
+
+/* ── Responsive ──────────────────────────────────────── */
+
+@media (max-width: 480px) {
+  .ma-avatar-btn,
+  .ma-avatar {
+    width: 82px;
+    height: 82px;
+  }
+
+  .ma-avatar-placeholder {
+    font-size: 1.7rem;
+  }
+
+  .ma-card {
+    padding: 16px;
+  }
+
+  .ma-payment-chip {
+    padding: 10px 13px;
+    font-size: 0.84rem;
+  }
+}

--- a/sunny_sales_web/src/pages/ManageAccount.jsx
+++ b/sunny_sales_web/src/pages/ManageAccount.jsx
@@ -1,24 +1,40 @@
-// (em português) Página Web para gestão de conta (alterar/remover conta)
-
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import axios from 'axios';
 import { BASE_URL } from '../config';
 import ImageCropper from '../components/ImageCropper';
 import BackHomeButton from '../components/BackHomeButton';
+import {
+  FiUser, FiLock, FiPackage, FiCamera, FiCheck,
+  FiDollarSign, FiSmartphone, FiTerminal, FiCreditCard, FiWifi,
+  FiChevronDown, FiChevronUp, FiSave,
+} from 'react-icons/fi';
+import './ManageAccount.css';
 
-// Página para o vendedor atualizar ou remover a sua conta
+const PAYMENT_METHODS = [
+  { id: 'Numerário', label: 'Numerário', icon: <FiDollarSign /> },
+  { id: 'MB Way', label: 'MB Way', icon: <FiSmartphone /> },
+  { id: 'Multibanco', label: 'Multibanco', icon: <FiTerminal /> },
+  { id: 'Cartão', label: 'Cartão', icon: <FiCreditCard /> },
+  { id: 'NFC', label: 'NFC', icon: <FiWifi /> },
+];
+
 export default function ManageAccount() {
   const [vendor, setVendor] = useState(null);
   const [name, setName] = useState('');
   const [email, setEmail] = useState('');
   const [product, setProduct] = useState('');
   const [pinColor, setPinColor] = useState('#FFB6C1');
-  const [photo, setPhoto] = useState(null); // blob da foto cortada
+  const [photo, setPhoto] = useState(null);
+  const [photoPreview, setPhotoPreview] = useState(null);
   const [cropSrc, setCropSrc] = useState(null);
-  const [password, setPassword] = useState('');
   const [oldPassword, setOldPassword] = useState('');
+  const [password, setPassword] = useState('');
+  const [paymentMethods, setPaymentMethods] = useState([]);
+  const [showSecurity, setShowSecurity] = useState(false);
+  const [saving, setSaving] = useState(false);
   const [error, setError] = useState('');
   const [success, setSuccess] = useState('');
+  const fileInputRef = useRef(null);
 
   useEffect(() => {
     const stored = localStorage.getItem('user');
@@ -29,16 +45,15 @@ export default function ManageAccount() {
       setEmail(v.email || '');
       setProduct(v.product || '');
       setPinColor(v.pin_color || '#FFB6C1');
+      if (v.payment_methods) {
+        setPaymentMethods(v.payment_methods.split(',').filter(Boolean));
+      }
     }
   }, []);
 
-  // Abre a interface de corte ao selecionar uma imagem
   const handlePhotoChange = (e) => {
     const file = e.target.files[0];
-    if (file) {
-      const url = URL.createObjectURL(file);
-      setCropSrc(url);
-    }
+    if (file) setCropSrc(URL.createObjectURL(file));
   };
 
   const handleCropCancel = () => {
@@ -50,12 +65,22 @@ export default function ManageAccount() {
     if (cropSrc) URL.revokeObjectURL(cropSrc);
     setCropSrc(null);
     setPhoto(blob);
+    if (photoPreview) URL.revokeObjectURL(photoPreview);
+    setPhotoPreview(URL.createObjectURL(blob));
   };
 
-  // Envia as alterações do formulário para o backend
+  const togglePayment = (id) => {
+    setPaymentMethods(prev =>
+      prev.includes(id) ? prev.filter(m => m !== id) : [...prev, id]
+    );
+  };
+
   const handleUpdate = async (e) => {
     e.preventDefault();
     if (!vendor) return;
+    setSaving(true);
+    setError('');
+    setSuccess('');
     try {
       const data = new FormData();
       if (name !== vendor.name) data.append('name', name);
@@ -65,116 +90,228 @@ export default function ManageAccount() {
         data.append('old_password', oldPassword);
       }
       if (product !== vendor.product) data.append('product', product);
-      if (pinColor !== (vendor.pin_color || '#FFB6C1'))
-        data.append('pin_color', pinColor);
-      if (photo) {
-        const file = new File([photo], 'profile.jpg', { type: 'image/jpeg' });
-        data.append('profile_photo', file);
-      }
+      if (pinColor !== (vendor.pin_color || '#FFB6C1')) data.append('pin_color', pinColor);
+      if (photo) data.append('profile_photo', new File([photo], 'profile.jpg', { type: 'image/jpeg' }));
+
+      const newMethods = paymentMethods.join(',');
+      if (newMethods !== (vendor.payment_methods || '')) data.append('payment_methods', newMethods);
+
       const token = localStorage.getItem('token');
       const res = await axios.patch(
         `${BASE_URL}/vendors/${vendor.id}/profile`,
         data,
-        {
-          headers: {
-            'Content-Type': 'multipart/form-data',
-            Authorization: `Bearer ${token}`,
-          },
-        }
+        { headers: { 'Content-Type': 'multipart/form-data', Authorization: `Bearer ${token}` } }
       );
       localStorage.setItem('user', JSON.stringify(res.data));
       setVendor(res.data);
-      setSuccess('Dados atualizados com sucesso');
-      setError('');
+      setSuccess('Dados atualizados com sucesso!');
       setPassword('');
       setOldPassword('');
       setPhoto(null);
+      if (photoPreview) { URL.revokeObjectURL(photoPreview); setPhotoPreview(null); }
     } catch (err) {
-      console.error(err);
-      setError('Erro ao atualizar');
-      setSuccess('');
+      setError(err.response?.data?.detail || 'Erro ao atualizar. Tente novamente.');
+    } finally {
+      setSaving(false);
     }
   };
 
+  const avatarSrc = photoPreview
+    || (vendor?.profile_photo ? `${BASE_URL.replace(/\/$/, '')}/${vendor.profile_photo}` : null);
+
   if (!vendor) {
     return (
-      <div className="form-box">
+      <div className="ma-wrapper">
         <BackHomeButton />
-        <h2 className="title">Definições de Conta</h2>
-        <p>Utilizador não autenticado.</p>
+        <p style={{ textAlign: 'center', color: 'var(--text-muted)' }}>Utilizador não autenticado.</p>
       </div>
     );
   }
 
   return (
-    <div className="form-box">
+    <div className="ma-wrapper">
       <BackHomeButton />
-      <h2 className="title">Definições de Conta</h2>
-      <form onSubmit={handleUpdate} className="form">
-        {error && <p style={{ color: 'red' }}>{error}</p>}
-        {success && <p style={{ color: 'black' }}>{success}</p>}
-        <span className="input-span">
-          <label className="label">Nome</label>
-          <input
-            type="text"
-            placeholder="Nome"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-          />
-        </span>
-        <span className="input-span">
-          <label className="label">Email</label>
-          <input
-            type="email"
-            placeholder="Email"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-          />
-        </span>
-        <span className="input-span">
-          <label className="label">Palavra-passe atual</label>
-          <input
-            type="password"
-            placeholder="Palavra-passe atual"
-            value={oldPassword}
-            onChange={(e) => setOldPassword(e.target.value)}
-          />
-        </span>
-        <span className="input-span">
-          <label className="label">Nova palavra-passe</label>
-          <input
-            type="password"
-            placeholder="Nova palavra-passe"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-          />
-        </span>
-        <span className="input-span">
-          <label className="label">Produto</label>
-          <select
-            value={product}
-            onChange={(e) => setProduct(e.target.value)}
-          >
-            <option value="Bolas de Berlim">Bolas de Berlim</option>
-            <option value="Gelados">Gelados</option>
-            <option value="Acessórios de Praia">Acessórios de Praia</option>
-          </select>
-        </span>
-        <span className="input-span">
-          <label className="label">Cor do Pin</label>
-          <input
-            type="color"
-            value={pinColor}
-            onChange={(e) => setPinColor(e.target.value)}
-            style={{ backgroundColor: pinColor }}
-          />
-        </span>
-        <span className="input-span">
-          <label className="label">Foto</label>
-          <input type="file" onChange={handlePhotoChange} />
-        </span>
-        <button type="submit" className="submit">Guardar</button>
-      </form>
+      <div className="ma-container">
+        <h1 className="ma-title">Definições de Conta</h1>
+
+        <form onSubmit={handleUpdate} className="ma-form">
+
+          {/* Avatar */}
+          <div className="ma-photo-section">
+            <button
+              type="button"
+              className="ma-avatar-btn"
+              onClick={() => fileInputRef.current?.click()}
+              aria-label="Alterar foto de perfil"
+            >
+              {avatarSrc ? (
+                <img src={avatarSrc} alt="Foto de perfil" className="ma-avatar" />
+              ) : (
+                <div className="ma-avatar ma-avatar-placeholder">
+                  {vendor.name?.charAt(0)?.toUpperCase() || '?'}
+                </div>
+              )}
+              <div className="ma-avatar-overlay">
+                <FiCamera className="ma-avatar-cam" />
+              </div>
+            </button>
+            <span className="ma-photo-hint">Toca para alterar a foto</span>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept="image/*"
+              onChange={handlePhotoChange}
+              style={{ display: 'none' }}
+            />
+          </div>
+
+          {error && <div className="ma-alert ma-alert-error">{error}</div>}
+          {success && (
+            <div className="ma-alert ma-alert-success">
+              <FiCheck /> {success}
+            </div>
+          )}
+
+          {/* Dados Pessoais */}
+          <div className="ma-card">
+            <div className="ma-card-header">
+              <FiUser className="ma-card-icon" />
+              <span className="ma-card-title">Dados Pessoais</span>
+            </div>
+            <div className="ma-field">
+              <label className="ma-label">Nome completo</label>
+              <input
+                className="ma-input"
+                type="text"
+                placeholder="O teu nome"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+              />
+            </div>
+            <div className="ma-field">
+              <label className="ma-label">Email</label>
+              <input
+                className="ma-input"
+                type="email"
+                placeholder="email@exemplo.com"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+              />
+            </div>
+          </div>
+
+          {/* Segurança */}
+          <div className="ma-card">
+            <button
+              type="button"
+              className="ma-card-header ma-card-toggle"
+              onClick={() => setShowSecurity(v => !v)}
+              aria-expanded={showSecurity}
+            >
+              <span className="ma-card-header-left">
+                <FiLock className="ma-card-icon" />
+                <span className="ma-card-title">Segurança</span>
+              </span>
+              {showSecurity ? <FiChevronUp className="ma-toggle-icon" /> : <FiChevronDown className="ma-toggle-icon" />}
+            </button>
+            {showSecurity && (
+              <div className="ma-card-body">
+                <div className="ma-field">
+                  <label className="ma-label">Palavra-passe atual</label>
+                  <input
+                    className="ma-input"
+                    type="password"
+                    placeholder="Palavra-passe atual"
+                    value={oldPassword}
+                    onChange={(e) => setOldPassword(e.target.value)}
+                    autoComplete="current-password"
+                  />
+                </div>
+                <div className="ma-field">
+                  <label className="ma-label">Nova palavra-passe</label>
+                  <input
+                    className="ma-input"
+                    type="password"
+                    placeholder="Mínimo 8 caracteres, maiúscula e número"
+                    value={password}
+                    onChange={(e) => setPassword(e.target.value)}
+                    autoComplete="new-password"
+                  />
+                </div>
+              </div>
+            )}
+          </div>
+
+          {/* Produto & Aparência */}
+          <div className="ma-card">
+            <div className="ma-card-header">
+              <FiPackage className="ma-card-icon" />
+              <span className="ma-card-title">Produto & Aparência</span>
+            </div>
+            <div className="ma-field">
+              <label className="ma-label">Tipo de produto</label>
+              <div className="ma-product-grid">
+                {['Bolas de Berlim', 'Gelados', 'Acessórios de Praia'].map(p => (
+                  <button
+                    key={p}
+                    type="button"
+                    className={`ma-product-chip${product === p ? ' selected' : ''}`}
+                    onClick={() => setProduct(p)}
+                  >
+                    {product === p && <FiCheck className="ma-chip-check" />}
+                    {p}
+                  </button>
+                ))}
+              </div>
+            </div>
+            <div className="ma-field">
+              <label className="ma-label">Cor do pin no mapa</label>
+              <div className="ma-color-row">
+                <input
+                  type="color"
+                  value={pinColor}
+                  onChange={(e) => setPinColor(e.target.value)}
+                  className="ma-color-input"
+                />
+                <span className="ma-color-preview" style={{ backgroundColor: pinColor }} />
+                <span className="ma-color-value">{pinColor.toUpperCase()}</span>
+              </div>
+            </div>
+          </div>
+
+          {/* Métodos de Pagamento */}
+          <div className="ma-card">
+            <div className="ma-card-header">
+              <FiCreditCard className="ma-card-icon" />
+              <span className="ma-card-title">Métodos de Pagamento</span>
+            </div>
+            <p className="ma-card-desc">Indica quais os métodos que aceitas dos clientes.</p>
+            <div className="ma-payment-grid">
+              {PAYMENT_METHODS.map(({ id, label, icon }) => {
+                const active = paymentMethods.includes(id);
+                return (
+                  <button
+                    key={id}
+                    type="button"
+                    className={`ma-payment-chip${active ? ' active' : ''}`}
+                    onClick={() => togglePayment(id)}
+                    aria-pressed={active}
+                  >
+                    <span className="ma-payment-icon">{icon}</span>
+                    <span className="ma-payment-label">{label}</span>
+                    {active && <FiCheck className="ma-payment-check" />}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          <button type="submit" className="ma-save-btn" disabled={saving}>
+            <FiSave />
+            {saving ? 'A guardar…' : 'Guardar Alterações'}
+          </button>
+        </form>
+      </div>
 
       {cropSrc && (
         <ImageCropper
@@ -186,4 +323,3 @@ export default function ManageAccount() {
     </div>
   );
 }
-

--- a/sunny_sales_web/src/pages/VendorDashboard.css
+++ b/sunny_sales_web/src/pages/VendorDashboard.css
@@ -371,6 +371,39 @@
   flex-shrink: 0;
 }
 
+.vd-detail-payments {
+  align-items: flex-start;
+}
+
+.vd-payments-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+}
+
+.vd-payment-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  background: var(--primary-light);
+  color: var(--primary-dark);
+  border-radius: var(--radius-full);
+  padding: 3px 9px 3px 6px;
+  font-size: 0.75rem;
+  font-weight: 700;
+  border: 1px solid rgba(10, 147, 150, 0.18);
+}
+
+.vd-payment-badge-icon {
+  font-size: 0.8rem;
+  display: flex;
+  align-items: center;
+}
+
+.vd-payment-badge-label {
+  line-height: 1;
+}
+
 /* ── Subscription CTA ────────────────────────────────── */
 
 .vd-cta-card {

--- a/sunny_sales_web/src/pages/VendorDashboard.jsx
+++ b/sunny_sales_web/src/pages/VendorDashboard.jsx
@@ -5,8 +5,16 @@ import axios from 'axios';
 import {
   FiMap, FiBarChart2, FiCalendar, FiUser, FiFileText, FiClock,
   FiCreditCard, FiShield, FiMail, FiMapPin, FiLogOut, FiMenu, FiX,
-  FiChevronRight,
+  FiChevronRight, FiDollarSign, FiSmartphone, FiTerminal, FiWifi,
 } from 'react-icons/fi';
+
+const PAYMENT_ICONS = {
+  'Numerário': <FiDollarSign />,
+  'MB Way': <FiSmartphone />,
+  'Multibanco': <FiTerminal />,
+  'Cartão': <FiCreditCard />,
+  'NFC': <FiWifi />,
+};
 import './VendorDashboard.css';
 
 let watchId = null;
@@ -269,6 +277,19 @@ export default function VendorDashboard() {
                   />
                 </span>
               </div>
+              {vendor.payment_methods && (
+                <div className="vd-detail-item vd-detail-payments">
+                  <span className="vd-detail-label">Pagamentos</span>
+                  <div className="vd-payments-row">
+                    {vendor.payment_methods.split(',').filter(Boolean).map(m => (
+                      <span key={m} className="vd-payment-badge" title={m}>
+                        <span className="vd-payment-badge-icon">{PAYMENT_ICONS[m] || <FiCreditCard />}</span>
+                        <span className="vd-payment-badge-label">{m}</span>
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              )}
             </div>
           </div>
         )}


### PR DESCRIPTION
- Rebuilt ManageAccount with section cards (dados pessoais, segurança,
  produto & aparência, métodos de pagamento) and a live photo preview
- Added payment methods toggles (Numerário, MB Way, Multibanco, Cartão, NFC)
  as interactive chips with icons
- Security section is collapsible to reduce visual noise
- Product selector replaced with pill chips; pin color shows live preview
- Added payment_methods column to Vendor model with auto-migration
- VendorOut schema and profile PATCH endpoint now expose payment_methods
- Dashboard profile card shows accepted payment method badges