### PR TITLE
Throttle map bearing updates to prevent tile layer thrashing

### DIFF
--- a/sunny_sales_web/src/pages/ModernMapLayout.jsx
+++ b/sunny_sales_web/src/pages/ModernMapLayout.jsx
@@ -66,22 +66,40 @@ function MapBearingController({ targetBearingRef }) {
   useEffect(() => {
     const current = { val: null };
     let rafId;
+    let lastApplied = null;
+    let lastApplyTs = 0;
     const LERP = 0.18;
+    // leaflet-rotate recomputes the tile grid bounds on every setBearing()
+    // call. Calling it every animation frame (even for sub-degree changes
+    // from compass noise) thrashes the tile layer and tiles never finish
+    // loading, leaving permanent gaps. Throttle real updates and skip
+    // imperceptible changes.
+    const MIN_INTERVAL_MS = 100;
+    const MIN_DELTA_DEG = 1;
 
-    const tick = () => {
+    const tick = (now) => {
       const target = targetBearingRef.current;
       if (target !== null && !isNaN(target)) {
         if (current.val === null) {
           current.val = target;
-          map.setBearing(target);
         } else {
           let diff = target - current.val;
           if (diff > 180) diff -= 360;
           if (diff < -180) diff += 360;
           if (Math.abs(diff) > 0.08) {
             current.val = (current.val + diff * LERP + 360) % 360;
-            map.setBearing(current.val);
           }
+        }
+
+        const sinceLast = now - lastApplyTs;
+        const appliedDiff =
+          lastApplied === null
+            ? Infinity
+            : Math.abs(((current.val - lastApplied + 540) % 360) - 180);
+        if (sinceLast >= MIN_INTERVAL_MS && appliedDiff >= MIN_DELTA_DEG) {
+          map.setBearing(current.val);
+          lastApplied = current.val;
+          lastApplyTs = now;
         }
       }
       rafId = requestAnimationFrame(tick);


### PR DESCRIPTION
## Summary
Optimized the map bearing animation controller to throttle `setBearing()` calls, preventing excessive tile grid recomputation that was causing tiles to fail loading and leave permanent gaps on the map.

## Key Changes
- Added throttling mechanism to `setBearing()` calls with a minimum 100ms interval between updates
- Implemented minimum delta threshold (1 degree) to skip imperceptible bearing changes from compass noise
- Modified the animation tick function to accept a timestamp parameter for throttle timing
- Separated bearing calculation logic from the actual map update logic to allow selective application

## Implementation Details
The leaflet-rotate library recomputes tile grid bounds on every `setBearing()` call. Previously, the animation loop was calling this method every frame (even for sub-degree changes), which thrashed the tile layer and prevented tiles from finishing their load operations.

The fix introduces two throttling conditions:
1. **Time-based**: Only apply updates if at least 100ms has passed since the last applied update
2. **Delta-based**: Only apply updates if the bearing change is at least 1 degree from the last applied value

This allows smooth bearing animations while preventing the tile layer thrashing that was causing visual artifacts.

https://claude.ai/code/session_01He19i6L1wvqacKDp5YUUUX