### PR TITLE
Implement dynamic Stripe checkout sessions with plan selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,8 @@ ss_TESTER/
    - `DATABASE_URL` — ligação à base de dados (PostgreSQL ou SQLite)
    - `SECRET_KEY` — chave para assinar tokens JWT
    - `SMTP_USER` e `SMTP_PASSWORD` — envio de emails (opcional)
-   - `STRIPE_API_KEY`, `STRIPE_PRICE_ID` — pagamentos (opcional)
+   - `STRIPE_API_KEY` — pagamentos (opcional)
+   - `STRIPE_PRICE_ID_SEMANAL`, `STRIPE_PRICE_ID_QUINZENAL`, `STRIPE_PRICE_ID_MENSAL` — price IDs dos planos de subscrição (opcional, têm valores por omissão)
 4. Execute o servidor:
    ```bash
    uvicorn backend.app.main:app --reload

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -157,10 +157,16 @@ def send_email(to: str, subject: str, body: str) -> None:
 
 # Configuração do Stripe
 stripe.api_key = os.getenv("STRIPE_API_KEY", "")
-STRIPE_PRICE_ID = os.getenv("STRIPE_PRICE_ID", "")
 STRIPE_WEBHOOK_SECRET = os.getenv("STRIPE_WEBHOOK_SECRET", "")
 SUCCESS_URL = os.getenv("SUCCESS_URL", "https://example.com/success")
 CANCEL_URL = os.getenv("CANCEL_URL", "https://example.com/cancel")
+
+# Price IDs dos planos de subscrição (Stripe)
+STRIPE_PLAN_PRICE_IDS = {
+    "semanal": os.getenv("STRIPE_PRICE_ID_SEMANAL", "price_1TitkNIUkNjcmfnZtCCHYsev"),
+    "quinzenal": os.getenv("STRIPE_PRICE_ID_QUINZENAL", "price_1TjgjNIUkNjcmfnZDnYLvkf4"),
+    "mensal": os.getenv("STRIPE_PRICE_ID_MENSAL", "price_1TjgjNIUkNjcmfnZ2YS7j2it"),
+}
 
 
 # validate_password
@@ -927,6 +933,7 @@ async def show_password_reset_form(token: str):
 # create_checkout_session
 def create_checkout_session(
     vendor_id: int,
+    plan: str = "mensal",
     db: Session = Depends(get_db),
     current_vendor: models.Vendor = Depends(get_current_vendor),
 ):
@@ -935,15 +942,16 @@ def create_checkout_session(
         raise HTTPException(status_code=404, detail="Vendor not found")
     if current_vendor.id != vendor_id:
         raise HTTPException(status_code=403, detail="Not authorized")
-    if not STRIPE_PRICE_ID:
-        raise HTTPException(status_code=500, detail="Stripe not configured")
+    price_id = STRIPE_PLAN_PRICE_IDS.get(plan)
+    if not price_id:
+        raise HTTPException(status_code=400, detail="Invalid plan")
     try:
         session = stripe.checkout.Session.create(
             mode="subscription",
-            line_items=[{"price": STRIPE_PRICE_ID, "quantity": 1}],
+            line_items=[{"price": price_id, "quantity": 1}],
             success_url=SUCCESS_URL,
             cancel_url=CANCEL_URL,
-            metadata={"vendor_id": vendor_id},
+            metadata={"vendor_id": vendor_id, "plan": plan},
         )
         return {"checkout_url": session.url}
     except Exception as exc:

--- a/sunny_sales_web/src/pages/PlanosVendedores.jsx
+++ b/sunny_sales_web/src/pages/PlanosVendedores.jsx
@@ -1,9 +1,9 @@
 import { useNavigate } from 'react-router-dom';
+import axios from 'axios';
 import { FiCheck, FiZap, FiStar, FiTrendingUp } from 'react-icons/fi';
 import BackHomeButton from '../components/BackHomeButton';
+import { BASE_URL } from '../config';
 import './PlanosVendedores.css';
-
-const STRIPE_PAYMENT_LINK = 'https://buy.stripe.com/test_28E3cvaRX1xWdIzd2ZeUU00';
 
 const PLANS = [
   {
@@ -79,13 +79,22 @@ const FAQS = [
 export default function PlanosVendedores() {
   const navigate = useNavigate();
 
-  const handlePlanClick = (e) => {
+  const handlePlanClick = async (e, planId) => {
     e.preventDefault();
     const user = localStorage.getItem('user');
     const token = localStorage.getItem('token');
     if (user && token) {
       const vendor = JSON.parse(user);
-      window.open(`${STRIPE_PAYMENT_LINK}?client_reference_id=${vendor.id}`, '_blank');
+      try {
+        const { data } = await axios.post(
+          `${BASE_URL}/vendors/${vendor.id}/create-checkout-session`,
+          null,
+          { params: { plan: planId }, headers: { Authorization: `Bearer ${token}` } }
+        );
+        window.open(data.checkout_url, '_blank');
+      } catch (err) {
+        console.error('Erro ao criar sessão de pagamento:', err);
+      }
     } else {
       navigate('/vendor-login');
     }
@@ -155,7 +164,7 @@ export default function PlanosVendedores() {
             </ul>
 
             <button
-              onClick={handlePlanClick}
+              onClick={(e) => handlePlanClick(e, plan.id)}
               className={`pv-plan-cta${plan.highlight ? ' pv-plan-cta--highlight' : ''}`}
             >
               {plan.cta}

--- a/sunny_sales_web/src/pages/VendorDashboard.jsx
+++ b/sunny_sales_web/src/pages/VendorDashboard.jsx
@@ -136,11 +136,19 @@ export default function VendorDashboard() {
     setSharing(false);
   };
 
-  const STRIPE_PAYMENT_LINK = 'https://buy.stripe.com/test_28E3cvaRX1xWdIzd2ZeUU00';
-
-  const paySubscription = () => {
+  const paySubscription = async (plan = 'mensal') => {
     if (!vendor) return;
-    window.open(`${STRIPE_PAYMENT_LINK}?client_reference_id=${vendor.id}`, '_blank');
+    const token = localStorage.getItem('token');
+    try {
+      const { data } = await axios.post(
+        `${BASE_URL}/vendors/${vendor.id}/create-checkout-session`,
+        null,
+        { params: { plan }, headers: { Authorization: `Bearer ${token}` } }
+      );
+      window.open(data.checkout_url, '_blank');
+    } catch (err) {
+      console.error('Erro ao criar sessão de pagamento:', err);
+    }
   };
 
   // ── Profile modal ─────────────────────────────────────


### PR DESCRIPTION
## Summary
Refactored the payment flow to use dynamic Stripe checkout sessions instead of static payment links. The system now supports multiple subscription plans (weekly, bi-weekly, monthly) with plan-specific pricing, allowing vendors to select their preferred plan before checkout.

## Key Changes

- **Frontend (PlanosVendedores.jsx & VendorDashboard.jsx)**
  - Replaced hardcoded Stripe payment link with dynamic API calls to `/vendors/{id}/create-checkout-session`
  - Updated `handlePlanClick` and `paySubscription` functions to accept plan parameter and make async requests
  - Integrated `BASE_URL` configuration for API endpoints
  - Added error handling for payment session creation

- **Backend (main.py)**
  - Created `STRIPE_PLAN_PRICE_IDS` dictionary to map plan names to Stripe price IDs (semanal, quinzenal, mensal)
  - Enhanced `create_checkout_session` endpoint to accept `plan` query parameter
  - Updated Stripe session creation to use plan-specific price IDs and include plan metadata
  - Improved validation to check for valid plan selection instead of just API key configuration

- **Documentation (README.md)**
  - Updated environment variables documentation to reflect new plan-specific price ID requirements
  - Clarified that plan price IDs have default fallback values

## Implementation Details
- Plan selection is passed from UI buttons to the backend via query parameter
- Stripe metadata now includes both vendor_id and plan for better tracking
- Authorization token is required for checkout session creation (vendor must be authenticated)
- Error handling logs payment session creation failures to console

https://claude.ai/code/session_01RCADHkkAuUZSP1GYEgTvK8