### PR TITLE
Redesign routes, stats, and subscription pages to match profile UI

### DIFF
--- a/sunny_sales_web/package-lock.json
+++ b/sunny_sales_web/package-lock.json
@@ -14,6 +14,7 @@
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-icons": "^4.11.0",
+        "react-is": "^19.2.7",
         "react-leaflet": "^5.0.0",
         "react-router-dom": "^7.6.3",
         "recharts": "^3.0.2"
@@ -1499,7 +1500,7 @@
       "version": "19.1.8",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.8.tgz",
       "integrity": "sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -1817,7 +1818,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/d3-array": {
@@ -3096,11 +3097,10 @@
       }
     },
     "node_modules/react-is": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.1.0.tgz",
-      "integrity": "sha512-Oe56aUPnkHyyDxxkvqtd7KkdQP5uIUfHxd5XTb3wE9d/kRnZLmKbDB0GWk919tdQ+mxxPtG6EAs6RMT6i1qtHg==",
-      "license": "MIT",
-      "peer": true
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.7.tgz",
+      "integrity": "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==",
+      "license": "MIT"
     },
     "node_modules/react-leaflet": {
       "version": "5.0.0",

--- a/sunny_sales_web/package.json
+++ b/sunny_sales_web/package.json
@@ -16,6 +16,7 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-icons": "^4.11.0",
+    "react-is": "^19.2.7",
     "react-leaflet": "^5.0.0",
     "react-router-dom": "^7.6.3",
     "recharts": "^3.0.2"

--- a/sunny_sales_web/src/pages/PaidWeeksScreen.css
+++ b/sunny_sales_web/src/pages/PaidWeeksScreen.css
@@ -1,0 +1,272 @@
+/* ── Wrapper ─────────────────────────────────────────── */
+
+.pw-wrapper {
+  min-height: 60vh;
+  padding-bottom: 3rem;
+}
+
+.pw-container {
+  max-width: 520px;
+  margin: 0 auto;
+  padding: 0 1rem 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+/* ── Header ──────────────────────────────────────────── */
+
+.pw-header {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding-bottom: 4px;
+}
+
+.pw-header-icon {
+  width: 46px;
+  height: 46px;
+  border-radius: var(--radius-md);
+  background: var(--primary-light);
+  color: var(--primary);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.3rem;
+  flex-shrink: 0;
+}
+
+.pw-title {
+  font-size: clamp(1.3rem, 5vw, 1.65rem);
+  font-weight: 800;
+  color: var(--text);
+  letter-spacing: -0.3px;
+  margin: 0 0 2px;
+}
+
+.pw-subtitle {
+  font-size: 0.82rem;
+  color: var(--text-muted);
+  margin: 0;
+}
+
+/* ── Summary bar ─────────────────────────────────────── */
+
+.pw-summary {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-xl);
+  padding: 18px 20px;
+  display: flex;
+  align-items: center;
+  justify-content: space-around;
+  box-shadow: var(--shadow-sm);
+  gap: 8px;
+}
+
+.pw-stat {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  flex: 1;
+}
+
+.pw-stat-value {
+  font-size: 1.35rem;
+  font-weight: 800;
+  color: var(--primary-dark);
+  line-height: 1;
+}
+
+.pw-stat-label {
+  font-size: 0.72rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  text-align: center;
+}
+
+.pw-stat-divider {
+  width: 1px;
+  height: 36px;
+  background: var(--border-strong);
+  flex-shrink: 0;
+}
+
+/* ── Loading ─────────────────────────────────────────── */
+
+.pw-loading {
+  display: flex;
+  justify-content: center;
+  padding: 3rem 0;
+}
+
+.pw-spinner {
+  width: 32px;
+  height: 32px;
+  border: 3px solid var(--border-strong);
+  border-top-color: var(--primary);
+  border-radius: 50%;
+  animation: pw-spin 0.7s linear infinite;
+}
+
+@keyframes pw-spin {
+  to { transform: rotate(360deg); }
+}
+
+/* ── Empty state ─────────────────────────────────────── */
+
+.pw-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  padding: 3rem 1rem;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-xl);
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.pw-empty-icon {
+  font-size: 2.2rem;
+  color: var(--border-strong);
+}
+
+/* ── Week list ───────────────────────────────────────── */
+
+.pw-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.pw-item {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-xl);
+  padding: 14px 16px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  box-shadow: var(--shadow-xs);
+  transition: box-shadow var(--transition), transform var(--transition);
+}
+
+.pw-item:hover {
+  box-shadow: var(--shadow-sm);
+  transform: translateY(-1px);
+}
+
+.pw-item-icon-wrap {
+  width: 40px;
+  height: 40px;
+  border-radius: var(--radius-md);
+  background: var(--primary-light);
+  color: var(--primary);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.05rem;
+  flex-shrink: 0;
+}
+
+.pw-item-icon {
+  font-size: 1rem;
+}
+
+.pw-item-body {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.pw-item-top {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.pw-item-dates {
+  font-size: 0.88rem;
+  font-weight: 700;
+  color: var(--text);
+}
+
+.pw-item-sub {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+/* ── Active badge ────────────────────────────────────── */
+
+.pw-badge-active {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  background: rgba(76, 175, 80, 0.12);
+  color: #2e7d32;
+  border: 1px solid rgba(76, 175, 80, 0.28);
+  border-radius: var(--radius-full);
+  padding: 2px 8px;
+  font-size: 0.7rem;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.pw-badge-active svg {
+  font-size: 0.7rem;
+}
+
+/* ── Receipt button ──────────────────────────────────── */
+
+.pw-receipt-btn {
+  width: 36px;
+  height: 36px;
+  border-radius: var(--radius-md);
+  background: var(--primary-light);
+  color: var(--primary);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1rem;
+  flex-shrink: 0;
+  text-decoration: none;
+  border: 1.5px solid rgba(10, 147, 150, 0.2);
+  transition: background var(--transition), box-shadow var(--transition);
+}
+
+.pw-receipt-btn:hover {
+  background: var(--primary);
+  color: #fff;
+  box-shadow: var(--shadow-warm);
+}
+
+/* ── Responsive ──────────────────────────────────────── */
+
+@media (max-width: 480px) {
+  .pw-summary {
+    padding: 14px 12px;
+  }
+
+  .pw-stat-value {
+    font-size: 1.15rem;
+  }
+
+  .pw-item {
+    padding: 12px 14px;
+  }
+
+  .pw-item-dates {
+    font-size: 0.82rem;
+  }
+}

--- a/sunny_sales_web/src/pages/PaidWeeksScreen.jsx
+++ b/sunny_sales_web/src/pages/PaidWeeksScreen.jsx
@@ -2,57 +2,117 @@ import React, { useState, useEffect } from 'react';
 import axios from 'axios';
 import { BASE_URL } from '../config';
 import BackHomeButton from '../components/BackHomeButton';
+import { FiCalendar, FiFileText, FiCheckCircle, FiCreditCard } from 'react-icons/fi';
+import './PaidWeeksScreen.css';
 
 export default function PaidWeeksScreen() {
   const [weeks, setWeeks] = useState([]);
-
-  const loadWeeks = async () => {
-    const stored = localStorage.getItem('user');
-    const token = localStorage.getItem('token');
-    if (!stored) return;
-    const vendor = JSON.parse(stored);
-    try {
-      const res = await axios.get(`${BASE_URL}/vendors/${vendor.id}/paid-weeks`, {
-        headers: token ? { Authorization: `Bearer ${token}` } : {},
-      });
-      setWeeks(res.data);
-    } catch (e) {
-      console.error('Erro ao carregar semanas:', e);
-    }
-  };
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    loadWeeks();
+    const stored = localStorage.getItem('user');
+    const token = localStorage.getItem('token');
+    if (!stored) { setLoading(false); return; }
+    const vendor = JSON.parse(stored);
+    axios.get(`${BASE_URL}/vendors/${vendor.id}/paid-weeks`, {
+      headers: token ? { Authorization: `Bearer ${token}` } : {},
+    })
+      .then(res => setWeeks(res.data))
+      .catch(e => console.error('Erro ao carregar semanas:', e))
+      .finally(() => setLoading(false));
   }, []);
 
+  const now = new Date();
+  const activeWeeks = weeks.filter(w => new Date(w.end_date) >= now);
+
   return (
-    <div className="page-wrapper">
+    <div className="pw-wrapper">
       <BackHomeButton />
-      <h2>Semanas Pagas</h2>
-      {weeks.length === 0 && (
-        <p className="page-empty">Sem semanas pagas registadas.</p>
-      )}
-      <ul className="page-list">
-        {weeks.map((item) => {
-          const start = new Date(item.start_date).toLocaleDateString('pt-PT');
-          const end = new Date(item.end_date).toLocaleDateString('pt-PT');
-          return (
-            <li key={item.id} className="page-list-item" style={{ cursor: 'default' }}>
-              <span className="page-list-item-title">{start} — {end}</span>
-              {item.receipt_url && (
-                <a
-                  href={item.receipt_url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="page-link-btn"
-                >
-                  Recibo
-                </a>
-              )}
-            </li>
-          );
-        })}
-      </ul>
+      <div className="pw-container">
+
+        <div className="pw-header">
+          <div className="pw-header-icon"><FiCreditCard /></div>
+          <div>
+            <h1 className="pw-title">Subscrição</h1>
+            <p className="pw-subtitle">Histórico de semanas pagas</p>
+          </div>
+        </div>
+
+        {weeks.length > 0 && (
+          <div className="pw-summary">
+            <div className="pw-stat">
+              <span className="pw-stat-value">{weeks.length}</span>
+              <span className="pw-stat-label">Semanas pagas</span>
+            </div>
+            <div className="pw-stat-divider" />
+            <div className="pw-stat">
+              <span className="pw-stat-value">{activeWeeks.length}</span>
+              <span className="pw-stat-label">Ativas agora</span>
+            </div>
+            <div className="pw-stat-divider" />
+            <div className="pw-stat">
+              <span className="pw-stat-value">{weeks.filter(w => w.receipt_url).length}</span>
+              <span className="pw-stat-label">Com recibo</span>
+            </div>
+          </div>
+        )}
+
+        {loading && (
+          <div className="pw-loading">
+            <div className="pw-spinner" />
+          </div>
+        )}
+
+        {!loading && weeks.length === 0 && (
+          <div className="pw-empty">
+            <FiCreditCard className="pw-empty-icon" />
+            <p>Sem semanas pagas registadas.</p>
+          </div>
+        )}
+
+        {!loading && weeks.length > 0 && (
+          <ul className="pw-list">
+            {weeks.map((item) => {
+              const startDate = new Date(item.start_date);
+              const endDate = new Date(item.end_date);
+              const isActive = endDate >= now;
+              const startStr = startDate.toLocaleDateString('pt-PT', { day: '2-digit', month: 'short', year: 'numeric' });
+              const endStr = endDate.toLocaleDateString('pt-PT', { day: '2-digit', month: 'short', year: 'numeric' });
+
+              return (
+                <li key={item.id} className="pw-item">
+                  <div className="pw-item-icon-wrap">
+                    <FiCalendar className="pw-item-icon" />
+                  </div>
+                  <div className="pw-item-body">
+                    <div className="pw-item-top">
+                      <span className="pw-item-dates">{startStr} — {endStr}</span>
+                      {isActive && (
+                        <span className="pw-badge-active">
+                          <FiCheckCircle />Ativa
+                        </span>
+                      )}
+                    </div>
+                    <span className="pw-item-sub">Semana de subscrição</span>
+                  </div>
+                  {item.receipt_url && (
+                    <a
+                      href={item.receipt_url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="pw-receipt-btn"
+                      title="Ver recibo"
+                    >
+                      <FiFileText />
+                    </a>
+                  )}
+                </li>
+              );
+            })}
+          </ul>
+        )}
+
+      </div>
     </div>
   );
 }

--- a/sunny_sales_web/src/pages/RouteDetail.css
+++ b/sunny_sales_web/src/pages/RouteDetail.css
@@ -1,0 +1,164 @@
+/* ── Wrapper ─────────────────────────────────────────── */
+
+.rd-wrapper {
+  min-height: 60vh;
+  padding-bottom: 3rem;
+}
+
+.rd-container {
+  max-width: 520px;
+  margin: 0 auto;
+  padding: 0 1rem 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+/* ── Header ──────────────────────────────────────────── */
+
+.rd-header {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding-bottom: 4px;
+}
+
+.rd-header-icon {
+  width: 46px;
+  height: 46px;
+  border-radius: var(--radius-md);
+  background: var(--primary-light);
+  color: var(--primary);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.3rem;
+  flex-shrink: 0;
+}
+
+.rd-title {
+  font-size: clamp(1.3rem, 5vw, 1.65rem);
+  font-weight: 800;
+  color: var(--text);
+  letter-spacing: -0.3px;
+  margin: 0 0 2px;
+}
+
+.rd-subtitle {
+  font-size: 0.82rem;
+  color: var(--text-muted);
+  margin: 0;
+  text-transform: capitalize;
+}
+
+/* ── Map ─────────────────────────────────────────────── */
+
+.rd-map {
+  height: 340px;
+  width: 100%;
+  border-radius: var(--radius-xl);
+  overflow: hidden;
+  box-shadow: var(--shadow-md);
+  border: 1px solid var(--border);
+}
+
+/* ── Stats grid ──────────────────────────────────────── */
+
+.rd-stats-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+}
+
+.rd-stat-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-xl);
+  padding: 16px 18px;
+  box-shadow: var(--shadow-xs);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.rd-stat-card--accent {
+  background: var(--primary-light-solid);
+  border-color: rgba(10, 147, 150, 0.2);
+}
+
+.rd-stat-card--accent .rd-stat-icon {
+  color: var(--primary-dark);
+}
+
+.rd-stat-card--accent .rd-stat-value {
+  color: var(--primary-dark);
+}
+
+.rd-stat-icon {
+  font-size: 1rem;
+  color: var(--primary);
+}
+
+.rd-stat-label {
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--text-muted);
+}
+
+.rd-stat-value {
+  font-size: 1.45rem;
+  font-weight: 800;
+  color: var(--text);
+  line-height: 1;
+}
+
+.rd-stat-unit {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+/* ── Empty state ─────────────────────────────────────── */
+
+.rd-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  padding: 3rem 1rem;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-xl);
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  max-width: 520px;
+  margin: 0 auto;
+}
+
+.rd-empty-icon {
+  font-size: 2.2rem;
+  color: var(--border-strong);
+}
+
+/* ── Responsive ──────────────────────────────────────── */
+
+@media (max-width: 480px) {
+  .rd-map {
+    height: 240px;
+    border-radius: var(--radius-lg);
+  }
+
+  .rd-stats-grid {
+    gap: 8px;
+  }
+
+  .rd-stat-card {
+    padding: 14px 14px;
+  }
+
+  .rd-stat-value {
+    font-size: 1.25rem;
+  }
+}

--- a/sunny_sales_web/src/pages/RouteDetail.jsx
+++ b/sunny_sales_web/src/pages/RouteDetail.jsx
@@ -3,13 +3,23 @@ import { useLocation } from 'react-router-dom';
 import { MapContainer, TileLayer, Polyline } from 'react-leaflet';
 import 'leaflet/dist/leaflet.css';
 import BackHomeButton from '../components/BackHomeButton';
+import { FiMapPin, FiClock, FiNavigation, FiCalendar } from 'react-icons/fi';
+import './RouteDetail.css';
 
 export default function RouteDetail() {
   const location = useLocation();
   const route = location.state?.route;
 
   if (!route) {
-    return <div className="page-wrapper"><p className="page-empty">Trajeto não encontrado.</p></div>;
+    return (
+      <div className="rd-wrapper">
+        <BackHomeButton />
+        <div className="rd-empty">
+          <FiMapPin className="rd-empty-icon" />
+          <p>Trajeto não encontrado.</p>
+        </div>
+      </div>
+    );
   }
 
   const polyline = route.points.map((p) => [p.lat, p.lng]);
@@ -17,42 +27,67 @@ export default function RouteDetail() {
   const start = new Date(route.start_time);
   const end = route.end_time ? new Date(route.end_time) : null;
   const durationMin = end ? Math.round((end - start) / 60000) : 0;
+  const km = (route.distance_m / 1000).toFixed(2);
+
+  const dateStr = start.toLocaleDateString('pt-PT', { weekday: 'long', day: '2-digit', month: 'long', year: 'numeric' });
 
   return (
-    <div className="page-wrapper">
+    <div className="rd-wrapper">
       <BackHomeButton />
+      <div className="rd-container">
 
-      <div className="route-map">
-        <MapContainer center={initial} zoom={15} style={{ width: '100%', height: '100%' }}>
-          <TileLayer
-            url="https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}.png"
-            attribution="&copy; <a href='https://openstreetmap.org'>OpenStreetMap</a> contributors &copy; <a href='https://carto.com/attributions'>CARTO</a>"
-            subdomains="abcd"
-            maxZoom={19}
-          />
-          <Polyline positions={polyline} color="var(--primary)" weight={4} />
-        </MapContainer>
-      </div>
-
-      <div className="route-info-card">
-        <div className="route-info-row">
-          <span className="route-info-label">Início</span>
-          <span className="route-info-value">{start.toLocaleString('pt-PT')}</span>
-        </div>
-        {end && (
-          <div className="route-info-row">
-            <span className="route-info-label">Fim</span>
-            <span className="route-info-value">{end.toLocaleString('pt-PT')}</span>
+        <div className="rd-header">
+          <div className="rd-header-icon"><FiMapPin /></div>
+          <div>
+            <h1 className="rd-title">Detalhe do Trajeto</h1>
+            <p className="rd-subtitle">{dateStr}</p>
           </div>
-        )}
-        <div className="route-info-row">
-          <span className="route-info-label">Duração</span>
-          <span className="route-info-value">{durationMin} min</span>
         </div>
-        <div className="route-info-row">
-          <span className="route-info-label">Distância</span>
-          <span className="route-info-value">{(route.distance_m / 1000).toFixed(2)} km</span>
+
+        <div className="rd-map">
+          <MapContainer center={initial} zoom={15} style={{ width: '100%', height: '100%' }}>
+            <TileLayer
+              url="https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}.png"
+              attribution="&copy; <a href='https://openstreetmap.org'>OpenStreetMap</a> contributors &copy; <a href='https://carto.com/attributions'>CARTO</a>"
+              subdomains="abcd"
+              maxZoom={19}
+            />
+            <Polyline positions={polyline} color="var(--primary)" weight={4} />
+          </MapContainer>
         </div>
+
+        <div className="rd-stats-grid">
+          <div className="rd-stat-card">
+            <div className="rd-stat-icon"><FiCalendar /></div>
+            <span className="rd-stat-label">Início</span>
+            <span className="rd-stat-value">
+              {start.toLocaleTimeString('pt-PT', { hour: '2-digit', minute: '2-digit' })}
+            </span>
+          </div>
+
+          {end && (
+            <div className="rd-stat-card">
+              <div className="rd-stat-icon"><FiCalendar /></div>
+              <span className="rd-stat-label">Fim</span>
+              <span className="rd-stat-value">
+                {end.toLocaleTimeString('pt-PT', { hour: '2-digit', minute: '2-digit' })}
+              </span>
+            </div>
+          )}
+
+          <div className="rd-stat-card">
+            <div className="rd-stat-icon"><FiClock /></div>
+            <span className="rd-stat-label">Duração</span>
+            <span className="rd-stat-value">{durationMin} <span className="rd-stat-unit">min</span></span>
+          </div>
+
+          <div className="rd-stat-card rd-stat-card--accent">
+            <div className="rd-stat-icon"><FiNavigation /></div>
+            <span className="rd-stat-label">Distância</span>
+            <span className="rd-stat-value">{km} <span className="rd-stat-unit">km</span></span>
+          </div>
+        </div>
+
       </div>
     </div>
   );

--- a/sunny_sales_web/src/pages/RoutesScreen.css
+++ b/sunny_sales_web/src/pages/RoutesScreen.css
@@ -1,0 +1,242 @@
+/* ── Wrapper ─────────────────────────────────────────── */
+
+.rs-wrapper {
+  min-height: 60vh;
+  padding-bottom: 3rem;
+}
+
+.rs-container {
+  max-width: 520px;
+  margin: 0 auto;
+  padding: 0 1rem 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+/* ── Header ──────────────────────────────────────────── */
+
+.rs-header {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding-bottom: 4px;
+}
+
+.rs-header-icon {
+  width: 46px;
+  height: 46px;
+  border-radius: var(--radius-md);
+  background: var(--primary-light);
+  color: var(--primary);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.3rem;
+  flex-shrink: 0;
+}
+
+.rs-title {
+  font-size: clamp(1.3rem, 5vw, 1.65rem);
+  font-weight: 800;
+  color: var(--text);
+  letter-spacing: -0.3px;
+  margin: 0 0 2px;
+}
+
+.rs-subtitle {
+  font-size: 0.82rem;
+  color: var(--text-muted);
+  margin: 0;
+}
+
+/* ── Summary bar ─────────────────────────────────────── */
+
+.rs-summary {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-xl);
+  padding: 18px 20px;
+  display: flex;
+  align-items: center;
+  justify-content: space-around;
+  box-shadow: var(--shadow-sm);
+  gap: 8px;
+}
+
+.rs-stat {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  flex: 1;
+}
+
+.rs-stat-value {
+  font-size: 1.35rem;
+  font-weight: 800;
+  color: var(--primary-dark);
+  line-height: 1;
+}
+
+.rs-stat-unit {
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--text-muted);
+}
+
+.rs-stat-label {
+  font-size: 0.72rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  text-align: center;
+}
+
+.rs-stat-divider {
+  width: 1px;
+  height: 36px;
+  background: var(--border-strong);
+  flex-shrink: 0;
+}
+
+/* ── Loading ─────────────────────────────────────────── */
+
+.rs-loading {
+  display: flex;
+  justify-content: center;
+  padding: 3rem 0;
+}
+
+.rs-spinner {
+  width: 32px;
+  height: 32px;
+  border: 3px solid var(--border-strong);
+  border-top-color: var(--primary);
+  border-radius: 50%;
+  animation: rs-spin 0.7s linear infinite;
+}
+
+@keyframes rs-spin {
+  to { transform: rotate(360deg); }
+}
+
+/* ── Empty state ─────────────────────────────────────── */
+
+.rs-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  padding: 3rem 1rem;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-xl);
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.rs-empty-icon {
+  font-size: 2.2rem;
+  color: var(--border-strong);
+}
+
+/* ── Route list ──────────────────────────────────────── */
+
+.rs-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.rs-item {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-xl);
+  padding: 14px 16px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  cursor: pointer;
+  transition: box-shadow var(--transition), transform var(--transition), border-color var(--transition);
+  box-shadow: var(--shadow-xs);
+}
+
+.rs-item:hover {
+  box-shadow: var(--shadow-md);
+  transform: translateY(-2px);
+  border-color: var(--primary-light-solid);
+}
+
+.rs-item-icon-wrap {
+  width: 40px;
+  height: 40px;
+  border-radius: var(--radius-md);
+  background: var(--primary-light);
+  color: var(--primary);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.05rem;
+  flex-shrink: 0;
+}
+
+.rs-item-body {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.rs-item-date {
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: var(--text);
+}
+
+.rs-item-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.rs-item-meta-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.rs-item-meta-tag svg {
+  font-size: 0.72rem;
+  color: var(--text-muted);
+}
+
+.rs-item-chevron {
+  color: var(--text-muted);
+  font-size: 1rem;
+  flex-shrink: 0;
+}
+
+/* ── Responsive ──────────────────────────────────────── */
+
+@media (max-width: 480px) {
+  .rs-summary {
+    padding: 14px 12px;
+  }
+
+  .rs-stat-value {
+    font-size: 1.15rem;
+  }
+
+  .rs-item {
+    padding: 12px 14px;
+  }
+}

--- a/sunny_sales_web/src/pages/RoutesScreen.jsx
+++ b/sunny_sales_web/src/pages/RoutesScreen.jsx
@@ -3,63 +3,112 @@ import { useNavigate } from 'react-router-dom';
 import axios from 'axios';
 import { BASE_URL } from '../config';
 import BackHomeButton from '../components/BackHomeButton';
+import { FiMap, FiNavigation, FiClock, FiCalendar, FiChevronRight } from 'react-icons/fi';
+import './RoutesScreen.css';
 
 export default function RoutesScreen() {
   const [routes, setRoutes] = useState([]);
+  const [loading, setLoading] = useState(true);
   const navigate = useNavigate();
 
-  const loadRoutes = async () => {
+  useEffect(() => {
     const stored = localStorage.getItem('user');
     const token = localStorage.getItem('token');
-    if (!stored) return;
+    if (!stored) { setLoading(false); return; }
     const vendor = JSON.parse(stored);
-
-    try {
-      const res = await axios.get(`${BASE_URL}/vendors/${vendor.id}/routes`, {
-        headers: token ? { Authorization: `Bearer ${token}` } : {},
-      });
-      setRoutes(res.data);
-    } catch (e) {
-      console.error('Erro ao carregar trajetos:', e);
-    }
-  };
-
-  useEffect(() => {
-    loadRoutes();
+    axios.get(`${BASE_URL}/vendors/${vendor.id}/routes`, {
+      headers: token ? { Authorization: `Bearer ${token}` } : {},
+    })
+      .then(res => setRoutes(res.data))
+      .catch(e => console.error('Erro ao carregar trajetos:', e))
+      .finally(() => setLoading(false));
   }, []);
 
-  return (
-    <div className="page-wrapper">
-      <BackHomeButton />
-      <h2>Histórico de Trajetos</h2>
-      {routes.length === 0 && (
-        <p className="page-empty">Sem trajetos registados.</p>
-      )}
-      <ul className="page-list">
-        {routes.map((route) => {
-          const start = new Date(route.start_time);
-          const end = route.end_time ? new Date(route.end_time) : null;
-          const durationMin = end ? Math.round((end - start) / 60000) : 0;
+  const totalKm = routes.reduce((s, r) => s + r.distance_m, 0) / 1000;
+  const totalMin = routes.reduce((s, r) => {
+    if (!r.end_time) return s;
+    return s + Math.round((new Date(r.end_time) - new Date(r.start_time)) / 60000);
+  }, 0);
 
-          return (
-            <li
-              key={route.id}
-              className="page-list-item"
-              onClick={() => navigate('/route-detail', { state: { route } })}
-            >
-              <div className="page-list-item-main">
-                <span className="page-list-item-title">
-                  {start.toLocaleString('pt-PT')}
-                </span>
-                <span className="page-list-item-desc">
-                  {durationMin} min · {(route.distance_m / 1000).toFixed(2)} km
-                </span>
-              </div>
-              <span className="page-chevron">›</span>
-            </li>
-          );
-        })}
-      </ul>
+  return (
+    <div className="rs-wrapper">
+      <BackHomeButton />
+      <div className="rs-container">
+
+        <div className="rs-header">
+          <div className="rs-header-icon"><FiMap /></div>
+          <div>
+            <h1 className="rs-title">Histórico de Trajetos</h1>
+            <p className="rs-subtitle">Os teus percursos registados</p>
+          </div>
+        </div>
+
+        {routes.length > 0 && (
+          <div className="rs-summary">
+            <div className="rs-stat">
+              <span className="rs-stat-value">{routes.length}</span>
+              <span className="rs-stat-label">Trajetos</span>
+            </div>
+            <div className="rs-stat-divider" />
+            <div className="rs-stat">
+              <span className="rs-stat-value">{totalKm.toFixed(1)}<span className="rs-stat-unit"> km</span></span>
+              <span className="rs-stat-label">Distância total</span>
+            </div>
+            <div className="rs-stat-divider" />
+            <div className="rs-stat">
+              <span className="rs-stat-value">{totalMin}<span className="rs-stat-unit"> min</span></span>
+              <span className="rs-stat-label">Tempo total</span>
+            </div>
+          </div>
+        )}
+
+        {loading && (
+          <div className="rs-loading">
+            <div className="rs-spinner" />
+          </div>
+        )}
+
+        {!loading && routes.length === 0 && (
+          <div className="rs-empty">
+            <FiMap className="rs-empty-icon" />
+            <p>Sem trajetos registados.</p>
+          </div>
+        )}
+
+        {!loading && routes.length > 0 && (
+          <ul className="rs-list">
+            {routes.map((route) => {
+              const start = new Date(route.start_time);
+              const end = route.end_time ? new Date(route.end_time) : null;
+              const durationMin = end ? Math.round((end - start) / 60000) : 0;
+              const km = (route.distance_m / 1000).toFixed(2);
+              const dateStr = start.toLocaleDateString('pt-PT', { day: '2-digit', month: 'short', year: 'numeric' });
+              const timeStr = start.toLocaleTimeString('pt-PT', { hour: '2-digit', minute: '2-digit' });
+
+              return (
+                <li
+                  key={route.id}
+                  className="rs-item"
+                  onClick={() => navigate('/route-detail', { state: { route } })}
+                >
+                  <div className="rs-item-icon-wrap">
+                    <FiNavigation className="rs-item-icon" />
+                  </div>
+                  <div className="rs-item-body">
+                    <span className="rs-item-date">{dateStr}</span>
+                    <div className="rs-item-meta">
+                      <span className="rs-item-meta-tag"><FiClock />{durationMin} min</span>
+                      <span className="rs-item-meta-tag"><FiNavigation />{km} km</span>
+                      <span className="rs-item-meta-tag"><FiCalendar />{timeStr}</span>
+                    </div>
+                  </div>
+                  <FiChevronRight className="rs-item-chevron" />
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
     </div>
   );
 }

--- a/sunny_sales_web/src/pages/StatsScreen.css
+++ b/sunny_sales_web/src/pages/StatsScreen.css
@@ -1,0 +1,265 @@
+/* ── Wrapper ─────────────────────────────────────────── */
+
+.ss-wrapper {
+  min-height: 60vh;
+  padding-bottom: 3rem;
+}
+
+.ss-container {
+  max-width: 520px;
+  margin: 0 auto;
+  padding: 0 1rem 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+/* ── Header ──────────────────────────────────────────── */
+
+.ss-header {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding-bottom: 4px;
+}
+
+.ss-header-icon {
+  width: 46px;
+  height: 46px;
+  border-radius: var(--radius-md);
+  background: var(--primary-light);
+  color: var(--primary);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.3rem;
+  flex-shrink: 0;
+}
+
+.ss-title {
+  font-size: clamp(1.3rem, 5vw, 1.65rem);
+  font-weight: 800;
+  color: var(--text);
+  letter-spacing: -0.3px;
+  margin: 0 0 2px;
+}
+
+.ss-subtitle {
+  font-size: 0.82rem;
+  color: var(--text-muted);
+  margin: 0;
+}
+
+/* ── Summary bar ─────────────────────────────────────── */
+
+.ss-summary {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-xl);
+  padding: 18px 20px;
+  display: flex;
+  align-items: center;
+  justify-content: space-around;
+  box-shadow: var(--shadow-sm);
+  gap: 8px;
+}
+
+.ss-stat {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  flex: 1;
+}
+
+.ss-stat-icon {
+  font-size: 1rem;
+  color: var(--primary);
+  margin-bottom: 2px;
+  display: flex;
+  align-items: center;
+}
+
+.ss-stat-value {
+  font-size: 1.3rem;
+  font-weight: 800;
+  color: var(--primary-dark);
+  line-height: 1;
+}
+
+.ss-stat-unit {
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--text-muted);
+}
+
+.ss-stat-label {
+  font-size: 0.72rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  text-align: center;
+}
+
+.ss-stat-divider {
+  width: 1px;
+  height: 40px;
+  background: var(--border-strong);
+  flex-shrink: 0;
+}
+
+/* ── Period filter ───────────────────────────────────── */
+
+.ss-period-bar {
+  display: flex;
+  gap: 8px;
+  padding: 2px 0;
+}
+
+.ss-period-btn {
+  background: var(--surface);
+  border: 1.5px solid var(--border-strong);
+  border-radius: var(--radius-full);
+  padding: 7px 16px;
+  font-size: 0.82rem;
+  font-weight: 700;
+  color: var(--text-secondary);
+  cursor: pointer;
+  min-height: auto;
+  box-shadow: none;
+  transition: all var(--transition);
+}
+
+.ss-period-btn:hover {
+  border-color: var(--primary);
+  color: var(--primary-dark);
+  background: var(--primary-light);
+  transform: none;
+  box-shadow: none;
+}
+
+.ss-period-btn.active {
+  background: var(--primary);
+  border-color: var(--primary);
+  color: #fff;
+  box-shadow: var(--shadow-warm);
+}
+
+/* ── Chart card ──────────────────────────────────────── */
+
+.ss-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-xl);
+  padding: 20px 16px 16px;
+  box-shadow: var(--shadow-sm);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.ss-chart {
+  width: 100%;
+  height: 300px;
+}
+
+.ss-chart-note {
+  font-size: 0.78rem;
+  color: var(--text-muted);
+  text-align: right;
+  margin: 0;
+  padding: 0 4px;
+}
+
+.ss-chart-note strong {
+  color: var(--primary-dark);
+}
+
+/* ── Custom tooltip ──────────────────────────────────── */
+
+.ss-tooltip {
+  background: var(--surface);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-md);
+  padding: 10px 14px;
+  box-shadow: var(--shadow-md);
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.ss-tooltip-date {
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.ss-tooltip-value {
+  font-size: 1rem;
+  font-weight: 800;
+  color: var(--primary-dark);
+}
+
+/* ── Loading ─────────────────────────────────────────── */
+
+.ss-loading {
+  display: flex;
+  justify-content: center;
+  padding: 3rem 0;
+}
+
+.ss-spinner {
+  width: 32px;
+  height: 32px;
+  border: 3px solid var(--border-strong);
+  border-top-color: var(--primary);
+  border-radius: 50%;
+  animation: ss-spin 0.7s linear infinite;
+}
+
+@keyframes ss-spin {
+  to { transform: rotate(360deg); }
+}
+
+/* ── Empty state ─────────────────────────────────────── */
+
+.ss-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  padding: 3rem 1rem;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-xl);
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.ss-empty-icon {
+  font-size: 2.2rem;
+  color: var(--border-strong);
+}
+
+/* ── Responsive ──────────────────────────────────────── */
+
+@media (max-width: 480px) {
+  .ss-summary {
+    padding: 14px 12px;
+  }
+
+  .ss-stat-value {
+    font-size: 1.1rem;
+  }
+
+  .ss-chart {
+    height: 220px;
+  }
+
+  .ss-card {
+    padding: 16px 10px 12px;
+  }
+}

--- a/sunny_sales_web/src/pages/StatsScreen.jsx
+++ b/sunny_sales_web/src/pages/StatsScreen.jsx
@@ -1,71 +1,164 @@
 import React, { useEffect, useState } from 'react';
 import axios from 'axios';
 import { BASE_URL } from '../config';
-import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, CartesianGrid } from 'recharts';
+import {
+  BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, CartesianGrid,
+} from 'recharts';
 import BackHomeButton from '../components/BackHomeButton';
+import { FiBarChart2, FiNavigation, FiCalendar, FiTrendingUp } from 'react-icons/fi';
+import './StatsScreen.css';
+
+const PERIODS = [
+  { id: 7, label: '7 dias' },
+  { id: 30, label: '30 dias' },
+  { id: 0, label: 'Tudo' },
+];
+
+function CustomTooltip({ active, payload, label }) {
+  if (!active || !payload?.length) return null;
+  return (
+    <div className="ss-tooltip">
+      <span className="ss-tooltip-date">{label}</span>
+      <span className="ss-tooltip-value">{payload[0].value} km</span>
+    </div>
+  );
+}
 
 export default function StatsScreen() {
-  const [chartData, setChartData] = useState([]);
-
-  const loadRoutes = async () => {
-    const stored = localStorage.getItem('user');
-    const token = localStorage.getItem('token');
-    if (!stored) return;
-    const vendor = JSON.parse(stored);
-    try {
-      const res = await axios.get(`${BASE_URL}/vendors/${vendor.id}/routes`, {
-        headers: token ? { Authorization: `Bearer ${token}` } : {},
-      });
-
-      const daily = {};
-      res.data.forEach((r) => {
-        const date = r.start_time.split('T')[0];
-        daily[date] = (daily[date] || 0) + r.distance_m;
-      });
-
-      const sorted = Object.entries(daily).sort();
-      const data = sorted.map(([date, dist]) => ({
-        date: date.slice(5),
-        distance: Number((dist / 1000).toFixed(2)),
-      }));
-
-      setChartData(data);
-    } catch (e) {
-      console.error('Erro ao carregar estatísticas:', e);
-    }
-  };
+  const [allData, setAllData] = useState([]);
+  const [period, setPeriod] = useState(30);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    loadRoutes();
+    const stored = localStorage.getItem('user');
+    const token = localStorage.getItem('token');
+    if (!stored) { setLoading(false); return; }
+    const vendor = JSON.parse(stored);
+    axios.get(`${BASE_URL}/vendors/${vendor.id}/routes`, {
+      headers: token ? { Authorization: `Bearer ${token}` } : {},
+    })
+      .then(res => {
+        const daily = {};
+        res.data.forEach((r) => {
+          const date = r.start_time.split('T')[0];
+          daily[date] = (daily[date] || 0) + r.distance_m;
+        });
+        const sorted = Object.entries(daily).sort();
+        const data = sorted.map(([date, dist]) => ({
+          date: date.slice(5),
+          fullDate: date,
+          distance: Number((dist / 1000).toFixed(2)),
+        }));
+        setAllData(data);
+      })
+      .catch(e => console.error('Erro ao carregar estatísticas:', e))
+      .finally(() => setLoading(false));
   }, []);
 
-  return (
-    <div className="page-wrapper">
-      <BackHomeButton />
-      <h2>Distâncias percorridas por dia</h2>
+  const chartData = period === 0 ? allData : allData.slice(-period);
 
-      {chartData.length > 0 ? (
-        <div className="chart-wrapper">
-          <ResponsiveContainer width="100%" height="100%">
-            <BarChart data={chartData} margin={{ top: 20, right: 16, left: 0, bottom: 5 }}>
-              <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" />
-              <XAxis dataKey="date" tick={{ fontSize: 12, fill: 'var(--text-secondary)' }} />
-              <YAxis unit=" km" tick={{ fontSize: 12, fill: 'var(--text-secondary)' }} />
-              <Tooltip
-                contentStyle={{
-                  background: 'var(--surface)',
-                  border: '1px solid var(--border)',
-                  borderRadius: 'var(--radius-sm)',
-                  fontSize: '0.85rem',
-                }}
-              />
-              <Bar dataKey="distance" fill="var(--primary)" radius={[4, 4, 0, 0]} />
-            </BarChart>
-          </ResponsiveContainer>
+  const totalKm = chartData.reduce((s, d) => s + d.distance, 0).toFixed(1);
+  const avgKm = chartData.length ? (chartData.reduce((s, d) => s + d.distance, 0) / chartData.length).toFixed(1) : '0';
+  const maxKm = chartData.length ? Math.max(...chartData.map(d => d.distance)).toFixed(1) : '0';
+
+  return (
+    <div className="ss-wrapper">
+      <BackHomeButton />
+      <div className="ss-container">
+
+        <div className="ss-header">
+          <div className="ss-header-icon"><FiBarChart2 /></div>
+          <div>
+            <h1 className="ss-title">Estatísticas</h1>
+            <p className="ss-subtitle">Distâncias percorridas por dia</p>
+          </div>
         </div>
-      ) : (
-        <p className="page-empty">Nenhum trajeto disponível.</p>
-      )}
+
+        {allData.length > 0 && (
+          <div className="ss-summary">
+            <div className="ss-stat">
+              <div className="ss-stat-icon"><FiNavigation /></div>
+              <span className="ss-stat-value">{totalKm}<span className="ss-stat-unit"> km</span></span>
+              <span className="ss-stat-label">Total</span>
+            </div>
+            <div className="ss-stat-divider" />
+            <div className="ss-stat">
+              <div className="ss-stat-icon"><FiTrendingUp /></div>
+              <span className="ss-stat-value">{avgKm}<span className="ss-stat-unit"> km</span></span>
+              <span className="ss-stat-label">Média/dia</span>
+            </div>
+            <div className="ss-stat-divider" />
+            <div className="ss-stat">
+              <div className="ss-stat-icon"><FiCalendar /></div>
+              <span className="ss-stat-value">{chartData.length}</span>
+              <span className="ss-stat-label">Dias</span>
+            </div>
+          </div>
+        )}
+
+        {allData.length > 0 && (
+          <div className="ss-period-bar">
+            {PERIODS.map(({ id, label }) => (
+              <button
+                key={id}
+                type="button"
+                className={`ss-period-btn${period === id ? ' active' : ''}`}
+                onClick={() => setPeriod(id)}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+        )}
+
+        {loading && (
+          <div className="ss-loading">
+            <div className="ss-spinner" />
+          </div>
+        )}
+
+        {!loading && allData.length === 0 && (
+          <div className="ss-empty">
+            <FiBarChart2 className="ss-empty-icon" />
+            <p>Nenhum trajeto disponível.</p>
+          </div>
+        )}
+
+        {!loading && chartData.length > 0 && (
+          <div className="ss-card">
+            <div className="ss-chart">
+              <ResponsiveContainer width="100%" height="100%">
+                <BarChart data={chartData} margin={{ top: 16, right: 8, left: -8, bottom: 0 }}>
+                  <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" vertical={false} />
+                  <XAxis
+                    dataKey="date"
+                    tick={{ fontSize: 11, fill: 'var(--text-muted)', fontWeight: 600 }}
+                    axisLine={false}
+                    tickLine={false}
+                  />
+                  <YAxis
+                    unit=" km"
+                    tick={{ fontSize: 11, fill: 'var(--text-muted)', fontWeight: 600 }}
+                    axisLine={false}
+                    tickLine={false}
+                    width={52}
+                  />
+                  <Tooltip content={<CustomTooltip />} cursor={{ fill: 'var(--primary-light)' }} />
+                  <Bar
+                    dataKey="distance"
+                    fill="var(--primary)"
+                    radius={[6, 6, 0, 0]}
+                  />
+                </BarChart>
+              </ResponsiveContainer>
+            </div>
+            {maxKm !== '0' && (
+              <p className="ss-chart-note">Máximo num dia: <strong>{maxKm} km</strong></p>
+            )}
+          </div>
+        )}
+
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
- RoutesScreen: polished card list with summary stats bar (total routes,
  km, time), loading spinner, icon badges per item, and empty state
- RouteDetail: 2x2 stat cards (start, end, duration, distance) with
  teal accent on the distance card; map promoted to a rounded card
- StatsScreen: summary bar, period filter (7d / 30d / all), custom
  tooltip, cleaner chart with no vertical grid lines
- PaidWeeksScreen: summary bar, active-week badge, icon-button for
  receipts, loading spinner, and empty state
- Each page gets its own scoped CSS file following the ma- pattern
- Install react-is to fix pre-existing recharts peer-dep build error

https://claude.ai/code/session_01UR3KJMF9aUUF5VHacYvVmd