### PR TITLE
Show payment method text labels alongside icons on seller card

### DIFF
--- a/sunny_sales_web/src/pages/ModernMapLayout.css
+++ b/sunny_sales_web/src/pages/ModernMapLayout.css
@@ -538,16 +538,21 @@ body {
 }
 
 .card-payment-chip {
-  display: flex;
+  display: inline-flex;
   align-items: center;
-  justify-content: center;
-  width: 28px;
-  height: 28px;
+  gap: 5px;
+  padding: 3px 9px;
   border-radius: var(--radius-full);
   background: var(--surface-alt);
   color: var(--text-secondary);
   border: 1px solid var(--border);
   transition: background var(--transition), color var(--transition);
+}
+
+.card-payment-label {
+  font-size: 11px;
+  font-weight: 500;
+  white-space: nowrap;
 }
 
 .card-payment-chip:hover {

--- a/sunny_sales_web/src/pages/ModernMapLayout.jsx
+++ b/sunny_sales_web/src/pages/ModernMapLayout.jsx
@@ -696,8 +696,9 @@ export default function ModernMapLayout() {
                     const method = m.trim();
                     const Icon = PAYMENT_ICONS[method];
                     return Icon ? (
-                      <span key={method} className="card-payment-chip" title={method}>
-                        <Icon size={14} />
+                      <span key={method} className="card-payment-chip">
+                        <Icon size={13} />
+                        <span className="card-payment-label">{method}</span>
                       </span>
                     ) : null;
                   })}


### PR DESCRIPTION
When clicking a map pin, the seller card now displays each payment
method as a pill with both the icon and its written name, instead
of icon-only chips.

https://claude.ai/code/session_01VbrP5fXmwarUNtfVjqsCG4