### PR TITLE
Add back home button to seller plans page

### DIFF
--- a/sunny_sales_web/src/pages/PlanosVendedores.jsx
+++ b/sunny_sales_web/src/pages/PlanosVendedores.jsx
@@ -1,5 +1,6 @@
 import { Link } from 'react-router-dom';
 import { FiCheck, FiZap, FiStar, FiTrendingUp } from 'react-icons/fi';
+import BackHomeButton from '../components/BackHomeButton';
 import './PlanosVendedores.css';
 
 const PLANS = [
@@ -76,6 +77,7 @@ const FAQS = [
 export default function PlanosVendedores() {
   return (
     <div className="pv-page">
+      <BackHomeButton />
 
       {/* ── Hero ── */}
       <div className="pv-hero">


### PR DESCRIPTION
## Summary
Added a back home navigation button to the PlanosVendedores (Seller Plans) page to improve user navigation and experience.

## Changes
- Imported the `BackHomeButton` component from the components directory
- Added the `<BackHomeButton />` component at the top of the page layout, positioned before the hero section

## Implementation Details
The back button is placed at the beginning of the page content, allowing users to easily navigate back to the home page from the seller plans page. This follows the existing pattern of using the `BackHomeButton` component for consistent navigation across the application.

https://claude.ai/code/session_01T4tcTPpt1UFZR6kPiwBcco