### PR TITLE
Refactor modal header layout and close button in VendorDashboard

### DIFF
--- a/sunny_sales_web/src/pages/VendorDashboard.css
+++ b/sunny_sales_web/src/pages/VendorDashboard.css
@@ -657,7 +657,7 @@
 .vd-modal-header {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  gap: 12px;
   margin-bottom: 20px;
 }
 
@@ -665,28 +665,6 @@
   font-size: 1.1rem;
   font-weight: 800;
   color: var(--text);
-}
-
-.vd-modal-close {
-  background: var(--surface-alt);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-full);
-  width: 32px;
-  height: 32px;
-  min-height: auto;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: var(--text-muted);
-  cursor: pointer;
-  flex-shrink: 0;
-  transition: background var(--transition), color var(--transition), border-color var(--transition);
-}
-
-.vd-modal-close:hover {
-  background: rgba(239, 68, 68, 0.08);
-  color: #c62828;
-  border-color: rgba(239, 68, 68, 0.2);
 }
 
 .vd-modal-form {

--- a/sunny_sales_web/src/pages/VendorDashboard.jsx
+++ b/sunny_sales_web/src/pages/VendorDashboard.jsx
@@ -6,7 +6,7 @@ import {
   FiCalendar, FiFileText,
   FiCreditCard, FiMail, FiMapPin, FiLogOut,
   FiDollarSign, FiSmartphone, FiTerminal, FiWifi,
-  FiNavigation, FiUser, FiX, FiLock, FiCheck,
+  FiNavigation, FiUser, FiLock, FiCheck,
 } from 'react-icons/fi';
 import ImageCropper from '../components/ImageCropper';
 import './VendorDashboard.css';
@@ -422,10 +422,10 @@ export default function VendorDashboard() {
         <div className="vd-modal-overlay" onClick={closeProfileModal}>
           <div className="vd-modal" onClick={e => e.stopPropagation()}>
             <div className="vd-modal-header">
-              <span className="vd-modal-title">Perfil</span>
-              <button type="button" className="vd-modal-close" onClick={closeProfileModal}>
-                <FiX size={18} />
+              <button type="button" className="back-btn" onClick={closeProfileModal}>
+                ← Voltar
               </button>
+              <span className="vd-modal-title">Perfil</span>
             </div>
 
             {/* Tabs */}


### PR DESCRIPTION
## Summary
Updated the profile modal header in VendorDashboard to use a back button instead of a close icon button, and adjusted the layout from space-between to gap-based alignment.

## Key Changes
- Changed modal header layout from `justify-content: space-between` to `gap: 12px` for more flexible spacing
- Replaced the circular close button (`.vd-modal-close`) with a back button using the existing `.back-btn` class
- Removed the `FiX` icon import as it's no longer needed
- Removed all `.vd-modal-close` CSS styles (32px circular button with hover effects)
- Reordered modal header elements: back button now appears before the title

## Implementation Details
- The back button now uses the standard back button styling (← Voltar) instead of a custom close icon
- This change simplifies the modal header by removing custom close button styling and leveraging existing button components
- The modal header now uses CSS gap for spacing, which is more maintainable than space-between for this layout pattern

https://claude.ai/code/session_013iug6EgpKNpuMowDTqPPG9