### PR TITLE
Add payment_methods field to VendorPublicOut schema

### DIFF
--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -87,6 +87,7 @@ class VendorPublicOut(BaseModel):
     last_seen: Optional[str] = None
     beaches: Optional[str] = None
     product_categories: Optional[str] = None
+    payment_methods: Optional[str] = None
     model_config = ConfigDict(from_attributes=True)
 
 


### PR DESCRIPTION
## Summary
Added a new optional `payment_methods` field to the `VendorPublicOut` schema to expose vendor payment method information in public API responses.

## Key Changes
- Added `payment_methods: Optional[str] = None` field to the `VendorPublicOut` model in `backend/app/schemas.py`
- The field follows the existing pattern of optional string fields like `beaches` and `product_categories`
- Maintains compatibility with the existing `ConfigDict(from_attributes=True)` configuration for ORM mapping

## Implementation Details
- The field is optional and defaults to `None`, ensuring backward compatibility
- Follows the same data type convention as related vendor information fields
- No database or model changes required; this is a schema-level addition for API exposure

https://claude.ai/code/session_013z8XY9qmV4ZMmt8PeW1pxL