### PR TITLE
Implement GPS noise filtering across all location services

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -189,6 +189,11 @@ def haversine(lat1, lon1, lat2, lon2):
     c = 2 * atan2(sqrt(a), sqrt(1 - a))
     return R * c
 
+# Distância mínima (metros) entre leituras de GPS consecutivas para serem
+# consideradas movimento real. Abaixo deste valor é ruído típico de GPS
+# e o ponto é ignorado, evitando que o trajeto "ande sozinho" parado.
+MIN_GPS_DISTANCE_M = 8.0
+
 # Gerenciador de WebSockets
 class ConnectionManager:
     # __init__
@@ -700,15 +705,23 @@ async def update_vendor_location(
     if not active_route:
         raise HTTPException(status_code=400, detail="Location sharing inactive")
 
+    points = json.loads(active_route.points or "[]")
+    last_point = points[-1] if points else None
+
+    # Ignora leituras de GPS demasiado próximas da última posição gravada:
+    # ruído de GPS (poucos metros) não deve ser contabilizado como movimento
+    # nem propagado ao mapa, para não dar a impressão de o vendedor estar
+    # sempre a deslocar-se enquanto está parado.
+    if last_point is not None:
+        moved = haversine(last_point["lat"], last_point["lng"], lat, lng)
+        if moved < MIN_GPS_DISTANCE_M:
+            return {"message": "Localização ignorada (ruído de GPS)"}
+
     vendor.current_lat = lat
     vendor.current_lng = lng
+    points.append({"lat": lat, "lng": lng, "t": utcnow().isoformat()})
+    active_route.points = json.dumps(points)
     db.commit()
-
-    if active_route:
-        points = json.loads(active_route.points or "[]")
-        points.append({"lat": lat, "lng": lng, "t": utcnow().isoformat()})
-        active_route.points = json.dumps(points)
-        db.commit()
 
     await manager.broadcast({"vendor_id": vendor_id, "lat": lat, "lng": lng})
     return {"message": "Localização atualizada com sucesso"}

--- a/mobile/android/app/src/main/java/com/sunnysales/vendor/LocationForegroundService.java
+++ b/mobile/android/app/src/main/java/com/sunnysales/vendor/LocationForegroundService.java
@@ -6,6 +6,7 @@ import android.app.NotificationManager;
 import android.app.Service;
 import android.content.Context;
 import android.content.Intent;
+import android.location.Location;
 import android.os.Build;
 import android.os.IBinder;
 import android.os.Looper;
@@ -26,9 +27,16 @@ public class LocationForegroundService extends Service {
     private static final String CHANNEL_ID = "location_channel";
     private static final int NOTIFICATION_ID = 1;
 
+    // Distância mínima (m) entre leituras para serem aceites como movimento real,
+    // e precisão máxima (m) aceitável — leituras piores são ruído e descartadas,
+    // evitando que o pin "mexa" estando o vendedor parado.
+    private static final float MIN_UPDATE_DISTANCE_METERS = 8f;
+    private static final float MAX_ACCEPTABLE_ACCURACY_METERS = 20f;
+
     private FusedLocationProviderClient fusedClient;
     private LocationCallback locationCallback;
     private PowerManager.WakeLock wakeLock;
+    private Location lastAcceptedLocation;
 
     public interface LocationListener {
         void onLocationUpdate(double lat, double lng);
@@ -83,17 +91,25 @@ public class LocationForegroundService extends Service {
         LocationRequest request = new LocationRequest.Builder(1000)
                 .setPriority(Priority.PRIORITY_HIGH_ACCURACY)
                 .setMinUpdateIntervalMillis(1000)
+                .setMinUpdateDistanceMeters(MIN_UPDATE_DISTANCE_METERS)
                 .build();
 
         locationCallback = new LocationCallback() {
             @Override
             public void onLocationResult(LocationResult result) {
-                if (result.getLastLocation() != null && listener != null) {
-                    listener.onLocationUpdate(
-                            result.getLastLocation().getLatitude(),
-                            result.getLastLocation().getLongitude()
-                    );
+                Location location = result.getLastLocation();
+                if (location == null || listener == null) {
+                    return;
                 }
+                if (location.hasAccuracy() && location.getAccuracy() > MAX_ACCEPTABLE_ACCURACY_METERS) {
+                    return;
+                }
+                if (lastAcceptedLocation != null
+                        && lastAcceptedLocation.distanceTo(location) < MIN_UPDATE_DISTANCE_METERS) {
+                    return;
+                }
+                lastAcceptedLocation = location;
+                listener.onLocationUpdate(location.getLatitude(), location.getLongitude());
             }
         };
 

--- a/sunny_sales_web/src/pages/ModernMapLayout.jsx
+++ b/sunny_sales_web/src/pages/ModernMapLayout.jsx
@@ -41,6 +41,51 @@ function haversineDistance(lat1, lng1, lat2, lng2) {
   return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
 }
 
+// Marker que anima suavemente entre posições em vez de saltar instantaneamente
+// para a nova posição recebida via WebSocket — disfarça pequenas oscilações
+// de GPS que ainda cheguem ao mapa.
+function AnimatedVendorMarker({ position, icon, eventHandlers }) {
+  const markerRef = useRef(null);
+  const displayedRef = useRef(position);
+  const animFrameRef = useRef(null);
+
+  useEffect(() => {
+    const marker = markerRef.current;
+    if (!marker) {
+      displayedRef.current = position;
+      return;
+    }
+    const from = displayedRef.current;
+    const to = position;
+    if (animFrameRef.current) cancelAnimationFrame(animFrameRef.current);
+
+    const duration = 500;
+    const start = performance.now();
+
+    const step = (now) => {
+      const t = Math.min(1, (now - start) / duration);
+      const lat = from[0] + (to[0] - from[0]) * t;
+      const lng = from[1] + (to[1] - from[1]) * t;
+      marker.setLatLng([lat, lng]);
+      if (t < 1) {
+        animFrameRef.current = requestAnimationFrame(step);
+      } else {
+        displayedRef.current = to;
+      }
+    };
+    animFrameRef.current = requestAnimationFrame(step);
+
+    return () => {
+      if (animFrameRef.current) cancelAnimationFrame(animFrameRef.current);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [position[0], position[1]]);
+
+  return (
+    <Marker ref={markerRef} position={displayedRef.current} icon={icon} eventHandlers={eventHandlers} />
+  );
+}
+
 function getClientPinHtml(heading) {
   const hasHeading = heading !== null && !isNaN(heading);
   const arrow = hasHeading
@@ -480,7 +525,7 @@ export default function ModernMapLayout() {
               const isOwn = loggedVendor && Number(v.id) === Number(loggedVendor.id);
               const pinColor = v.pin_color || '#7B61FF';
               return (
-                <Marker
+                <AnimatedVendorMarker
                   key={v.id}
                   position={[v.current_lat, v.current_lng]}
                   icon={L.divIcon({

--- a/sunny_sales_web/src/pages/VendorDashboard.jsx
+++ b/sunny_sales_web/src/pages/VendorDashboard.jsx
@@ -12,6 +12,20 @@ import {
 import ImageCropper from '../components/ImageCropper';
 import './VendorDashboard.css';
 
+// Distância mínima (m) entre leituras de GPS para serem aceites como
+// movimento real; abaixo disto é ruído típico de GPS e a leitura é ignorada.
+const MIN_GPS_DISTANCE_M = 8;
+
+function haversineDistance(lat1, lng1, lat2, lng2) {
+  const R = 6371000;
+  const φ1 = (lat1 * Math.PI) / 180;
+  const φ2 = (lat2 * Math.PI) / 180;
+  const Δφ = ((lat2 - lat1) * Math.PI) / 180;
+  const Δλ = ((lng2 - lng1) * Math.PI) / 180;
+  const a = Math.sin(Δφ / 2) ** 2 + Math.cos(φ1) * Math.cos(φ2) * Math.sin(Δλ / 2) ** 2;
+  return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+}
+
 const PAYMENT_ICONS = {
   'Numerário': <FiDollarSign />,
   'MB Way': <FiSmartphone />,
@@ -21,6 +35,7 @@ const PAYMENT_ICONS = {
 };
 
 let watchId = null;
+let lastSentLocation = null;
 
 function getGreeting() {
   const h = new Date().getHours();
@@ -77,14 +92,26 @@ export default function VendorDashboard() {
       await axios.post(`${BASE_URL}/vendors/${vendor.id}/routes/start`, null, {
         headers: { Authorization: `Bearer ${token}` },
       });
+      lastSentLocation = null;
       watchId = navigator.geolocation.watchPosition(
         async (pos) => {
+          const { latitude: lat, longitude: lng, accuracy } = pos.coords;
+          // Descarta leituras pouco precisas ou demasiado próximas da última
+          // posição enviada (ruído de GPS), para o pin não "tremer" parado.
+          if (accuracy != null && accuracy > 20) return;
+          if (
+            lastSentLocation &&
+            haversineDistance(lastSentLocation.lat, lastSentLocation.lng, lat, lng) < MIN_GPS_DISTANCE_M
+          ) {
+            return;
+          }
           try {
             await axios.put(
               `${BASE_URL}/vendors/${vendor.id}/location`,
-              { lat: pos.coords.latitude, lng: pos.coords.longitude },
+              { lat, lng },
               { headers: { Authorization: `Bearer ${token}` } }
             );
+            lastSentLocation = { lat, lng };
           } catch (err) {
             console.error('Erro ao enviar localização:', err);
           }


### PR DESCRIPTION
## Summary
This PR implements comprehensive GPS noise filtering across the entire location tracking stack (web, mobile, and backend) to prevent vendor pins from jittering when stationary. The solution uses a minimum distance threshold (8 meters) to distinguish real movement from typical GPS drift.

## Key Changes

**Frontend (Web - ModernMapLayout.jsx & VendorDashboard.jsx)**
- Added `AnimatedVendorMarker` component that smoothly animates marker position changes over 500ms instead of jumping instantly, masking remaining GPS oscillations
- Implemented GPS noise filtering in location submission: ignores readings with accuracy > 20m or within 8m of the last sent position
- Added `haversineDistance` utility function to calculate distance between coordinates
- Tracks `lastSentLocation` to prevent sending redundant nearby updates

**Mobile (Android - LocationForegroundService.java)**
- Added `MIN_UPDATE_DISTANCE_METERS` (8m) and `MAX_ACCEPTABLE_ACCURACY_METERS` (20m) constants
- Configured `LocationRequest` with `setMinUpdateDistanceMeters` to filter at the OS level
- Added accuracy validation: discards readings with accuracy > 20m
- Tracks `lastAcceptedLocation` to prevent duplicate nearby location callbacks
- Improved null-safety in location callback handling

**Backend (Python - main.py)**
- Added `MIN_GPS_DISTANCE_M` constant (8 meters) for consistency across services
- Implemented distance check before recording route points: ignores GPS readings closer than 8m to the last recorded point
- Returns informative response when GPS noise is filtered
- Reorganized logic to check distance before updating vendor coordinates

## Implementation Details
- All three layers (mobile, web, backend) now use the same 8-meter threshold for consistency
- The web frontend adds smooth animation on top of filtering for better UX
- Mobile filtering happens at the OS level via `LocationRequest` configuration, reducing unnecessary callbacks
- Backend filtering prevents noisy points from being recorded in route history
- Accuracy-based filtering (20m threshold) removes low-confidence GPS readings across all platforms

https://claude.ai/code/session_01UVYdSH6CdTJaEvWZTh3nFu