### PR TITLE
Fix layout spacing and improve responsive design for map view

### DIFF
--- a/sunny_sales_web/src/components/WeatherCard.css
+++ b/sunny_sales_web/src/components/WeatherCard.css
@@ -2,11 +2,12 @@
   width: 100%;
   border-radius: 14px;
   overflow: hidden;
-  background: linear-gradient(135deg, #F5A623 0%, #E8820C 38%, #C4530A 65%, #7A2010 100%);
+  background: linear-gradient(135deg, #f5a623, #ee9b00 38%, #ee9b00 65%, #ffd166);
   color: #fff;
   box-shadow: 0 4px 20px rgba(0, 0, 0, 0.18);
   font-family: 'Inter', 'Roboto', sans-serif;
   user-select: none;
+  flex-shrink: 0;
 }
 
 /* ── Main row ─────────────────────────────── */
@@ -119,7 +120,7 @@
 
 /* ── Skeleton state ────────────────────────── */
 .weather-card--skeleton {
-  background: linear-gradient(135deg, #F5A623 0%, #C4530A 100%);
+  background: linear-gradient(135deg, #f5a623, #ee9b00 38%, #ee9b00 65%, #ffd166);
   padding: 18px;
   display: flex;
   flex-direction: column;

--- a/sunny_sales_web/src/pages/ModernMapLayout.css
+++ b/sunny_sales_web/src/pages/ModernMapLayout.css
@@ -13,9 +13,11 @@ body {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 18px;
-  min-height: 80vh;
-  padding-bottom: 8px;
+  gap: 10px;
+  height: calc(100svh - var(--navbar-h) - var(--footer-h) - 32px);
+  min-height: 0;
+  padding-bottom: 0;
+  overflow: hidden;
 }
 
 .map-wrapper {
@@ -25,7 +27,8 @@ body {
   overflow: hidden;
   box-shadow: 0 8px 32px rgba(0, 0, 0, 0.14), 0 2px 8px rgba(0, 0, 0, 0.08);
   border: none;
-  min-height: 480px;
+  flex: 1;
+  min-height: 0;
 }
 
 /* ── Map area ─────────────────────────────────────────── */
@@ -33,8 +36,8 @@ body {
 .map-area {
   position: relative;
   flex: 1;
-  height: 70vh;
-  min-height: 380px;
+  height: 100%;
+  min-height: 0;
   padding: 0;
   text-align: left;
   display: flex;
@@ -809,8 +812,8 @@ body {
 
   .map-area {
     width: 100%;
-    height: calc(100svh - 160px);
-    min-height: 300px;
+    height: 100%;
+    min-height: 0;
   }
 
   .vendor-card {


### PR DESCRIPTION
## Summary
This PR refactors the layout spacing and sizing logic for the ModernMapLayout component to improve responsiveness and fix overflow issues. It also updates the WeatherCard gradient styling for better visual consistency.

## Key Changes

**ModernMapLayout.css:**
- Reduced gap between flex items from 18px to 10px for tighter spacing
- Changed height calculation from fixed `min-height: 80vh` to dynamic `height: calc(100svh - var(--navbar-h) - var(--footer-h) - 32px)` to account for navbar and footer heights
- Set `min-height: 0` and `overflow: hidden` on the main container to prevent flex overflow issues
- Updated `.map-wrapper` to use `flex: 1` instead of fixed `min-height: 480px` for better flex distribution
- Updated `.map-area` to use `height: 100%` and `min-height: 0` instead of fixed `height: 70vh` and `min-height: 380px`
- Applied same responsive fixes to mobile breakpoint (removed hardcoded `calc(100svh - 160px)`)

**WeatherCard.css:**
- Updated gradient colors from darker orange tones (`#F5A623`, `#E8820C`, `#C4530A`, `#7A2010`) to lighter, more vibrant palette (`#f5a623`, `#ee9b00`, `#ffd166`)
- Applied gradient update to both normal and skeleton states for consistency
- Added `flex-shrink: 0` to prevent the card from shrinking in flex layouts

## Implementation Details
The layout changes use CSS custom variables (`--navbar-h`, `--footer-h`) for dynamic height calculation, making the component more maintainable and responsive to layout changes. The shift from fixed heights to flex-based sizing improves responsiveness across different viewport sizes.

https://claude.ai/code/session_012mWPxnnSGgRcicJVVxDWEV