### PR TITLE
Show product and payment methods on seller pin card

### DIFF
--- a/sunny_sales_web/src/pages/ModernMapLayout.css
+++ b/sunny_sales_web/src/pages/ModernMapLayout.css
@@ -511,10 +511,48 @@ body {
 }
 
 .card-name {
-  margin: 0 0 4px;
+  margin: 0 0 6px;
   font-size: 0.95rem;
   font-weight: 700;
   color: var(--text);
+}
+
+.card-product {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  background: var(--primary-light);
+  color: var(--primary);
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 3px 8px;
+  border-radius: var(--radius-full);
+  margin-bottom: 10px;
+}
+
+.card-payments {
+  display: flex;
+  justify-content: center;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.card-payment-chip {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: var(--radius-full);
+  background: var(--surface-alt);
+  color: var(--text-secondary);
+  border: 1px solid var(--border);
+  transition: background var(--transition), color var(--transition);
+}
+
+.card-payment-chip:hover {
+  background: var(--primary-light);
+  color: var(--primary);
 }
 
 /* ── Locate buttons ───────────────────────────────────── */

--- a/sunny_sales_web/src/pages/ModernMapLayout.jsx
+++ b/sunny_sales_web/src/pages/ModernMapLayout.jsx
@@ -9,8 +9,19 @@ import VendorLocateButton from '../components/VendorLocateButton';
 import LocateHint from '../components/LocateHint';
 import BeachConditions from '../components/BeachConditions';
 import WelcomeCard from '../components/WelcomeCard';
-import { FiMapPin, FiFilter, FiCheck } from 'react-icons/fi';
+import {
+  FiMapPin, FiFilter, FiCheck,
+  FiDollarSign, FiSmartphone, FiTerminal, FiCreditCard, FiWifi, FiTag,
+} from 'react-icons/fi';
 import './ModernMapLayout.css';
+
+const PAYMENT_ICONS = {
+  'Numerário':   FiDollarSign,
+  'MB Way':      FiSmartphone,
+  'Multibanco':  FiTerminal,
+  'Cartão':      FiCreditCard,
+  'NFC':         FiWifi,
+};
 
 const DISTANCE_OPTIONS = [
   { label: 'Todos', value: null },
@@ -669,11 +680,30 @@ export default function ModernMapLayout() {
                 />
               ) : (
                 <div
-                  className="card-photo"
+                  className="card-photo card-photo--placeholder"
                   style={{ background: selected.pin_color || '#ccc' }}
                 />
               )}
               <h4 className="card-name">{selected.name}</h4>
+              {selected.product && (
+                <div className="card-product">
+                  <FiTag size={12} />
+                  <span>{selected.product}</span>
+                </div>
+              )}
+              {selected.payment_methods && (
+                <div className="card-payments">
+                  {selected.payment_methods.split(',').map((m) => {
+                    const method = m.trim();
+                    const Icon = PAYMENT_ICONS[method];
+                    return Icon ? (
+                      <span key={method} className="card-payment-chip" title={method}>
+                        <Icon size={14} />
+                      </span>
+                    ) : null;
+                  })}
+                </div>
+              )}
             </div>
           )}
         </main>


### PR DESCRIPTION
When a user taps a seller's map pin, the popup card now displays
the product being sold (with a tag icon) and the accepted payment
methods as icon chips (Numerário, MB Way, Multibanco, Cartão, NFC).

https://claude.ai/code/session_01E4iSNz4y4DDhAe81wLGuSW