### PR TITLE
Update product category name from "Acessórios" to "Acessórios de Praia"

### DIFF
--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -22,7 +22,7 @@ class VendorProfileUpdate(BaseModel):
     name: Optional[str] = None
     email: Optional[str] = None
     password: Optional[str] = None
-    product: Optional[Literal["Bolas de Berlim", "Gelados", "Acessórios"]] = None
+    product: Optional[Literal["Bolas de Berlim", "Gelados", "Acessórios de Praia"]] = None
     profile_photo: Optional[str] = None
     pin_color: Optional[str] = None
 
@@ -31,7 +31,7 @@ class VendorCreate(BaseModel):
     name: str
     email: str
     password: str
-    product: Literal["Bolas de Berlim", "Gelados", "Acessórios"]
+    product: Literal["Bolas de Berlim", "Gelados", "Acessórios de Praia"]
     profile_photo: str
     license_number: str
     license_municipality: str


### PR DESCRIPTION
## Summary
Updated the product category literal value in vendor schemas to use the more specific name "Acessórios de Praia" instead of the generic "Acessórios".

## Key Changes
- Updated `VendorProfileUpdate` schema product field literal to include "Acessórios de Praia"
- Updated `VendorCreate` schema product field literal to include "Acessórios de Praia"
- Removed generic "Acessórios" category in favor of the beach-specific variant

## Details
This change ensures consistency across vendor creation and profile update endpoints by standardizing the product category naming convention. The new name "Acessórios de Praia" (Beach Accessories) is more descriptive and aligns with the beach/coastal vendor context of the application.

https://claude.ai/code/session_017snTzS68xtL1tYcPwYjZtC