### PR TITLE
Remove benefits section and implementation page from PlanosVendedores

### DIFF
--- a/sunny_sales_web/src/App.jsx
+++ b/sunny_sales_web/src/App.jsx
@@ -26,7 +26,7 @@ import Dashboard from './pages/Dashboard';
 import ModernMapLayout from './pages/ModernMapLayout';
 import SobreProjeto from './pages/SobreProjeto';
 import Sustentabilidade from './pages/Sustentabilidade';
-import ImplementarScreen from './pages/ImplementarScreen';
+
 import Sessions from './pages/Sessions';
 import ForgotPassword from './pages/ForgotPassword';
 import Contacto from './pages/Contacto';
@@ -122,13 +122,6 @@ function AppLayout() {
           <span className="nav-divider">|</span>
           <NavLink
             className={({ isActive }) => `nav-link${isActive ? ' active' : ''}`}
-            to="/implementacao"
-          >
-            Implementar
-          </NavLink>
-          <span className="nav-divider">|</span>
-          <NavLink
-            className={({ isActive }) => `nav-link${isActive ? ' active' : ''}`}
             to="/planos"
           >
             Planos
@@ -170,7 +163,6 @@ function AppLayout() {
           <Route path="/about" element={<About />} />
           <Route path="/sobre-projeto" element={<SobreProjeto />} />
           <Route path="/sustentabilidade" element={<Sustentabilidade />} />
-          <Route path="/implementacao" element={<ImplementarScreen />} />
           <Route path="/settings" element={<AccountSettings />} />
           <Route path="/login" element={<VendorLogin />} />
           <Route path="/vendor-login" element={<VendorLogin />} />

--- a/sunny_sales_web/src/pages/PlanosVendedores.css
+++ b/sunny_sales_web/src/pages/PlanosVendedores.css
@@ -10,7 +10,7 @@
   overflow: hidden;
   background: linear-gradient(135deg, var(--primary-dark) 0%, var(--primary) 55%, #0fb8bc 100%);
   border-radius: var(--radius-xl);
-  padding: 52px 28px 44px;
+  padding: 36px 28px 32px;
   text-align: center;
   color: white;
   margin-bottom: 2rem;

--- a/sunny_sales_web/src/pages/PlanosVendedores.jsx
+++ b/sunny_sales_web/src/pages/PlanosVendedores.jsx
@@ -1,5 +1,5 @@
 import { Link } from 'react-router-dom';
-import { FiCheck, FiZap, FiStar, FiTrendingUp, FiMapPin, FiBarChart2, FiSmartphone, FiUsers } from 'react-icons/fi';
+import { FiCheck, FiZap, FiStar, FiTrendingUp } from 'react-icons/fi';
 import './PlanosVendedores.css';
 
 const PLANS = [
@@ -66,13 +66,6 @@ const PLANS = [
   },
 ];
 
-const BENEFITS = [
-  { icon: <FiMapPin size={22} />, title: 'Visibilidade Máxima', text: 'O teu carrinho aparece no mapa em tempo real para milhares de pessoas na praia.' },
-  { icon: <FiSmartphone size={22} />, title: 'App Móvel', text: 'Gere a tua localização e rota diretamente do telemóvel, onde quer que estejas.' },
-  { icon: <FiBarChart2 size={22} />, title: 'Estatísticas', text: 'Acompanha visitas ao teu perfil, horários de maior procura e muito mais.' },
-  { icon: <FiUsers size={22} />, title: 'Comunidade', text: 'Faz parte de uma rede de vendedores de praia e ganha mais clientes todos os dias.' },
-];
-
 const FAQS = [
   { q: 'Posso cancelar quando quiser?', a: 'Sim. Podes cancelar a qualquer momento. O acesso mantém-se ativo até ao fim do período pago.' },
   { q: 'Como funciona o pagamento?', a: 'O pagamento é feito de forma segura via Stripe. Aceitamos cartões de crédito e débito.' },
@@ -88,7 +81,6 @@ export default function PlanosVendedores() {
       <div className="pv-hero">
         <div className="pv-hero-blur pv-hero-blur-1" />
         <div className="pv-hero-blur pv-hero-blur-2" />
-        <span className="pv-hero-icon">☀️</span>
         <h1 className="pv-hero-title">Leva o teu negócio<br />para a praia</h1>
         <p className="pv-hero-lead">
           Junta-te à plataforma que coloca os vendedores de praia no mapa —
@@ -101,19 +93,6 @@ export default function PlanosVendedores() {
           <div className="pv-hero-stat-divider" />
           <div className="pv-hero-stat"><strong>Real-time</strong><span>Localização</span></div>
         </div>
-      </div>
-
-      {/* ── Benefits ── */}
-      <div className="pv-benefits">
-        {BENEFITS.map((b) => (
-          <div key={b.title} className="pv-benefit-card">
-            <div className="pv-benefit-icon">{b.icon}</div>
-            <div>
-              <h3 className="pv-benefit-title">{b.title}</h3>
-              <p className="pv-benefit-text">{b.text}</p>
-            </div>
-          </div>
-        ))}
       </div>
 
       {/* ── Pricing header ── */}


### PR DESCRIPTION
## Summary
This PR removes the benefits showcase section from the PlanosVendedores (Seller Plans) page and eliminates the implementation/Implementar page from the application entirely.

## Key Changes
- **PlanosVendedores.jsx**: 
  - Removed unused icon imports (FiMapPin, FiBarChart2, FiSmartphone, FiUsers)
  - Deleted the BENEFITS array containing 4 benefit cards (Visibilidade Máxima, App Móvel, Estatísticas, Comunidade)
  - Removed the benefits section rendering from the component JSX
  - Removed the sun emoji (☀️) icon from the hero section

- **App.jsx**:
  - Removed the ImplementarScreen import
  - Deleted the "/implementacao" navigation link from the AppLayout header
  - Removed the "/implementacao" route definition

- **PlanosVendedores.css**:
  - Adjusted hero section padding from `52px 28px 44px` to `36px 28px 32px` to accommodate the removal of the hero icon

## Implementation Details
The benefits section was a prominent feature showcasing key platform advantages. Its removal streamlines the pricing page to focus directly on plan comparison and pricing information. The implementation page removal suggests this feature or section is no longer part of the application's navigation structure.

https://claude.ai/code/session_01QbDVdPh9bTcAE8Pve7Sxbq