### PR TITLE
Security improvements: email logging, vendor data exposure, and webhook validation

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -151,7 +151,9 @@ BASE_APP_URL = os.getenv("BASE_APP_URL", "https://ss-tester.onrender.com")
 
 def send_email(to: str, subject: str, body: str) -> None:
     """Send an email notification. Patch this in tests or integrate a real provider."""
-    print(f"[Email] To: {to}\nSubject: {subject}\n{body}")
+    # O corpo do email contém tokens secretos (confirmação/reset de password);
+    # nunca o registar em logs.
+    print(f"[Email] To: {to}\nSubject: {subject}")
 
 # Configuração do Stripe
 stripe.api_key = os.getenv("STRIPE_API_KEY", "")
@@ -579,7 +581,7 @@ async def create_vendor(
 # --------------------------
 # Listar vendedores
 # --------------------------
-@app.get("/vendors/", response_model=list[schemas.VendorOut])
+@app.get("/vendors/", response_model=list[schemas.VendorPublicOut])
 # list_vendors
 def list_vendors(
     current_vendor: models.Vendor | None = Depends(get_current_vendor_optional),
@@ -1026,19 +1028,22 @@ def list_stories(vendor_id: int, db: Session = Depends(get_db)):
 @app.post("/stripe/webhook")
 # stripe_webhook
 async def stripe_webhook(request: Request, db: Session = Depends(get_db)):
+    if not STRIPE_WEBHOOK_SECRET:
+        # Sem segredo configurado não é possível verificar a autenticidade do
+        # pedido; rejeitar em vez de confiar em JSON não assinado.
+        raise HTTPException(status_code=500, detail="Webhook not configured")
+
     payload = await request.body()
     sig = request.headers.get("stripe-signature")
-    if STRIPE_WEBHOOK_SECRET:
-        try:
-            event = stripe.Webhook.construct_event(payload, sig, STRIPE_WEBHOOK_SECRET)
-        except Exception:
-            raise HTTPException(status_code=400, detail="Invalid webhook")
-    else:
-        # Sem segredo definido, interpretar payload como JSON bruto
-        event = json.loads(payload)
+    try:
+        event = stripe.Webhook.construct_event(payload, sig, STRIPE_WEBHOOK_SECRET)
+    except Exception:
+        raise HTTPException(status_code=400, detail="Invalid webhook")
 
     if event.get("type") == "checkout.session.completed":
         session = event["data"]["object"]
+        if session.get("payment_status") != "paid":
+            return {"status": "ignored"}
         vendor_id = int(session.get("client_reference_id") or session.get("metadata", {}).get("vendor_id") or 0)
         vendor = db.query(models.Vendor).filter(models.Vendor.id == vendor_id).first()
         if vendor:
@@ -1056,20 +1061,22 @@ async def stripe_webhook(request: Request, db: Session = Depends(get_db)):
 
 
 # --------------------------
-# Endpoint para ativar pagamento manualmente
+# Endpoint para ativar pagamento manualmente (ex.: pagamento por transferência)
+# Apenas acessível por administradores - nunca pelo próprio vendedor.
 # --------------------------
 @app.post("/vendors/{vendor_id}/activate-subscription")
 # activate_subscription_manual
 def activate_subscription_manual(
     vendor_id: int,
     db: Session = Depends(get_db),
-    current_vendor: models.Vendor = Depends(get_current_vendor),
+    admin: bool = Depends(get_admin),
 ):
-    if current_vendor.id != vendor_id:
-        raise HTTPException(status_code=403, detail="Not authorized")
+    vendor = db.query(models.Vendor).filter(models.Vendor.id == vendor_id).first()
+    if not vendor:
+        raise HTTPException(status_code=404, detail="Vendor not found")
 
-    current_vendor.subscription_active = True
-    current_vendor.subscription_valid_until = utcnow() + timedelta(days=7)
+    vendor.subscription_active = True
+    vendor.subscription_valid_until = utcnow() + timedelta(days=7)
     paid = models.PaidWeek(
         vendor_id=vendor_id,
         start_date=utcnow(),

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -74,6 +74,22 @@ class VendorOut(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
 
+# VendorPublicOut - subconjunto seguro exposto a utilizadores não autenticados
+# (mapa público). Nunca incluir email, nif, phone, license_number, business_name.
+class VendorPublicOut(BaseModel):
+    id: int
+    name: str
+    product: str
+    profile_photo: str
+    pin_color: Optional[str] = None
+    current_lat: Optional[float] = None
+    current_lng: Optional[float] = None
+    last_seen: Optional[str] = None
+    beaches: Optional[str] = None
+    product_categories: Optional[str] = None
+    model_config = ConfigDict(from_attributes=True)
+
+
 # RoutePoint
 class RoutePoint(BaseModel):
     lat: float

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -11,6 +11,8 @@ from fastapi.testclient import TestClient
 def client(tmp_path):
     # setup DATABASE_URL for tests
     os.environ["DATABASE_URL"] = f"sqlite:///{tmp_path}/test.db?check_same_thread=False"
+    os.environ["ADMIN_TOKEN"] = "test-admin-token"
+    os.environ["STRIPE_WEBHOOK_SECRET"] = "test-webhook-secret"
 
     # reload application modules so they pick up the new DATABASE_URL
     from backend.app import database, models, main
@@ -24,6 +26,10 @@ def client(tmp_path):
         sent_emails.append({"to": to, "subject": subject, "body": body})
 
     main.send_email = fake_send_email
+
+    # nos testes não há um pedido Stripe real assinado; simular a verificação
+    # da assinatura para se poder testar o fluxo do webhook isoladamente
+    main.stripe.Webhook.construct_event = lambda payload, sig, secret: __import__("json").loads(payload)
 
     # create tables
     models.Base.metadata.create_all(bind=database.engine)
@@ -51,7 +57,7 @@ def activate_subscription(client, vendor_id):
     token = get_token(client)
     resp = client.post(
         f"/vendors/{vendor_id}/activate-subscription",
-        headers={"Authorization": f"Bearer {token}"},
+        headers={"X-Admin-Token": os.environ["ADMIN_TOKEN"]},
     )
     assert resp.status_code == 200
     return token
@@ -356,7 +362,13 @@ def test_paid_weeks_listing(client):
 
     event = {
         "type": "checkout.session.completed",
-        "data": {"object": {"metadata": {"vendor_id": vendor_id}, "url": "http://r"}},
+        "data": {
+            "object": {
+                "metadata": {"vendor_id": vendor_id},
+                "url": "http://r",
+                "payment_status": "paid",
+            }
+        },
     }
     resp = client.post("/stripe/webhook", json=event)
     assert resp.status_code == 200


### PR DESCRIPTION
## Summary
This PR implements several security hardening measures across authentication, data exposure, and payment webhook handling.

## Key Changes

- **Email logging security**: Removed email body from logs to prevent accidental exposure of sensitive tokens (password reset/confirmation links)

- **Vendor data exposure**: 
  - Created new `VendorPublicOut` schema that exposes only safe, non-sensitive vendor fields (name, product, location, photos)
  - Updated `/vendors/` list endpoint to use `VendorPublicOut` instead of full `VendorOut`, preventing exposure of email, NIF, phone, license number, and business name to unauthenticated users

- **Webhook security**:
  - Added early validation to reject Stripe webhooks when `STRIPE_WEBHOOK_SECRET` is not configured, preventing acceptance of unsigned payloads
  - Added payment status check to ignore webhook events that aren't actually paid
  - Simplified webhook verification logic by removing fallback to unsigned JSON parsing

- **Manual subscription activation**:
  - Changed `/vendors/{vendor_id}/activate-subscription` endpoint from vendor self-service to admin-only operation
  - Updated authentication from vendor token to admin token (`get_admin` dependency)
  - Added vendor existence validation before activation

- **Test improvements**:
  - Added `ADMIN_TOKEN` and `STRIPE_WEBHOOK_SECRET` environment variables to test setup
  - Mocked Stripe webhook signature verification for isolated webhook testing
  - Updated subscription activation test to use admin token instead of vendor token
  - Added `payment_status` field to webhook test event

## Notable Implementation Details
- The `VendorPublicOut` schema explicitly documents which fields must never be exposed to unauthenticated users
- Webhook validation now fails-secure by rejecting unsigned requests rather than accepting them as fallback
- Manual subscription activation is now restricted to administrators, preventing vendors from self-activating subscriptions

https://claude.ai/code/session_01D8EXKU1Y8gkdUbksYwpbYh