### PR TITLE
Add payment methods selection to vendor profile editor

### DIFF
--- a/sunny_sales_web/src/pages/VendorDashboard.css
+++ b/sunny_sales_web/src/pages/VendorDashboard.css
@@ -723,6 +723,44 @@
   padding: 0;
 }
 
+.vd-modal-payments-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.vd-modal-payment-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: var(--surface-alt);
+  border: 1.5px solid var(--border);
+  border-radius: var(--radius-full);
+  padding: 7px 14px;
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  cursor: pointer;
+  min-height: auto;
+  transition: background var(--transition), border-color var(--transition), color var(--transition);
+}
+
+.vd-modal-payment-chip-icon {
+  display: flex;
+  align-items: center;
+  font-size: 0.9rem;
+}
+
+.vd-modal-payment-chip.active {
+  background: var(--primary-light);
+  border-color: var(--primary);
+  color: var(--primary-dark);
+}
+
+.vd-modal-payment-chip:hover {
+  border-color: var(--primary-light-solid);
+}
+
 .vd-modal-error {
   color: #c62828;
   font-size: 0.82rem;

--- a/sunny_sales_web/src/pages/VendorDashboard.jsx
+++ b/sunny_sales_web/src/pages/VendorDashboard.jsx
@@ -7,7 +7,7 @@ import {
   FiCreditCard, FiMail, FiMapPin, FiLogOut,
   FiDollarSign, FiSmartphone, FiTerminal, FiWifi,
   FiNavigation, FiUser, FiLock, FiCheck,
-  FiChevronRight, FiSend, FiCheckSquare,
+  FiSend, FiCheckSquare,
 } from 'react-icons/fi';
 import ImageCropper from '../components/ImageCropper';
 import './VendorDashboard.css';
@@ -45,6 +45,7 @@ export default function VendorDashboard() {
   const [editPhotoPreview, setEditPhotoPreview] = useState(null);
   const [editCropSrc, setEditCropSrc] = useState(null);
   const [editPinColor, setEditPinColor] = useState('#7B61FF');
+  const [editPaymentMethods, setEditPaymentMethods] = useState([]);
   const [editSaving, setEditSaving] = useState(false);
   const [editError, setEditError] = useState('');
   // Security tab state
@@ -163,6 +164,7 @@ export default function VendorDashboard() {
     setEditPhotoPreview(null);
     setEditCropSrc(null);
     setEditPinColor(vendor.pin_color || '#7B61FF');
+    setEditPaymentMethods(vendor.payment_methods ? vendor.payment_methods.split(',').filter(Boolean) : []);
     setEditError('');
     setSecOldPassword('');
     setSecNewPassword('');
@@ -192,6 +194,12 @@ export default function VendorDashboard() {
     setEditCropSrc(null);
   };
 
+  const togglePaymentMethod = (method) => {
+    setEditPaymentMethods((prev) =>
+      prev.includes(method) ? prev.filter((m) => m !== method) : [...prev, method]
+    );
+  };
+
   const handleEditCropComplete = (blob) => {
     if (editCropSrc) URL.revokeObjectURL(editCropSrc);
     setEditCropSrc(null);
@@ -212,6 +220,8 @@ export default function VendorDashboard() {
       if (editEmail !== vendor.email) data.append('email', editEmail);
       if (editProduct !== vendor.product) data.append('product', editProduct);
       if (editPinColor !== (vendor.pin_color || '#7B61FF')) data.append('pin_color', editPinColor);
+      const newPaymentMethods = editPaymentMethods.join(',');
+      if (newPaymentMethods !== (vendor.payment_methods || '')) data.append('payment_methods', newPaymentMethods);
       if (editPhoto) {
         const file = new File([editPhoto], 'profile.jpg', { type: 'image/jpeg' });
         data.append('profile_photo', file);
@@ -325,7 +335,6 @@ export default function VendorDashboard() {
                 <span className="vd-detail-row-icon"><FiMail /></span>
                 <span className="vd-detail-row-label">EMAIL</span>
                 <span className="vd-detail-row-value">{vendor.email}</span>
-                <FiChevronRight className="vd-detail-row-chevron" />
               </div>
               <div className="vd-detail-row">
                 <span className="vd-detail-row-icon">
@@ -333,7 +342,6 @@ export default function VendorDashboard() {
                 </span>
                 <span className="vd-detail-row-label">COR DO PIN</span>
                 <span className="vd-detail-row-value" />
-                <FiChevronRight className="vd-detail-row-chevron" />
               </div>
               {vendor.payment_methods && (
                 <div className="vd-detail-row vd-detail-row-payments">
@@ -360,7 +368,7 @@ export default function VendorDashboard() {
               <span className="vd-cta-title">Subscrição Inativa</span>
               <span className="vd-cta-desc">Ative para aparecer no mapa</span>
             </div>
-            <button className="vd-cta-btn" onClick={paySubscription}>
+            <button className="vd-cta-btn" onClick={() => navigate('/planos')}>
               Ativar
             </button>
           </div>
@@ -526,6 +534,22 @@ export default function VendorDashboard() {
                         className="vd-modal-pin-input"
                       />
                     </label>
+                  </div>
+                </div>
+                <div className="vd-modal-field">
+                  <label className="vd-modal-label">Métodos de pagamento aceites</label>
+                  <div className="vd-modal-payments-grid">
+                    {Object.keys(PAYMENT_ICONS).map((method) => (
+                      <button
+                        type="button"
+                        key={method}
+                        className={`vd-modal-payment-chip${editPaymentMethods.includes(method) ? ' active' : ''}`}
+                        onClick={() => togglePaymentMethod(method)}
+                      >
+                        <span className="vd-modal-payment-chip-icon">{PAYMENT_ICONS[method]}</span>
+                        {method}
+                      </button>
+                    ))}
                   </div>
                 </div>
 


### PR DESCRIPTION
## Summary
This PR adds the ability for vendors to select and manage their accepted payment methods directly from the profile edit modal in the Vendor Dashboard.

## Key Changes
- **New UI Components**: Added payment method chip selector with visual feedback
  - Created `.vd-modal-payments-grid` for flex layout of payment method chips
  - Created `.vd-modal-payment-chip` styled button component with active/hover states
  - Added icon support for payment method chips via `.vd-modal-payment-chip-icon`

- **State Management**: 
  - Added `editPaymentMethods` state to track selected payment methods
  - Implemented `togglePaymentMethod()` function to add/remove payment methods from selection
  - Initialize payment methods from vendor data on modal open

- **Data Persistence**:
  - Payment methods are now sent to the backend as comma-separated string
  - Only updates backend if payment methods have changed

- **UI Improvements**:
  - Removed unused `FiChevronRight` icon import
  - Removed chevron icons from email and pin color detail rows
  - Changed inactive subscription button to navigate to `/planos` instead of calling `paySubscription()`

## Implementation Details
- Payment methods are stored as comma-separated values in the vendor object
- The chip selector uses the existing `PAYMENT_ICONS` constant for consistent icon rendering
- Active payment method chips are highlighted with primary color styling
- Changes are only persisted when the user saves the profile edit form

https://claude.ai/code/session_01XdjCMBqnxVC3KzSck3CUNP