### PR TITLE
Remove reset buttons from Vendedores and Distância filters

### DIFF
--- a/sunny_sales_web/src/pages/ModernMapLayout.jsx
+++ b/sunny_sales_web/src/pages/ModernMapLayout.jsx
@@ -639,12 +639,6 @@ export default function ModernMapLayout() {
                 <div className="filter-section">
                   <div className="filter-section-row">
                     <span className="filter-section-title">Vendedores</span>
-                    <button
-                      className="filter-reset-link"
-                      onClick={() => setPendingProducts([])}
-                    >
-                      Repor
-                    </button>
                   </div>
                   {PRODUCTS.map((p) => {
                     const active = pendingProducts.includes(p);
@@ -670,12 +664,6 @@ export default function ModernMapLayout() {
                       <FiMapPin size={14} style={{ marginRight: 6 }} />
                       Distância
                     </span>
-                    <button
-                      className="filter-reset-link"
-                      onClick={() => setPendingDistance(null)}
-                    >
-                      Repor
-                    </button>
                   </div>
                   <div className="filter-distance-row">
                     {DISTANCE_OPTIONS.map((opt) => (


### PR DESCRIPTION
## Summary
Removed the "Repor" (Reset) buttons from the Vendedores and Distância filter sections in the ModernMapLayout component.

## Changes
- Removed the reset button from the Vendedores filter section that cleared pending products
- Removed the reset button from the Distância filter section that cleared pending distance selection

## Details
These reset buttons were previously allowing users to quickly clear their filter selections. The removal simplifies the filter UI by relying on users to manually deselect filter options instead of providing a dedicated reset action.

https://claude.ai/code/session_01Ut23DS1pWjhzmFNKnx5shR