### PR TITLE
Reduce padding and gap in vendor dashboard quick action items

### DIFF
--- a/sunny_sales_web/src/pages/VendorDashboard.css
+++ b/sunny_sales_web/src/pages/VendorDashboard.css
@@ -481,14 +481,13 @@
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
-  padding: 18px 14px 16px;
+  padding: 14px 10px 12px;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 9px;
+  gap: 7px;
   cursor: pointer;
-  aspect-ratio: 1 / 1;
   box-shadow: var(--shadow-xs);
   transition: box-shadow var(--transition), transform var(--transition), border-color var(--transition), background var(--transition);
   color: var(--text);
@@ -939,7 +938,7 @@
   }
 
   .vd-quick-item {
-    padding: 16px 12px 14px;
+    padding: 12px 10px 10px;
   }
 
   .vd-quick-icon {


### PR DESCRIPTION
## Summary
This PR adjusts the spacing and layout properties of quick action items in the Vendor Dashboard to create a more compact design.

## Key Changes
- **Reduced padding** on `.vd-quick-action` from `18px 14px 16px` to `14px 10px 12px`
- **Reduced gap** between flex items from `9px` to `7px`
- **Removed `aspect-ratio: 1 / 1`** constraint from `.vd-quick-action` to allow flexible sizing
- **Reduced padding** on `.vd-quick-item` (mobile breakpoint) from `16px 12px 14px` to `12px 10px 10px`

## Implementation Details
These changes create a tighter, more space-efficient layout for the quick action buttons while maintaining visual hierarchy through the existing shadow and transition effects. The removal of the aspect-ratio constraint allows the items to size naturally based on their content and the reduced padding/gap values.

https://claude.ai/code/session_011zpfWMdfNxWQg7Y4ZAHB3s