### PR TITLE
Mostrar mapa logo com posição rápida em vez de esperar pelo GPS de alta precisão

### DIFF
--- a/mobile/src/pages/MainScreen.jsx
+++ b/mobile/src/pages/MainScreen.jsx
@@ -47,6 +47,16 @@ export default function MainScreen({ auth, onLogout, onUserUpdate }) {
           if (active) setMapError('Permissão de localização negada. Ativa nas definições do telemóvel.');
           return;
         }
+        // Pede já uma posição rápida (baixa precisão) para mostrar o mapa sem
+        // esperar pela primeira leitura de GPS de alta precisão, que pode demorar muito.
+        try {
+          const quickPos = await Geolocation.getCurrentPosition({ enableHighAccuracy: false, timeout: 5000 });
+          if (active && quickPos) {
+            setPosition([quickPos.coords.latitude, quickPos.coords.longitude]);
+          }
+        } catch {
+          // ignora; o watchPosition abaixo continua a tentar
+        }
         watchIdRef.current = await Geolocation.watchPosition(
           { enableHighAccuracy: true },
           (pos, err) => {

--- a/mobile/src/pages/MapView.jsx
+++ b/mobile/src/pages/MapView.jsx
@@ -34,6 +34,16 @@ export default function MapView() {
           if (active) setError('Permissão de localização negada. Ativa nas definições do telemóvel.');
           return;
         }
+        // Pede já uma posição rápida (baixa precisão) para mostrar o mapa sem
+        // esperar pela primeira leitura de GPS de alta precisão, que pode demorar muito.
+        try {
+          const quickPos = await Geolocation.getCurrentPosition({ enableHighAccuracy: false, timeout: 5000 });
+          if (active && quickPos) {
+            setPosition([quickPos.coords.latitude, quickPos.coords.longitude]);
+          }
+        } catch {
+          // ignora; o watchPosition abaixo continua a tentar
+        }
         watchIdRef.current = await Geolocation.watchPosition(
           { enableHighAccuracy: true },
           (pos, err) => {


### PR DESCRIPTION
O mapa do app mobile só montava depois da primeira leitura de GPS de alta
precisão, que pode demorar muitos segundos (ou nunca chegar em espaços
fechados), dando a impressão de mapa que não carrega.