### PR TITLE
Add Android build CI/CD workflow

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -1,0 +1,47 @@
+name: Android Build
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js 18
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+
+      - name: Setup Java JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - name: Install dependencies
+        working-directory: mobile
+        run: npm install
+
+      - name: Build React
+        working-directory: mobile
+        run: npm run build
+
+      - name: Sync Capacitor Android
+        working-directory: mobile
+        run: npx cap sync android
+
+      - name: Build Android APK
+        working-directory: mobile/android
+        run: ./gradlew assembleDebug
+
+      - name: Upload APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-debug
+          path: mobile/android/app/build/outputs/apk/debug/app-debug.apk


### PR DESCRIPTION
## Summary
This PR adds a GitHub Actions workflow to automate the building and packaging of the Android mobile application.

## Key Changes
- Created `.github/workflows/android-build.yml` with a complete CI/CD pipeline for Android builds
- Workflow triggers on pushes to `main` branch and manual dispatch
- Automated setup of Node.js 18 and Java JDK 21 (Temurin distribution)
- Automated dependency installation and React build process
- Capacitor sync to generate Android native code
- Gradle build to generate debug APK
- Artifact upload for built APK accessible from workflow runs

## Implementation Details
- Uses `ubuntu-latest` runner for build environment
- Installs dependencies and builds the React app in the `mobile` directory
- Syncs Capacitor configuration to Android platform
- Builds debug APK using Gradle's `assembleDebug` task
- Uploads the resulting APK artifact (`app-debug.apk`) for easy access and distribution

https://claude.ai/code/session_01Vq71ynGWZdZZpW5zVxkkZH