### PR TITLE
Simplify vendor pin marker styling and remove drop shadows

### DIFF
--- a/sunny_sales_web/src/pages/ModernMapLayout.css
+++ b/sunny_sales_web/src/pages/ModernMapLayout.css
@@ -760,9 +760,8 @@ body {
   box-sizing: border-box;
   border: 9px solid var(--pin-color, #7B61FF);
   border-radius: 50% 50% 0;
-  background: #fff;
+  background: transparent;
   transform: rotate(45deg);
-  filter: drop-shadow(0 3px 6px rgba(0, 0, 0, 0.35));
 }
 
 .vendor-pin-marker::before {
@@ -776,10 +775,6 @@ body {
   height: 4px;
   border-radius: 50%;
   background: rgba(0, 0, 0, 0.25);
-}
-
-.vendor-own-pin .vendor-pin-marker::after {
-  filter: drop-shadow(0 3px 8px rgba(0, 0, 0, 0.5));
 }
 
 .user-location-marker {


### PR DESCRIPTION
## Summary
Refactored the vendor pin marker CSS to simplify styling by removing drop shadow effects and making the background transparent instead of white.

## Key Changes
- Changed `.vendor-pin-marker` background from white (`#fff`) to `transparent`
- Removed drop shadow filter from `.vendor-pin-marker` (was `drop-shadow(0 3px 6px rgba(0, 0, 0, 0.35))`)
- Removed the entire `.vendor-own-pin .vendor-pin-marker::after` rule that applied an additional drop shadow filter

## Implementation Details
These changes simplify the visual styling of vendor pin markers by:
- Eliminating redundant shadow effects that may have caused visual clutter
- Making the marker background transparent to allow for cleaner layering with underlying map elements
- Reducing CSS complexity by removing vendor-specific shadow styling rules

https://claude.ai/code/session_01GscjVA3zNeLmQVPaRX3ShE