### PR TITLE
Simplify subscription payment flow with Stripe payment link

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -984,7 +984,7 @@ async def stripe_webhook(request: Request, db: Session = Depends(get_db)):
 
     if event.get("type") == "checkout.session.completed":
         session = event["data"]["object"]
-        vendor_id = int(session.get("metadata", {}).get("vendor_id", 0))
+        vendor_id = int(session.get("client_reference_id") or session.get("metadata", {}).get("vendor_id") or 0)
         vendor = db.query(models.Vendor).filter(models.Vendor.id == vendor_id).first()
         if vendor:
             vendor.subscription_active = True

--- a/sunny_sales_web/src/pages/VendorDashboard.jsx
+++ b/sunny_sales_web/src/pages/VendorDashboard.jsx
@@ -135,19 +135,11 @@ export default function VendorDashboard() {
     setSharing(false);
   };
 
-  const paySubscription = async () => {
+  const STRIPE_PAYMENT_LINK = 'https://buy.stripe.com/test_28E3cvaRX1xWdIzd2ZeUU00';
+
+  const paySubscription = () => {
     if (!vendor) return;
-    try {
-      const token = localStorage.getItem('token');
-      const res = await axios.post(
-        `${BASE_URL}/vendors/${vendor.id}/create-checkout-session`,
-        null,
-        { headers: token ? { Authorization: `Bearer ${token}` } : {} }
-      );
-      if (res.data.checkout_url) window.open(res.data.checkout_url, '_blank');
-    } catch (err) {
-      console.error('Erro no pagamento:', err);
-    }
+    window.open(`${STRIPE_PAYMENT_LINK}?client_reference_id=${vendor.id}`, '_blank');
   };
 
   // ── Profile modal ─────────────────────────────────────


### PR DESCRIPTION
## Summary
Refactored the subscription payment flow to use Stripe's hosted payment links instead of server-side checkout session creation. This simplifies the payment process by eliminating the need for backend API calls and reduces complexity in the payment handling logic.

## Key Changes
- **Frontend (VendorDashboard.jsx)**
  - Replaced async `paySubscription` function with a synchronous implementation
  - Removed axios POST request to backend checkout session endpoint
  - Now directly opens Stripe payment link with vendor ID passed as `client_reference_id` query parameter
  - Removed try-catch error handling (no longer needed for direct link navigation)

- **Backend (main.py)**
  - Updated Stripe webhook handler to support both `client_reference_id` (from hosted payment links) and `metadata.vendor_id` (from server-created sessions)
  - Maintains backward compatibility while supporting the new payment link approach

## Implementation Details
- The Stripe payment link is now hardcoded as a constant (`STRIPE_PAYMENT_LINK`) pointing to the test environment
- Vendor identification is passed via the `client_reference_id` query parameter, which Stripe automatically includes in webhook events
- The webhook handler uses a fallback chain to extract vendor ID, supporting both old and new payment methods

https://claude.ai/code/session_01QkwqHrYxLaxmcC7rh2LLKC