### PR TITLE
Add wake lock and service restart to LocationForegroundService

### DIFF
--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -49,4 +49,5 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
 </manifest>

--- a/mobile/android/app/src/main/java/com/sunnysales/vendor/LocationForegroundService.java
+++ b/mobile/android/app/src/main/java/com/sunnysales/vendor/LocationForegroundService.java
@@ -4,10 +4,12 @@ import android.app.Notification;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.app.Service;
+import android.content.Context;
 import android.content.Intent;
 import android.os.Build;
 import android.os.IBinder;
 import android.os.Looper;
+import android.os.PowerManager;
 
 import androidx.annotation.Nullable;
 import androidx.core.app.NotificationCompat;
@@ -26,6 +28,7 @@ public class LocationForegroundService extends Service {
 
     private FusedLocationProviderClient fusedClient;
     private LocationCallback locationCallback;
+    private PowerManager.WakeLock wakeLock;
 
     public interface LocationListener {
         void onLocationUpdate(double lat, double lng);
@@ -59,8 +62,21 @@ public class LocationForegroundService extends Service {
             startForeground(NOTIFICATION_ID, notification);
         }
 
+        acquireWakeLock();
         startLocationUpdates();
         return START_STICKY;
+    }
+
+    private void acquireWakeLock() {
+        if (wakeLock != null && wakeLock.isHeld()) {
+            return;
+        }
+        PowerManager powerManager = (PowerManager) getSystemService(Context.POWER_SERVICE);
+        wakeLock = powerManager.newWakeLock(
+                PowerManager.PARTIAL_WAKE_LOCK,
+                "SunnySales:LocationWakeLock"
+        );
+        wakeLock.acquire(10 * 60 * 60 * 1000L);
     }
 
     private void startLocationUpdates() {
@@ -102,10 +118,24 @@ public class LocationForegroundService extends Service {
     }
 
     @Override
+    public void onTaskRemoved(Intent rootIntent) {
+        super.onTaskRemoved(rootIntent);
+        Intent restartIntent = new Intent(getApplicationContext(), LocationForegroundService.class);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            getApplicationContext().startForegroundService(restartIntent);
+        } else {
+            getApplicationContext().startService(restartIntent);
+        }
+    }
+
+    @Override
     public void onDestroy() {
         super.onDestroy();
         if (fusedClient != null && locationCallback != null) {
             fusedClient.removeLocationUpdates(locationCallback);
+        }
+        if (wakeLock != null && wakeLock.isHeld()) {
+            wakeLock.release();
         }
         listener = null;
     }


### PR DESCRIPTION
## Summary
Enhanced the LocationForegroundService to maintain location tracking even when the app is backgrounded or the task is removed. This includes acquiring a wake lock to prevent the device from sleeping and implementing service restart logic.

## Key Changes
- **Wake Lock Management**: Added `PowerManager.WakeLock` to prevent the device from entering sleep mode while location updates are active
  - Acquires a partial wake lock (10 hours) when the service starts
  - Properly releases the wake lock in `onDestroy()`
  - Includes safety checks to prevent duplicate wake lock acquisitions
  
- **Service Restart on Task Removal**: Implemented `onTaskRemoved()` callback to automatically restart the service if the user swipes the app away
  - Handles both Android O+ (using `startForegroundService()`) and earlier versions
  
- **Permissions**: Added `WAKE_LOCK` permission to AndroidManifest.xml to support wake lock functionality

## Implementation Details
- The wake lock is acquired in `onStartCommand()` before starting location updates
- Wake lock state is checked before acquisition to avoid redundant operations
- Service restart uses the application context to ensure proper initialization
- All wake lock resources are properly cleaned up in the `onDestroy()` lifecycle method

https://claude.ai/code/session_01MEd9cB3oUPPNR2ziBgarDm