### PR TITLE
Fix CARTO tile layer URLs with subdomain support

### DIFF
--- a/mobile/src/pages/MainScreen.jsx
+++ b/mobile/src/pages/MainScreen.jsx
@@ -180,8 +180,9 @@ export default function MainScreen({ auth, onLogout, onUserUpdate }) {
         {position ? (
           <MapContainer center={position} zoom={16} className="map-container" zoomControl={false}>
             <TileLayer
-              url="https://basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}.png"
+              url="https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}.png"
               attribution="&copy; <a href='https://openstreetmap.org'>OpenStreetMap</a> contributors &copy; <a href='https://carto.com/attributions'>CARTO</a>"
+              subdomains="abcd"
             />
             <Marker position={position} icon={vendorIcon} />
             <FollowPosition position={position} />

--- a/mobile/src/pages/MapView.jsx
+++ b/mobile/src/pages/MapView.jsx
@@ -78,8 +78,9 @@ export default function MapView() {
       {position ? (
         <MapContainer center={position} zoom={16} className="map-container" zoomControl={false}>
           <TileLayer
-            url="https://basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}.png"
+            url="https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}.png"
             attribution="&copy; <a href='https://openstreetmap.org'>OpenStreetMap</a> contributors &copy; <a href='https://carto.com/attributions'>CARTO</a>"
+            subdomains="abcd"
           />
           <Marker position={position} icon={vendorIcon} />
           <FollowPosition position={position} />

--- a/sunny_sales_web/public/resort-map.html
+++ b/sunny_sales_web/public/resort-map.html
@@ -31,8 +31,9 @@
     <script>
         // Exemplo de inicialização do mapa (pode ser removido se já existir no projeto)
         var map = L.map('map').setView([38.7169, -9.1399], 13);
-        L.tileLayer('https://basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}.png', {
+        L.tileLayer('https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}.png', {
             attribution: '&copy; <a href="https://openstreetmap.org">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>',
+            subdomains: 'abcd',
             maxZoom: 19
         }).addTo(map);
 

--- a/sunny_sales_web/src/pages/ModernMapLayout.jsx
+++ b/sunny_sales_web/src/pages/ModernMapLayout.jsx
@@ -494,8 +494,9 @@ export default function ModernMapLayout() {
           >
             <MapBearingController targetBearingRef={targetBearingRef} />
             <TileLayer
-              url="https://basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}.png"
+              url="https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}.png"
               attribution="&copy; <a href='https://openstreetmap.org'>OpenStreetMap</a> contributors &copy; <a href='https://carto.com/attributions'>CARTO</a>"
+              subdomains="abcd"
               maxZoom={19}
             />
             {!isVendorLogged && clientPos && (

--- a/sunny_sales_web/src/pages/RouteDetail.jsx
+++ b/sunny_sales_web/src/pages/RouteDetail.jsx
@@ -47,8 +47,9 @@ export default function RouteDetail() {
         <div className="rd-map">
           <MapContainer center={initial} zoom={15} style={{ width: '100%', height: '100%' }}>
             <TileLayer
-              url="https://basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}.png"
+              url="https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}.png"
               attribution="&copy; <a href='https://openstreetmap.org'>OpenStreetMap</a> contributors &copy; <a href='https://carto.com/attributions'>CARTO</a>"
+              subdomains="abcd"
               maxZoom={19}
             />
             <Polyline positions={polyline} color="var(--primary)" weight={4} />


### PR DESCRIPTION
## Summary
Updated CARTO tile layer URLs across the application to use subdomain placeholders and explicitly configure subdomains for improved tile loading performance and reliability.

## Key Changes
- Modified tile layer URLs from `https://basemaps.cartocdn.com/...` to `https://{s}.basemaps.cartocdn.com/...` to support subdomain-based requests
- Added `subdomains="abcd"` configuration to all TileLayer components and Leaflet tile layer instances
- Applied changes consistently across 5 files:
  - `mobile/src/pages/MainScreen.jsx`
  - `mobile/src/pages/MapView.jsx`
  - `sunny_sales_web/public/resort-map.html`
  - `sunny_sales_web/src/pages/ModernMapLayout.jsx`
  - `sunny_sales_web/src/pages/RouteDetail.jsx`

## Implementation Details
The `{s}` placeholder in the URL allows Leaflet to distribute tile requests across multiple subdomains (a, b, c, d), which:
- Increases the number of parallel connections to the tile server
- Improves map loading performance by bypassing browser connection limits
- Enhances reliability through load distribution

This is a standard best practice for tile layer configuration in Leaflet-based applications.

https://claude.ai/code/session_01Cae4o6yRZoSs7MshM5QrXK