### PR TITLE
Remove eco banner from vendor dashboard

### DIFF
--- a/sunny_sales_web/src/pages/VendorDashboard.css
+++ b/sunny_sales_web/src/pages/VendorDashboard.css
@@ -508,19 +508,6 @@
   box-shadow: var(--shadow-xs);
 }
 
-/* ── Eco banner ──────────────────────────────────────── */
-
-.vd-eco-banner {
-  background: var(--secondary);
-  color: #fff;
-  text-align: center;
-  padding: 12px 20px;
-  border-radius: var(--radius-lg);
-  font-size: 0.82rem;
-  font-weight: 700;
-  letter-spacing: 0.02em;
-  margin-top: 4px;
-}
 
 /* ── Location toggle switch ──────────────────────────── */
 

--- a/sunny_sales_web/src/pages/VendorDashboard.jsx
+++ b/sunny_sales_web/src/pages/VendorDashboard.jsx
@@ -419,10 +419,6 @@ export default function VendorDashboard() {
           Terminar Sessão
         </button>
 
-        {/* Eco banner */}
-        <div className="vd-eco-banner">
-          Praia limpa, planeta feliz.
-        </div>
       </div>
 
       {/* Profile edit modal */}


### PR DESCRIPTION
## Summary
Removed the eco banner component from the vendor dashboard, including both the JSX element and its associated CSS styling.

## Changes
- Removed the eco banner JSX element (`<div className="vd-eco-banner">`) that displayed "Praia limpa, planeta feliz." message
- Removed the `.vd-eco-banner` CSS class definition and all its styling rules from the stylesheet

## Details
The eco banner was a decorative element positioned in the vendor dashboard sidebar. This change simplifies the dashboard UI by removing this non-essential component.

https://claude.ai/code/session_015fqa1jAQHUiWCVtKTpPgXn