### PR TITLE
Fix map tiles failing to load by dropping CARTO subdomain sharding

### DIFF
--- a/mobile/src/pages/MainScreen.jsx
+++ b/mobile/src/pages/MainScreen.jsx
@@ -180,7 +180,7 @@ export default function MainScreen({ auth, onLogout, onUserUpdate }) {
         {position ? (
           <MapContainer center={position} zoom={16} className="map-container" zoomControl={false}>
             <TileLayer
-              url="https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}.png"
+              url="https://basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}.png"
               attribution="&copy; <a href='https://openstreetmap.org'>OpenStreetMap</a> contributors &copy; <a href='https://carto.com/attributions'>CARTO</a>"
             />
             <Marker position={position} icon={vendorIcon} />

--- a/mobile/src/pages/MapView.jsx
+++ b/mobile/src/pages/MapView.jsx
@@ -78,7 +78,7 @@ export default function MapView() {
       {position ? (
         <MapContainer center={position} zoom={16} className="map-container" zoomControl={false}>
           <TileLayer
-            url="https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}.png"
+            url="https://basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}.png"
             attribution="&copy; <a href='https://openstreetmap.org'>OpenStreetMap</a> contributors &copy; <a href='https://carto.com/attributions'>CARTO</a>"
           />
           <Marker position={position} icon={vendorIcon} />

--- a/sunny_sales_web/public/resort-map.html
+++ b/sunny_sales_web/public/resort-map.html
@@ -31,9 +31,8 @@
     <script>
         // Exemplo de inicialização do mapa (pode ser removido se já existir no projeto)
         var map = L.map('map').setView([38.7169, -9.1399], 13);
-        L.tileLayer('https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}.png', {
+        L.tileLayer('https://basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}.png', {
             attribution: '&copy; <a href="https://openstreetmap.org">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>',
-            subdomains: 'abcd',
             maxZoom: 19
         }).addTo(map);
 

--- a/sunny_sales_web/src/pages/ModernMapLayout.jsx
+++ b/sunny_sales_web/src/pages/ModernMapLayout.jsx
@@ -462,9 +462,8 @@ export default function ModernMapLayout() {
           >
             <MapBearingController targetBearingRef={targetBearingRef} />
             <TileLayer
-              url="https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}.png"
+              url="https://basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}.png"
               attribution="&copy; <a href='https://openstreetmap.org'>OpenStreetMap</a> contributors &copy; <a href='https://carto.com/attributions'>CARTO</a>"
-              subdomains="abcd"
               maxZoom={19}
             />
             {!isVendorLogged && clientPos && (

--- a/sunny_sales_web/src/pages/RouteDetail.jsx
+++ b/sunny_sales_web/src/pages/RouteDetail.jsx
@@ -47,9 +47,8 @@ export default function RouteDetail() {
         <div className="rd-map">
           <MapContainer center={initial} zoom={15} style={{ width: '100%', height: '100%' }}>
             <TileLayer
-              url="https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}.png"
+              url="https://basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}.png"
               attribution="&copy; <a href='https://openstreetmap.org'>OpenStreetMap</a> contributors &copy; <a href='https://carto.com/attributions'>CARTO</a>"
-              subdomains="abcd"
               maxZoom={19}
             />
             <Polyline positions={polyline} color="var(--primary)" weight={4} />


### PR DESCRIPTION
Tile requests used {s}.basemaps.cartocdn.com with subdomains=abcd, so
whole map regions (which hash to the same subdomain) went blank when
one of those subdomains was unreachable on the client network. CARTO's
single basemaps.cartocdn.com host serves the same tiles without that
per-subdomain DNS dependency.