### PR TITLE
Refine PlanosVendedores page layout and spacing

### DIFF
--- a/sunny_sales_web/src/pages/PlanosVendedores.css
+++ b/sunny_sales_web/src/pages/PlanosVendedores.css
@@ -1,5 +1,5 @@
 .pv-page {
-  max-width: 1000px;
+  max-width: 860px;
   margin: 0 auto;
   padding: 0 1rem 4rem;
 }
@@ -13,7 +13,7 @@
   padding: 36px 28px 32px;
   text-align: center;
   color: white;
-  margin-bottom: 2rem;
+  margin-bottom: 1.75rem;
 }
 
 .pv-hero-blur {
@@ -50,7 +50,7 @@
 .pv-hero-title {
   font-size: clamp(1.55rem, 5vw, 2.3rem);
   font-weight: 800;
-  margin: 0 0 14px;
+  margin: 0 0 10px;
   line-height: 1.15;
   letter-spacing: -0.5px;
   position: relative;
@@ -62,7 +62,7 @@
   font-size: 0.975rem;
   opacity: 0.9;
   max-width: 540px;
-  margin: 0 auto 28px;
+  margin: 0 auto;
   line-height: 1.65;
   position: relative;
   z-index: 1;


### PR DESCRIPTION
## Summary
This PR adjusts the layout dimensions and spacing of the PlanosVendedores page to improve visual hierarchy and component alignment.

## Key Changes
- Reduced max-width from 1000px to 860px for a more compact page layout
- Decreased hero section bottom margin from 2rem to 1.75rem
- Reduced hero title bottom margin from 14px to 10px for tighter spacing
- Removed bottom margin from hero subtitle (changed from 28px to 0) to eliminate extra spacing

## Implementation Details
These spacing adjustments appear to be refinements to the hero section's visual presentation, creating a more condensed and balanced layout. The changes maintain the responsive design approach using clamp() for the title font size while tightening the vertical spacing between elements.

https://claude.ai/code/session_01MsPys3df4RjWoUwcUv7MzK