### PR TITLE
Update Stripe price IDs and add payment error handling

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -163,9 +163,9 @@ CANCEL_URL = os.getenv("CANCEL_URL", "https://example.com/cancel")
 
 # Price IDs dos planos de subscrição (Stripe)
 STRIPE_PLAN_PRICE_IDS = {
-    "semanal": os.getenv("STRIPE_PRICE_ID_SEMANAL", "price_1TitkNIUkNjcmfnZtCCHYsev"),
-    "quinzenal": os.getenv("STRIPE_PRICE_ID_QUINZENAL", "price_1TjgjNIUkNjcmfnZDnYLvkf4"),
-    "mensal": os.getenv("STRIPE_PRICE_ID_MENSAL", "price_1TjgjNIUkNjcmfnZ2YS7j2it"),
+    "semanal": os.getenv("STRIPE_PRICE_ID_SEMANAL", "price_1TjhC7IUkNjcmfnZf8Kzjsam"),
+    "quinzenal": os.getenv("STRIPE_PRICE_ID_QUINZENAL", "price_1TjhBKIUkNjcmfnZF5tlmASF"),
+    "mensal": os.getenv("STRIPE_PRICE_ID_MENSAL", "price_1TjhCMIUkNjcmfnZECNOhR4y"),
 }
 
 

--- a/sunny_sales_web/src/pages/PlanosVendedores.jsx
+++ b/sunny_sales_web/src/pages/PlanosVendedores.jsx
@@ -94,6 +94,7 @@ export default function PlanosVendedores() {
         window.open(data.checkout_url, '_blank');
       } catch (err) {
         console.error('Erro ao criar sessão de pagamento:', err);
+        alert(err.response?.data?.detail || 'Não foi possível iniciar o pagamento. Tenta novamente.');
       }
     } else {
       navigate('/vendor-login');


### PR DESCRIPTION
## Summary
This PR updates the Stripe subscription plan price IDs to new values and improves error handling in the payment checkout flow by displaying user-friendly error messages.

## Key Changes
- **Backend (main.py)**: Updated all three Stripe plan price IDs (semanal, quinzenal, mensal) to new values
  - These appear to be migrated to new Stripe price objects, likely due to product or pricing structure changes
- **Frontend (PlanosVendedores.jsx)**: Enhanced error handling in the payment session creation
  - Added user-facing alert message when payment checkout fails
  - Displays server error details if available, otherwise shows a generic fallback message in Portuguese

## Implementation Details
The error handling improvement provides better UX by:
- Catching payment initialization errors and alerting the user instead of silently failing
- Attempting to display the server's error detail message when available
- Falling back to a user-friendly Portuguese message if no server detail is provided

https://claude.ai/code/session_01XKZE8oHDT9Z2Kpv1CziA1e