### PR TITLE
Remove weather widget and duplicate pin color preview

### DIFF
--- a/sunny_sales_web/src/pages/ManageAccount.jsx
+++ b/sunny_sales_web/src/pages/ManageAccount.jsx
@@ -273,7 +273,6 @@ export default function ManageAccount() {
                   onChange={(e) => setPinColor(e.target.value)}
                   className="ma-color-input"
                 />
-                <span className="ma-color-preview" style={{ backgroundColor: pinColor }} />
                 <span className="ma-color-value">{pinColor.toUpperCase()}</span>
               </div>
             </div>

--- a/sunny_sales_web/src/pages/ModernMapLayout.jsx
+++ b/sunny_sales_web/src/pages/ModernMapLayout.jsx
@@ -7,7 +7,6 @@ import { BASE_URL } from '../config';
 import LocateButton from '../components/LocateButton';
 import VendorLocateButton from '../components/VendorLocateButton';
 import LocateHint from '../components/LocateHint';
-import BeachConditions from '../components/BeachConditions';
 import WelcomeCard from '../components/WelcomeCard';
 import {
   FiMapPin, FiFilter, FiCheck,
@@ -708,7 +707,6 @@ export default function ModernMapLayout() {
           )}
         </main>
       </div>
-      <BeachConditions />
       {showWelcome && <WelcomeCard onClose={dismissWelcome} />}
     </div>
   );


### PR DESCRIPTION
- Remove BeachConditions component (weather/meteorology widget) from map layout
- Remove redundant circle preview next to the color input in seller profile pin color picker, keeping only the native color input swatch

https://claude.ai/code/session_015n4DhvEjoaY995MLC4Dw6M