### PR TITLE
Fix Stripe invoice retrieval and map pin styling

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1073,11 +1073,19 @@ async def stripe_webhook(request: Request, db: Session = Depends(get_db)):
         if vendor:
             vendor.subscription_active = True
             vendor.subscription_valid_until = utcnow() + timedelta(days=7)
+            receipt_url = None
+            invoice_id = session.get("invoice")
+            if invoice_id:
+                try:
+                    invoice = stripe.Invoice.retrieve(invoice_id)
+                    receipt_url = invoice.get("hosted_invoice_url") or invoice.get("invoice_pdf")
+                except Exception:
+                    receipt_url = None
             paid = models.PaidWeek(
                 vendor_id=vendor_id,
                 start_date=utcnow(),
                 end_date=utcnow() + timedelta(days=7),
-                receipt_url=session.get("receipt_url") or session.get("url"),
+                receipt_url=receipt_url,
             )
             db.add(paid)
             db.commit()

--- a/sunny_sales_web/src/pages/ModernMapLayout.css
+++ b/sunny_sales_web/src/pages/ModernMapLayout.css
@@ -760,6 +760,7 @@ body {
   box-sizing: border-box;
   border: 9px solid var(--pin-color, #7B61FF);
   border-radius: 50% 50% 0;
+  background: #fff;
   transform: rotate(45deg);
   filter: drop-shadow(0 3px 6px rgba(0, 0, 0, 0.35));
 }


### PR DESCRIPTION
## Summary
This PR fixes the Stripe webhook handler to properly retrieve invoice URLs from the Stripe API and improves the visual styling of map pins.

## Key Changes
- **Stripe Invoice Handling**: Updated the webhook handler to fetch invoice details from Stripe using the invoice ID instead of relying on potentially missing session data. The code now attempts to retrieve the hosted invoice URL or PDF from the invoice object with proper error handling.
- **Map Pin Styling**: Added a white background color to map pin elements to improve visibility and consistency.

## Implementation Details
- The invoice retrieval now uses `stripe.Invoice.retrieve()` to fetch the actual invoice object and extract the `hosted_invoice_url` or `invoice_pdf` URL
- Added a try-except block to gracefully handle cases where the invoice retrieval fails
- The receipt URL now defaults to `None` if no valid invoice URL can be obtained, rather than falling back to potentially incorrect session data

https://claude.ai/code/session_01RMzimLDJv211yTDHdh2B1G