### PR TITLE
Remove hero stats section from PlanosVendedores page

### DIFF
--- a/sunny_sales_web/src/pages/PlanosVendedores.css
+++ b/sunny_sales_web/src/pages/PlanosVendedores.css
@@ -68,43 +68,6 @@
   z-index: 1;
 }
 
-.pv-hero-stats {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 0;
-  background: rgba(255,255,255,0.12);
-  backdrop-filter: blur(8px);
-  border: 1px solid rgba(255,255,255,0.2);
-  border-radius: var(--radius-full);
-  padding: 12px 28px;
-  display: inline-flex;
-  position: relative;
-  z-index: 1;
-}
-
-.pv-hero-stat {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  padding: 0 20px;
-}
-.pv-hero-stat strong {
-  font-size: 1.15rem;
-  font-weight: 800;
-  color: white;
-}
-.pv-hero-stat span {
-  font-size: 0.72rem;
-  opacity: 0.78;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-}
-.pv-hero-stat-divider {
-  width: 1px;
-  height: 32px;
-  background: rgba(255,255,255,0.25);
-}
 
 /* ── Benefits ──────────────────────────────────────────── */
 .pv-benefits {

--- a/sunny_sales_web/src/pages/PlanosVendedores.jsx
+++ b/sunny_sales_web/src/pages/PlanosVendedores.jsx
@@ -86,13 +86,6 @@ export default function PlanosVendedores() {
           Junta-te à plataforma que coloca os vendedores de praia no mapa —
           literalmente. Mais visibilidade, mais clientes, mais vendas.
         </p>
-        <div className="pv-hero-stats">
-          <div className="pv-hero-stat"><strong>+500</strong><span>Vendedores</span></div>
-          <div className="pv-hero-stat-divider" />
-          <div className="pv-hero-stat"><strong>+12k</strong><span>Utilizadores</span></div>
-          <div className="pv-hero-stat-divider" />
-          <div className="pv-hero-stat"><strong>Real-time</strong><span>Localização</span></div>
-        </div>
       </div>
 
       {/* ── Pricing header ── */}


### PR DESCRIPTION
## Summary
Removed the statistics display section from the PlanosVendedores (Seller Plans) hero area, including both the JSX component and associated CSS styling.

## Changes Made
- **Removed JSX component**: Deleted the `pv-hero-stats` div containing three statistics cards displaying:
  - "+500 Vendedores" (Sellers)
  - "+12k Utilizadores" (Users)
  - "Real-time Localização" (Real-time Location)
  
- **Removed CSS styles**: Deleted all related styling classes:
  - `.pv-hero-stats` - Container styling with glassmorphism effect
  - `.pv-hero-stat` - Individual stat card styling
  - `.pv-hero-stat-divider` - Vertical divider between stats

## Notes
The hero section now contains only the headline and description text. The statistics display has been completely removed from both the markup and stylesheet.

https://claude.ai/code/session_01Ht5h9B6qBXqBJ2pyNs8PiB