### PR TITLE
Refactor mobile app to single-screen map-based layout

### DIFF
--- a/mobile/src/App.jsx
+++ b/mobile/src/App.jsx
@@ -1,11 +1,9 @@
 import React, { useState, useEffect } from 'react';
 import Login from './pages/Login.jsx';
-import Dashboard from './pages/Dashboard.jsx';
-import MapView from './pages/MapView.jsx';
+import MainScreen from './pages/MainScreen.jsx';
 
 export default function App() {
   const [auth, setAuth] = useState(null);
-  const [tab, setTab] = useState('dashboard');
 
   useEffect(() => {
     const token = localStorage.getItem('token');
@@ -32,36 +30,5 @@ export default function App() {
 
   if (!auth) return <Login onLogin={handleLogin} />;
 
-  return (
-    <div className="app-shell">
-      <div className="app-shell-content">
-        {tab === 'dashboard' ? (
-          <Dashboard auth={auth} onLogout={handleLogout} />
-        ) : (
-          <MapView />
-        )}
-      </div>
-      <nav className="bottom-nav">
-        <button
-          className={`bottom-nav-item ${tab === 'dashboard' ? 'active' : ''}`}
-          onClick={() => setTab('dashboard')}
-        >
-          <svg viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" strokeWidth="2">
-            <path d="M3 9.5 12 3l9 6.5V20a1 1 0 0 1-1 1h-5v-7H9v7H4a1 1 0 0 1-1-1V9.5Z" />
-          </svg>
-          Início
-        </button>
-        <button
-          className={`bottom-nav-item ${tab === 'map' ? 'active' : ''}`}
-          onClick={() => setTab('map')}
-        >
-          <svg viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" strokeWidth="2">
-            <circle cx="12" cy="10" r="3" />
-            <path d="M12 21s7-6.5 7-11.5A7 7 0 0 0 5 9.5C5 14.5 12 21 12 21Z" />
-          </svg>
-          Mapa
-        </button>
-      </nav>
-    </div>
-  );
+  return <MainScreen auth={auth} onLogout={handleLogout} />;
 }

--- a/mobile/src/index.css
+++ b/mobile/src/index.css
@@ -145,176 +145,167 @@ body {
   text-align: center;
 }
 
-/* ── Dashboard ─────────────────────────────────── */
-.dashboard-screen {
+/* ── Main Screen (single screen) ─────────────── */
+.main-screen {
+  position: relative;
+  width: 100%;
+  height: 100vh;
+  height: 100dvh;
+  overflow: hidden;
+}
+
+.main-map-area {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+}
+
+.main-map-area .map-container {
+  width: 100%;
+  height: 100%;
+}
+
+.main-map-area .map-loading {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  color: var(--text-muted);
   background: var(--bg);
 }
 
-.dashboard-header {
-  background: var(--white);
-  padding: 16px 20px;
-  box-shadow: 0 1px 0 var(--border);
-  position: sticky;
+/* Top bar overlay */
+.main-top-bar {
+  position: absolute;
   top: 0;
-  z-index: 10;
-}
-
-.header-top {
+  left: 0;
+  right: 0;
+  z-index: 1000;
   display: flex;
   align-items: center;
   justify-content: space-between;
+  padding: calc(12px + env(safe-area-inset-top, 0)) 16px 12px;
+  background: rgba(255, 255, 255, 0.92);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  box-shadow: 0 1px 8px rgba(0, 0, 0, 0.08);
 }
 
-.vendor-info {
+.main-top-bar .vendor-info {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: 10px;
 }
 
-.vendor-avatar {
-  width: 44px;
-  height: 44px;
+.main-top-bar .vendor-avatar {
+  width: 38px;
+  height: 38px;
   border-radius: 50%;
   background: linear-gradient(135deg, var(--primary), var(--navy));
   color: white;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 18px;
-  font-weight: 700;
-  flex-shrink: 0;
-}
-
-.vendor-name {
   font-size: 16px;
   font-weight: 700;
-  color: var(--text);
-}
-
-.vendor-product {
-  font-size: 13px;
-  color: var(--text-muted);
-}
-
-.dashboard-main {
-  padding: 20px 16px;
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-}
-
-/* ── Location Card ─────────────────────────────── */
-.location-card {
-  background: var(--white);
-  border-radius: var(--radius);
-  padding: 24px 20px;
-  box-shadow: var(--shadow);
-  display: flex;
-  flex-direction: column;
-  gap: 20px;
-  border: 2px solid transparent;
-  transition: border-color 0.3s;
-}
-
-.location-card.sharing {
-  border-color: var(--primary);
-}
-
-.location-status {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-}
-
-.status-dot {
-  width: 10px;
-  height: 10px;
-  border-radius: 50%;
   flex-shrink: 0;
 }
 
-.status-dot.active {
-  background: #22c55e;
-  box-shadow: 0 0 0 3px rgba(34, 197, 94, 0.2);
-  animation: pulse 2s infinite;
-}
-
-.status-dot.inactive {
-  background: var(--border);
-}
-
-@keyframes pulse {
-  0%, 100% { box-shadow: 0 0 0 3px rgba(34, 197, 94, 0.2); }
-  50% { box-shadow: 0 0 0 6px rgba(34, 197, 94, 0.1); }
-}
-
-.status-label {
+.main-top-bar .vendor-name {
   font-size: 15px;
-  font-weight: 600;
+  font-weight: 700;
   color: var(--text);
 }
 
-.coords-display {
+/* Bottom controls overlay */
+.main-bottom-controls {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 1000;
   display: flex;
-  gap: 12px;
-  background: var(--primary-light);
+  flex-direction: column;
+  gap: 10px;
+  padding: 16px 16px calc(16px + env(safe-area-inset-bottom, 0));
+  background: linear-gradient(to top, rgba(255,255,255,0.97) 60%, rgba(255,255,255,0));
+  pointer-events: none;
+}
+
+.main-bottom-controls > * {
+  pointer-events: auto;
+}
+
+.sharing-indicator {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  justify-content: center;
+  background: rgba(255, 255, 255, 0.95);
   border-radius: var(--radius-sm);
-  padding: 10px 14px;
-}
-
-.coords-display span {
-  font-size: 12px;
-  font-family: monospace;
-  color: var(--primary-dark);
-  font-weight: 600;
-}
-
-.sharing-note {
-  font-size: 12px;
-  color: var(--text-muted);
-  text-align: center;
-}
-
-/* ── Website Card ─────────────────────────────── */
-.website-card {
-  background: var(--white);
-  border-radius: var(--radius);
-  padding: 18px 20px;
+  padding: 10px 16px;
   box-shadow: var(--shadow);
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
+  font-size: 14px;
+  font-weight: 600;
+  color: #16a34a;
 }
 
-.website-card-content {
-  display: flex;
-  align-items: center;
-  gap: 14px;
+.btn-website {
+  background: var(--white);
+  color: var(--primary-dark);
+  border: 1.5px solid var(--primary);
+  width: 100%;
+  font-size: 15px;
 }
 
-.website-card-icon {
-  width: 44px;
-  height: 44px;
-  border-radius: 12px;
+.btn-website:active {
   background: var(--primary-light);
-  color: var(--primary);
+}
+
+/* ── Map ─────────────────────────────────── */
+.map-overlay-alert {
+  position: absolute;
+  top: 80px;
+  left: 16px;
+  right: 16px;
+  z-index: 1000;
+}
+
+.vendor-location-marker {
+  position: relative;
+  width: 40px;
+  height: 40px;
   display: flex;
   align-items: center;
   justify-content: center;
-  flex-shrink: 0;
 }
 
-.website-card-title {
-  font-size: 15px;
-  font-weight: 600;
-  color: var(--text);
+.vendor-location-pulse {
+  position: absolute;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: rgba(75, 163, 195, 0.28);
+  animation: vendor-pulse 2s ease-out infinite;
+  pointer-events: none;
 }
 
-.website-card-desc {
-  font-size: 12px;
-  color: var(--text-muted);
-  margin-top: 2px;
+.vendor-location-dot {
+  position: relative;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--primary);
+  border: 2.5px solid white;
+  box-shadow: 0 2px 8px rgba(75, 163, 195, 0.55);
+  z-index: 1;
+}
+
+@keyframes vendor-pulse {
+  0%   { transform: scale(0.4); opacity: 1; }
+  100% { transform: scale(1.4); opacity: 0; }
 }
 
 /* ── Alerts ─────────────────────────────────── */
@@ -413,6 +404,7 @@ body {
 .location-toggle-btn {
   padding: 16px;
   font-size: 16px;
+  box-shadow: var(--shadow-lg);
 }
 
 /* ── Error ─────────────────────────────────── */
@@ -449,114 +441,25 @@ body {
   40% { transform: scale(1); opacity: 1; }
 }
 
-/* ── App shell / bottom nav ─────────────────────── */
-.app-shell {
-  display: flex;
-  flex-direction: column;
-  height: 100vh;
-  height: 100dvh;
-}
-
-.app-shell-content {
-  flex: 1;
-  overflow-y: auto;
-  min-height: 0;
-}
-
-.app-shell-content .screen {
-  min-height: 100%;
-  height: 100%;
-}
-
-.bottom-nav {
-  display: flex;
-  background: var(--gold);
-  padding: 6px env(safe-area-inset-right, 0) calc(6px + env(safe-area-inset-bottom, 0)) env(safe-area-inset-left, 0);
-  box-shadow: 0 -2px 16px rgba(0, 0, 0, 0.15);
+/* ── Status dot ─────────────────────────────── */
+.status-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
   flex-shrink: 0;
 }
 
-.bottom-nav-item {
-  flex: 1;
-  background: transparent;
-  border: none;
-  color: rgba(255, 255, 255, 0.8);
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 4px;
-  padding: 8px 4px;
-  font-size: 12px;
-  font-weight: 600;
-  border-radius: 12px;
-  transition: color 0.15s, background 0.15s;
+.status-dot.active {
+  background: #22c55e;
+  box-shadow: 0 0 0 3px rgba(34, 197, 94, 0.2);
+  animation: pulse 2s infinite;
 }
 
-.bottom-nav-item.active {
-  color: #ffffff;
-  background: rgba(255, 255, 255, 0.18);
+.status-dot.inactive {
+  background: var(--border);
 }
 
-/* ── Map screen ─────────────────────────────────── */
-.map-screen {
-  height: 100%;
-  position: relative;
-}
-
-.map-container {
-  width: 100%;
-  height: 100%;
-}
-
-.map-overlay-alert {
-  position: absolute;
-  top: 16px;
-  left: 16px;
-  right: 16px;
-  z-index: 1000;
-}
-
-.map-loading {
-  height: 100%;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: 12px;
-  color: var(--text-muted);
-}
-
-.vendor-location-marker {
-  position: relative;
-  width: 40px;
-  height: 40px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.vendor-location-pulse {
-  position: absolute;
-  width: 36px;
-  height: 36px;
-  border-radius: 50%;
-  background: rgba(75, 163, 195, 0.28);
-  animation: vendor-pulse 2s ease-out infinite;
-  pointer-events: none;
-}
-
-.vendor-location-dot {
-  position: relative;
-  width: 18px;
-  height: 18px;
-  border-radius: 50%;
-  background: var(--primary);
-  border: 2.5px solid white;
-  box-shadow: 0 2px 8px rgba(75, 163, 195, 0.55);
-  z-index: 1;
-}
-
-@keyframes vendor-pulse {
-  0%   { transform: scale(0.4); opacity: 1; }
-  100% { transform: scale(1.4); opacity: 0; }
+@keyframes pulse {
+  0%, 100% { box-shadow: 0 0 0 3px rgba(34, 197, 94, 0.2); }
+  50% { box-shadow: 0 0 0 6px rgba(34, 197, 94, 0.1); }
 }

--- a/mobile/src/pages/MainScreen.jsx
+++ b/mobile/src/pages/MainScreen.jsx
@@ -1,0 +1,265 @@
+import React, { useState, useEffect, useRef, useCallback } from 'react';
+import { MapContainer, TileLayer, Marker, useMap } from 'react-leaflet';
+import { Geolocation } from '@capacitor/geolocation';
+import { registerPlugin } from '@capacitor/core';
+import L from 'leaflet';
+import 'leaflet/dist/leaflet.css';
+import { BASE_URL, WEB_URL } from '../config.js';
+
+const LocationTracker = registerPlugin('LocationTracker');
+
+const vendorIcon = L.divIcon({
+  className: '',
+  html: '<div class="vendor-location-marker"><div class="vendor-location-pulse"></div><div class="vendor-location-dot"></div></div>',
+  iconSize: [40, 40],
+  iconAnchor: [20, 20],
+});
+
+function FollowPosition({ position }) {
+  const map = useMap();
+  useEffect(() => {
+    if (position) map.setView(position, map.getZoom() < 15 ? 16 : map.getZoom());
+  }, [position, map]);
+  return null;
+}
+
+export default function MainScreen({ auth, onLogout }) {
+  const { token, user, vendorId } = auth;
+  const [sharing, setSharing] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const [position, setPosition] = useState(null);
+  const [mapError, setMapError] = useState(null);
+  const listenerRef = useRef(null);
+  const watchIdRef = useRef(null);
+
+  const authHeader = { Authorization: `Bearer ${token}` };
+  const subscriptionActive = user?.subscription_active;
+
+  useEffect(() => {
+    let active = true;
+    const startWatch = async () => {
+      try {
+        const perm = await Geolocation.requestPermissions();
+        if (perm.location !== 'granted') {
+          if (active) setMapError('Permissão de localização negada. Ativa nas definições do telemóvel.');
+          return;
+        }
+        watchIdRef.current = await Geolocation.watchPosition(
+          { enableHighAccuracy: true },
+          (pos, err) => {
+            if (!active) return;
+            if (err) {
+              setMapError('Não foi possível obter a localização.');
+              return;
+            }
+            if (pos) {
+              setMapError(null);
+              setPosition([pos.coords.latitude, pos.coords.longitude]);
+            }
+          }
+        );
+      } catch {
+        if (active) setMapError('Não foi possível obter a localização.');
+      }
+    };
+    startWatch();
+    return () => {
+      active = false;
+      if (watchIdRef.current != null) Geolocation.clearWatch({ id: watchIdRef.current });
+    };
+  }, []);
+
+  const sendLocation = useCallback(async (lat, lng) => {
+    try {
+      setPosition([lat, lng]);
+      await fetch(`${BASE_URL}/vendors/${vendorId}/location`, {
+        method: 'PUT',
+        headers: { ...authHeader, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ lat, lng }),
+      });
+    } catch (err) {
+      console.error('Erro ao enviar localização:', err);
+    }
+  }, [vendorId, token]);
+
+  const startSharing = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const perm = await Geolocation.requestPermissions();
+      if (perm.location !== 'granted') {
+        setError('Permissão de localização negada.');
+        setLoading(false);
+        return;
+      }
+
+      const res = await fetch(`${BASE_URL}/vendors/${vendorId}/routes/start`, {
+        method: 'POST',
+        headers: authHeader,
+      });
+      if (!res.ok) {
+        const err = await res.json();
+        throw new Error(err.detail || 'Erro ao iniciar partilha');
+      }
+
+      listenerRef.current = await LocationTracker.addListener('locationUpdate', ({ lat, lng }) => {
+        sendLocation(lat, lng);
+      });
+      await LocationTracker.startTracking();
+      setSharing(true);
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const stopSharing = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      if (listenerRef.current) {
+        await listenerRef.current.remove();
+        listenerRef.current = null;
+      }
+      await LocationTracker.stopTracking();
+    } catch (err) {
+      console.error('Erro ao parar tracking nativo:', err);
+    }
+    try {
+      await fetch(`${BASE_URL}/vendors/${vendorId}/routes/stop`, {
+        method: 'POST',
+        headers: authHeader,
+      });
+    } catch (err) {
+      console.error('Erro ao parar partilha:', err);
+    } finally {
+      setSharing(false);
+      setLoading(false);
+    }
+  };
+
+  const handleLogout = async () => {
+    if (sharing) await stopSharing();
+    try {
+      await fetch(`${BASE_URL}/logout`, { method: 'POST', headers: authHeader });
+    } catch {}
+    onLogout();
+  };
+
+  const openWebsite = () => {
+    window.open(`${WEB_URL}/#/dashboard`, '_system');
+  };
+
+  useEffect(() => {
+    return () => {
+      if (listenerRef.current) listenerRef.current.remove();
+    };
+  }, []);
+
+  const vendorName = user?.name || 'Vendedor';
+
+  return (
+    <div className="main-screen">
+      {/* Map background */}
+      <div className="main-map-area">
+        {mapError && <div className="alert alert-warning map-overlay-alert">{mapError}</div>}
+        {position ? (
+          <MapContainer center={position} zoom={16} className="map-container" zoomControl={false}>
+            <TileLayer
+              url="https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}.png"
+              attribution="&copy; <a href='https://openstreetmap.org'>OpenStreetMap</a> contributors &copy; <a href='https://carto.com/attributions'>CARTO</a>"
+            />
+            <Marker position={position} icon={vendorIcon} />
+            <FollowPosition position={position} />
+          </MapContainer>
+        ) : (
+          !mapError && (
+            <div className="map-loading">
+              <span className="loading-dots"><span /><span /><span /></span>
+              <p>A obter a tua localização…</p>
+            </div>
+          )
+        )}
+      </div>
+
+      {/* Top bar */}
+      <div className="main-top-bar">
+        <div className="vendor-info">
+          <div className="vendor-avatar">
+            {vendorName.charAt(0).toUpperCase()}
+          </div>
+          <span className="vendor-name">{vendorName}</span>
+        </div>
+        <button className="btn-icon logout-btn" onClick={handleLogout} title="Sair">
+          <svg viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" strokeWidth="2">
+            <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
+            <polyline points="16 17 21 12 16 7" />
+            <line x1="21" y1="12" x2="9" y2="12" />
+          </svg>
+        </button>
+      </div>
+
+      {/* Bottom overlay controls */}
+      <div className="main-bottom-controls">
+        {!subscriptionActive && (
+          <div className="alert alert-warning">
+            <strong>Subscrição inativa.</strong> Renova no site para partilhar localização.
+          </div>
+        )}
+
+        {error && <div className="error-msg">{error}</div>}
+
+        {sharing && (
+          <div className="sharing-indicator">
+            <div className="status-dot active" />
+            <span>A partilhar localização</span>
+          </div>
+        )}
+
+        <button
+          className={`btn location-toggle-btn ${sharing ? 'btn-danger' : 'btn-primary'}`}
+          onClick={sharing ? stopSharing : startSharing}
+          disabled={loading || !subscriptionActive}
+        >
+          {loading ? (
+            <span className="loading-dots"><span /><span /><span /></span>
+          ) : sharing ? (
+            <>
+              <svg viewBox="0 0 24 24" width="20" height="20" fill="currentColor">
+                <rect x="6" y="6" width="12" height="12" rx="1" />
+              </svg>
+              Parar partilha
+            </>
+          ) : (
+            <>
+              <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" strokeWidth="2">
+                <circle cx="12" cy="12" r="3" />
+                <circle cx="12" cy="12" r="8" strokeDasharray="2 2" />
+                <line x1="12" y1="2" x2="12" y2="5" />
+                <line x1="12" y1="19" x2="12" y2="22" />
+                <line x1="2" y1="12" x2="5" y2="12" />
+                <line x1="19" y1="12" x2="22" y2="12" />
+              </svg>
+              Iniciar partilha
+            </>
+          )}
+        </button>
+
+        <button className="btn btn-website" onClick={openWebsite}>
+          <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" strokeWidth="2">
+            <circle cx="12" cy="12" r="10" />
+            <line x1="2" y1="12" x2="22" y2="12" />
+            <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z" />
+          </svg>
+          Aceder ao site
+          <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="2.5">
+            <line x1="7" y1="17" x2="17" y2="7" />
+            <polyline points="7 7 17 7 17 17" />
+          </svg>
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Consolidated the mobile app from a multi-tab dashboard/map interface into a single unified map screen. This simplifies navigation and provides a more focused location-sharing experience.

## Key Changes

- **Removed multi-tab navigation**: Eliminated the bottom navigation bar and tab-based routing system (`app-shell`, `bottom-nav`)
- **Created new MainScreen component**: Consolidated Dashboard and MapView functionality into a single, full-screen map interface with overlaid controls
- **Redesigned layout architecture**:
  - Map now fills the entire viewport as the background layer
  - Top bar with vendor info and logout button overlaid with backdrop blur
  - Bottom controls panel with location sharing toggle and website link
  - All controls positioned absolutely over the map with proper z-index layering
- **Updated CSS organization**:
  - Removed dashboard-specific styles (dashboard-screen, dashboard-header, location-card, website-card)
  - Introduced new `.main-screen`, `.main-top-bar`, `.main-bottom-controls` classes
  - Reorganized map-related styles under unified naming convention
  - Added safe-area insets for notch/safe area support
  - Implemented gradient overlays for better readability over map
- **Simplified App.jsx**: Removed tab state management and navigation logic, now renders MainScreen directly
- **Preserved functionality**: Location tracking, sharing controls, subscription validation, and logout remain intact

## Implementation Details

- Map uses absolute positioning with `inset: 0` to fill the screen
- Top bar uses `backdrop-filter: blur(12px)` for modern glass-morphism effect
- Bottom controls use gradient background that fades to transparent
- Proper pointer-events management ensures map interaction while controls remain clickable
- Safe area insets account for mobile notches and home indicators

https://claude.ai/code/session_01HgNDGqePLC69qH57uTormk