### PR TITLE
Refine typography sizing across PlanosVendedores page

### DIFF
--- a/sunny_sales_web/src/pages/PlanosVendedores.css
+++ b/sunny_sales_web/src/pages/PlanosVendedores.css
@@ -48,7 +48,7 @@
 }
 
 .pv-hero-title {
-  font-size: clamp(1.8rem, 5.5vw, 3rem);
+  font-size: clamp(1.55rem, 5vw, 2.3rem);
   font-weight: 800;
   margin: 0 0 14px;
   line-height: 1.15;
@@ -59,7 +59,7 @@
 }
 
 .pv-hero-lead {
-  font-size: clamp(0.95rem, 2.5vw, 1.1rem);
+  font-size: 0.975rem;
   opacity: 0.9;
   max-width: 540px;
   margin: 0 auto 28px;
@@ -138,7 +138,7 @@
   margin-bottom: 14px;
 }
 .pv-pricing-title {
-  font-size: clamp(1.4rem, 4vw, 2rem);
+  font-size: clamp(1.2rem, 3.5vw, 1.55rem);
   font-weight: 800;
   color: var(--text);
   margin: 0 0 10px;
@@ -363,7 +363,7 @@
   margin-bottom: 2.5rem;
 }
 .pv-faq-title {
-  font-size: 1.2rem;
+  font-size: 1.05rem;
   font-weight: 800;
   color: var(--text);
   margin: 0 0 16px;
@@ -438,7 +438,7 @@
   margin-bottom: 12px;
 }
 .pv-cta-title {
-  font-size: clamp(1.2rem, 3.5vw, 1.7rem);
+  font-size: 1.15rem;
   font-weight: 800;
   color: white;
   margin: 0 0 10px;


### PR DESCRIPTION
## Summary
This PR adjusts font sizes throughout the PlanosVendedores page to improve visual hierarchy and readability. The changes reduce overall font sizes and simplify responsive scaling in several key sections.

## Key Changes
- **Hero title**: Reduced clamp range from `clamp(1.8rem, 5.5vw, 3rem)` to `clamp(1.55rem, 5vw, 2.3rem)` for more constrained scaling
- **Hero lead text**: Changed from responsive `clamp(0.95rem, 2.5vw, 1.1rem)` to fixed `0.975rem` for consistency
- **Pricing section title**: Adjusted clamp range from `clamp(1.4rem, 4vw, 2rem)` to `clamp(1.2rem, 3.5vw, 1.55rem)` for tighter sizing
- **FAQ section title**: Reduced from `1.2rem` to `1.05rem` for better proportions
- **CTA section title**: Changed from responsive `clamp(1.2rem, 3.5vw, 1.7rem)` to fixed `1.15rem` for consistency

## Implementation Details
The changes balance responsive design with fixed sizing, removing some viewport-width-based scaling in favor of fixed font sizes where appropriate. This creates a more controlled typography system while maintaining readability across different screen sizes.

https://claude.ai/code/session_01RKCEZx1dYHWwehZuz7Zbqp