### PR TITLE
Increase modal z-index to prevent layering issues

### DIFF
--- a/mobile/src/index.css
+++ b/mobile/src/index.css
@@ -495,7 +495,7 @@ body {
   background: rgba(0, 0, 0, 0.45);
   display: flex;
   align-items: flex-end;
-  z-index: 1000;
+  z-index: 2000;
 }
 
 .profile-sheet {


### PR DESCRIPTION
## Summary
Increased the z-index of the modal overlay from 1000 to 2000 to ensure proper stacking order and prevent other elements from appearing above the modal.

## Changes
- Updated `.profile-sheet` modal z-index from `1000` to `2000` in `mobile/src/index.css`

## Details
This change addresses z-index layering conflicts where elements with z-index values between 1000-2000 could appear above the modal overlay. By increasing the z-index to 2000, we ensure the modal maintains proper visual hierarchy and remains on top of other page elements.

https://claude.ai/code/session_01G8oTEJiX9FR7Co5i7RmjFR