### PR TITLE
Remove hex color value displays from pin color inputs

### DIFF
--- a/sunny_sales_web/src/pages/ManageAccount.jsx
+++ b/sunny_sales_web/src/pages/ManageAccount.jsx
@@ -273,7 +273,6 @@ export default function ManageAccount() {
                   onChange={(e) => setPinColor(e.target.value)}
                   className="ma-color-input"
                 />
-                <span className="ma-color-value">{pinColor.toUpperCase()}</span>
               </div>
             </div>
           </div>

--- a/sunny_sales_web/src/pages/VendorDashboard.jsx
+++ b/sunny_sales_web/src/pages/VendorDashboard.jsx
@@ -328,7 +328,6 @@ export default function VendorDashboard() {
                 <span className="vd-detail-label">Cor do Pin</span>
                 <span className="vd-detail-value vd-pin-row">
                   <span className="vd-pin-dot" style={{ backgroundColor: pinColor }} />
-                  <span className="vd-pin-hex">{pinColor.toUpperCase()}</span>
                 </span>
               </div>
               {vendor.payment_methods && (
@@ -514,7 +513,6 @@ export default function VendorDashboard() {
                         className="vd-modal-pin-input"
                       />
                     </label>
-                    <span className="vd-pin-hex">{editPinColor.toUpperCase()}</span>
                   </div>
                 </div>
 


### PR DESCRIPTION
## Summary
This PR removes the display of hex color values that were shown alongside color picker inputs across multiple pages in the application.

## Key Changes
- **VendorDashboard.jsx**: Removed hex color display from both the vendor details section and the pin color edit modal
- **ManageAccount.jsx**: Removed hex color display from the pin color input section

## Details
The changes remove three instances of `<span>` elements that were displaying the uppercase hex color value (e.g., "#FF5733") next to color input fields. These elements used the following classes:
- `vd-pin-hex` (VendorDashboard)
- `ma-color-value` (ManageAccount)

The color picker inputs themselves remain functional; only the text representation of the hex value is being removed from the UI.

https://claude.ai/code/session_01N2tje3VXpzW5Wq1JnSzL81