### PR TITLE
Simplify vendor map pins with SVG-based design

### DIFF
--- a/sunny_sales_web/src/pages/ModernMapLayout.css
+++ b/sunny_sales_web/src/pages/ModernMapLayout.css
@@ -743,63 +743,13 @@ body {
   border: none !important;
 }
 
-.vendor-pin-stack {
-  position: relative;
-  width: 44px;
-  height: 58px;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-}
-
-.vendor-pin-teardrop {
-  position: relative;
-  width: 40px;
-  height: 40px;
-  border-radius: 50% 50% 50% 0;
-  transform: rotate(-45deg);
-  border: 3px solid white;
-  box-shadow: 0 3px 8px rgba(0, 0, 0, 0.35);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.vendor-pin-photo {
-  width: 28px;
-  height: 28px;
-  border-radius: 50%;
-  overflow: hidden;
-  transform: rotate(45deg);
-  background: rgba(255, 255, 255, 0.25);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: white;
-  font-size: 12px;
-  font-weight: 700;
-}
-
-.vendor-pin-photo img {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
+.vendor-pin-svg {
   display: block;
+  filter: drop-shadow(0 3px 6px rgba(0, 0, 0, 0.35));
 }
 
-.vendor-pin-arrow {
-  position: absolute;
-  top: -10px;
-  left: 50%;
-  transform: translateX(-50%) rotate(45deg);
-}
-
-.vendor-pin-tip {
-  width: 7px;
-  height: 7px;
-  border-radius: 50%;
-  margin-top: 2px;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+.vendor-own-pin .vendor-pin-svg {
+  filter: drop-shadow(0 3px 8px rgba(0, 0, 0, 0.5));
 }
 
 .user-location-marker {

--- a/sunny_sales_web/src/pages/ModernMapLayout.jsx
+++ b/sunny_sales_web/src/pages/ModernMapLayout.jsx
@@ -55,29 +55,13 @@ function escapeHtml(str) {
   }[c]));
 }
 
-function getInitials(name) {
-  const parts = String(name ?? '').trim().split(/\s+/).filter(Boolean);
-  if (parts.length === 0) return '?';
-  if (parts.length === 1) return parts[0].charAt(0).toUpperCase();
-  return (parts[0].charAt(0) + parts[parts.length - 1].charAt(0)).toUpperCase();
-}
-
-function getVendorPinHtml(color, heading, photoUrl, name) {
-  const hasHeading = heading !== null && !isNaN(heading);
-  const arrow = hasHeading
-    ? `<svg viewBox="0 0 20 20" width="11" height="11" style="display:block;"><polygon points="10,1 6.5,14 10,11.5 13.5,14" fill="white"/></svg>`
-    : '';
-  const inner = photoUrl
-    ? `<img src="${escapeHtml(photoUrl)}" alt="" />`
-    : `<span>${escapeHtml(getInitials(name))}</span>`;
+function getVendorPinHtml(color) {
+  const safeColor = escapeHtml(color);
   return `
-    <div class="vendor-pin-stack">
-      <div class="vendor-pin-teardrop" style="background:${color}">
-        <div class="vendor-pin-photo">${inner}</div>
-        ${hasHeading ? `<div class="vendor-pin-arrow">${arrow}</div>` : ''}
-      </div>
-      <div class="vendor-pin-tip" style="background:${color}"></div>
-    </div>`;
+    <svg width="32" height="44" viewBox="0 0 32 44" xmlns="http://www.w3.org/2000/svg" class="vendor-pin-svg">
+      <path d="M16 0C7.163 0 0 7.163 0 16c0 11.5 16 28 16 28s16-16.5 16-28C32 7.163 24.837 0 16 0z" fill="${safeColor}" stroke="white" stroke-width="2"/>
+      <circle cx="16" cy="16" r="6" fill="white"/>
+    </svg>`;
 }
 
 function MapBearingController({ targetBearingRef }) {
@@ -499,16 +483,15 @@ export default function ModernMapLayout() {
             {filteredVendors.map((v) => {
               const isOwn = loggedVendor && Number(v.id) === Number(loggedVendor.id);
               const pinColor = v.pin_color || '#7B61FF';
-              const photoUrl = v.profile_photo ? mediaUrl(v.profile_photo) : null;
               return (
                 <Marker
                   key={v.id}
                   position={[v.current_lat, v.current_lng]}
                   icon={L.divIcon({
                     className: isOwn ? 'vendor-own-pin' : 'vendor-pin',
-                    html: getVendorPinHtml(pinColor, isOwn ? heading : null, photoUrl, v.name),
-                    iconSize: [44, 58],
-                    iconAnchor: [22, 58],
+                    html: getVendorPinHtml(pinColor),
+                    iconSize: [32, 44],
+                    iconAnchor: [16, 44],
                   })}
                   eventHandlers={{
                     click: () => focusVendor(v),


### PR DESCRIPTION
## Summary
Refactored vendor map pins from a complex HTML/CSS-based teardrop design to a simpler SVG-based implementation. This change removes unnecessary complexity while maintaining visual consistency.

## Key Changes
- **Replaced HTML pin structure with SVG**: Converted the multi-element teardrop pin design (`.vendor-pin-stack`, `.vendor-pin-teardrop`, `.vendor-pin-photo`, etc.) to a single SVG element with a circular marker
- **Removed photo/initials display**: Eliminated the profile photo and name initials functionality from pins, simplifying the pin to show only color and a white center dot
- **Removed heading arrow**: Deleted the directional arrow that appeared on the logged-in vendor's pin
- **Updated CSS**: Replaced 50+ lines of pin styling rules with minimal SVG-specific styles (`.vendor-pin-svg` and `.vendor-own-pin .vendor-pin-svg`)
- **Adjusted pin dimensions**: Changed icon size from 44x58px to 32x44px and updated anchor point accordingly
- **Simplified function signature**: `getVendorPinHtml()` now only requires the color parameter, removing dependencies on heading, photoUrl, and name

## Implementation Details
- The new SVG pin uses a teardrop path shape with a white stroke and a white circle in the center
- Drop shadow is applied via CSS filter instead of box-shadow for better SVG rendering
- The own vendor pin has a slightly stronger drop shadow (0.5 opacity vs 0.35)
- All HTML escaping is preserved for the color parameter to prevent injection vulnerabilities

https://claude.ai/code/session_014MWCRRrucYgQfj1TkUF54V