### PR TITLE
Melhorar alinhamento e responsividade mobile em todo o site

### DIFF
--- a/sunny_sales_web/src/components/Footer.css
+++ b/sunny_sales_web/src/components/Footer.css
@@ -4,7 +4,7 @@
   bottom: 0;
   left: 0;
   width: 100%;
-  height: var(--footer-h, 44px);
+  height: calc(var(--footer-h, 44px) + env(safe-area-inset-bottom, 0px));
   overflow: hidden;
   background: var(--primary, #0A9396);
   padding-bottom: env(safe-area-inset-bottom, 0px);

--- a/sunny_sales_web/src/index.css
+++ b/sunny_sales_web/src/index.css
@@ -227,7 +227,7 @@ body {
   height: 100%;
   max-width: none;
   margin: 0 auto;
-  padding: calc(var(--navbar-h) + 16px) 0.5rem var(--footer-h);
+  padding: calc(var(--navbar-h) + 16px) 0.5rem calc(var(--footer-h) + env(safe-area-inset-bottom, 0px));
   background: transparent;
 }
 
@@ -653,7 +653,7 @@ h2 {
   }
 
   .container {
-    padding: calc(var(--navbar-h) + 8px) 0.25rem var(--footer-h);
+    padding: calc(var(--navbar-h) + 8px) 0.25rem calc(var(--footer-h) + env(safe-area-inset-bottom, 0px));
   }
 }
 
@@ -681,8 +681,29 @@ h2 {
 
 @supports (padding: max(0px)) {
   .navbar {
-    padding-left: max(24px, env(safe-area-inset-left));
-    padding-right: max(24px, env(safe-area-inset-right));
+    padding-left: max(28px, env(safe-area-inset-left));
+    padding-right: max(28px, env(safe-area-inset-right));
+  }
+
+  @media (max-width: 768px) {
+    .navbar {
+      padding-left: max(16px, env(safe-area-inset-left));
+      padding-right: max(16px, env(safe-area-inset-right));
+    }
+  }
+
+  @media (max-width: 480px) {
+    .navbar {
+      padding-left: max(14px, env(safe-area-inset-left));
+      padding-right: max(14px, env(safe-area-inset-right));
+    }
+  }
+
+  @media (max-width: 375px) {
+    .navbar {
+      padding-left: max(12px, env(safe-area-inset-left));
+      padding-right: max(12px, env(safe-area-inset-right));
+    }
   }
 }
 
@@ -763,6 +784,9 @@ h2 {
   font-weight: 700;
   font-size: 0.9rem;
   color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .page-list-item-desc {

--- a/sunny_sales_web/src/pages/AccountSettings.jsx
+++ b/sunny_sales_web/src/pages/AccountSettings.jsx
@@ -41,12 +41,14 @@ export default function AccountSettings() {
       <h2 className="title">Definições da Conta</h2>
 
       <div className="form">
-        <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '1rem', alignItems: 'center' }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '1rem', alignItems: 'center', gap: '12px', flexWrap: 'wrap' }}>
           <span>Notificações Ativas</span>
-          <label className="checkbox-container">
-            <input type="checkbox" checked={enabled} onChange={toggleNotifications} />
-            <span className="checkmark"></span>
-          </label>
+          <input
+            type="checkbox"
+            className="theme-checkbox"
+            checked={enabled}
+            onChange={toggleNotifications}
+          />
         </div>
 
         <span className="input-span">

--- a/sunny_sales_web/src/pages/Contacto.css
+++ b/sunny_sales_web/src/pages/Contacto.css
@@ -45,7 +45,7 @@
   padding: 10px 14px;
   border: 1.5px solid var(--border);
   border-radius: var(--radius-md);
-  background: var(--background);
+  background: var(--surface-alt);
   color: var(--text);
   font-family: inherit;
   font-size: 0.9rem;

--- a/sunny_sales_web/src/pages/ModernMapLayout.css
+++ b/sunny_sales_web/src/pages/ModernMapLayout.css
@@ -841,11 +841,15 @@ body {
   }
 }
 
-/* Move locate button above vendor card when both are visible */
+/* Move locate + compass buttons above vendor card when both are visible */
 @media (max-width: 768px) {
   .map-area:has(.vendor-card) .locate-btn,
   .map-area:has(.vendor-card) .vendor-locate-btn {
     bottom: 168px;
+  }
+
+  .map-area:has(.vendor-card) .compass-btn {
+    bottom: 222px;
   }
 }
 
@@ -853,5 +857,9 @@ body {
   .map-area:has(.vendor-card) .locate-btn,
   .map-area:has(.vendor-card) .vendor-locate-btn {
     bottom: 156px;
+  }
+
+  .map-area:has(.vendor-card) .compass-btn {
+    bottom: 210px;
   }
 }

--- a/sunny_sales_web/src/pages/PlanosVendedores.css
+++ b/sunny_sales_web/src/pages/PlanosVendedores.css
@@ -561,3 +561,18 @@
     padding: 32px 18px;
   }
 }
+
+@media (max-width: 360px) {
+  .pv-hero-stats {
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 6px;
+    padding: 10px 12px;
+  }
+  .pv-hero-stat {
+    padding: 0 8px;
+  }
+  .pv-hero-stat-divider {
+    display: none;
+  }
+}

--- a/sunny_sales_web/src/pages/VendorDetailScreen.jsx
+++ b/sunny_sales_web/src/pages/VendorDetailScreen.jsx
@@ -91,7 +91,7 @@ export default function VendorDetailScreen() {
             {vendor.name?.charAt(0)?.toUpperCase() || '?'}
           </div>
         )}
-        <h2 style={{ margin: '12px 0 4px' }}>{vendor.name}</h2>
+        <h2 style={{ margin: '12px 0 4px', wordBreak: 'break-word' }}>{vendor.name}</h2>
         <p style={{ color: 'var(--text-secondary)', margin: 0 }}>{vendor.product}</p>
       </div>
 


### PR DESCRIPTION
- Footer: corrigir altura para incluir safe-area-inset-bottom do iOS (iPhone com barra home)
- index.css: padding inferior do container inclui safe area; navbar usa max() correto por breakpoint; page-list-item-title com truncação overflow para strings longas
- ModernMapLayout: botão bússola sobe quando card do vendedor está visível em mobile
- PlanosVendedores: hero stats faz wrap em ecrãs ≤360px (evita overflow em iPhone SE/5)
- Contacto: corrigir variável CSS indefinida --background → --surface-alt nos inputs do formulário
- AccountSettings: substituir classes .checkbox-container/.checkmark indefinidas pelo toggle theme-checkbox existente; row com flex-wrap para mobile
- VendorDetailScreen: word-break em nomes de vendedores longos