### PR TITLE
Remove info cards sections from SobreProjeto and Sustentabilidade pages

### DIFF
--- a/sunny_sales_web/src/pages/SobreProjeto.jsx
+++ b/sunny_sales_web/src/pages/SobreProjeto.jsx
@@ -22,38 +22,6 @@ export default function SobreProjeto() {
         <div className="info-badge">Web &amp; Mobile</div>
       </div>
 
-      <div className="info-cards">
-        <div className="info-card accent">
-          <div className="info-card-icon">🏖️</div>
-          <h3 className="info-card-title">Quem Somos</h3>
-          <p className="info-card-text">
-            Uma plataforma digital que valoriza o comércio ambulante de praia — de bolas de
-            Berlim e gelados a acessórios e bebidas — unindo tradição e tecnologia.
-          </p>
-        </div>
-
-        <div className="info-card">
-          <div className="info-card-icon">💡</div>
-          <h3 className="info-card-title">A Nossa Motivação</h3>
-          <p className="info-card-text">
-            Banhistas perdem tempo a procurar vendedores e estes percorrem longas distâncias
-            sem saber onde estão os clientes. O Sunny Sales resolve isto em tempo real.
-          </p>
-        </div>
-
-        <div className="info-card">
-          <div className="info-card-icon">✅</div>
-          <h3 className="info-card-title">Benefícios</h3>
-          <ul className="info-card-list">
-            <li>Menos tempo a procurar vendedores</li>
-            <li>Vendedores direcionados ao público certo</li>
-            <li>Menos deslocações desnecessárias</li>
-            <li>Comércio local mais organizado</li>
-            <li>Promoção da sustentabilidade balnear</li>
-          </ul>
-        </div>
-      </div>
-
       <div className="info-section">
         <h3 className="info-section-title">Como Funciona</h3>
         <ul className="info-timeline">

--- a/sunny_sales_web/src/pages/Sustentabilidade.jsx
+++ b/sunny_sales_web/src/pages/Sustentabilidade.jsx
@@ -22,38 +22,6 @@ export default function Sustentabilidade() {
         <div className="info-badge">Praias mais limpas</div>
       </div>
 
-      <div className="info-cards">
-        <div className="info-card">
-
-          <h3 className="info-card-title">Redução da Pegada Ecológica</h3>
-          <p className="info-card-text">
-            Ao otimizar os percursos dos vendedores com base na localização real dos clientes,
-            reduzimos as deslocações desnecessárias, diminuindo o esforço físico e o impacto
-            ambiental de cada jornada de trabalho.
-          </p>
-        </div>
-
-        <div className="info-card accent">
-
-          <h3 className="info-card-title">Embalagens Sustentáveis</h3>
-          <p className="info-card-text">
-            Incentivamos ativamente os vendedores parceiros a utilizarem sacos biodegradáveis,
-            embalagens reutilizáveis e materiais amigos do ambiente. A plataforma destaca os
-            vendedores com práticas sustentáveis certificadas.
-          </p>
-        </div>
-
-        <div className="info-card">
-
-          <h3 className="info-card-title">Apoio a Campanhas</h3>
-          <p className="info-card-text">
-            Divulgamos e colaboramos com iniciativas de limpeza de praias, sensibilização
-            ambiental e educação para a sustentabilidade. Juntos, construímos praias
-            melhores para as gerações futuras.
-          </p>
-        </div>
-      </div>
-
       <div className="info-section">
         <h3 className="info-section-title">Consciencialização dos Banhistas</h3>
         <ul className="info-list">


### PR DESCRIPTION
## Summary
This PR removes the info cards component sections from two pages in the application, streamlining the layout and content structure.

## Changes Made
- **SobreProjeto.jsx**: Removed the `info-cards` section containing three cards:
  - "Quem Somos" card with beach commerce platform description
  - "A Nossa Motivação" card explaining the problem being solved
  - "Benefícios" card listing key benefits with a bulleted list

- **Sustentabilidade.jsx**: Removed the `info-cards` section containing three cards:
  - "Redução da Pegada Ecológica" card about optimizing vendor routes
  - "Embalagens Sustentáveis" card about eco-friendly packaging initiatives
  - "Apoio a Campanhas" card about beach cleanup collaboration

## Notes
Both pages retain their header sections and the "Como Funciona" / "Consciencialização dos Banhistas" sections that follow the removed cards. This appears to be a content reorganization or simplification of the page layouts.

https://claude.ai/code/session_012EGVPqa5tstjataKWx5sPK