### PR TITLE
Add location heartbeat to prevent vendor disappearing from map

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -197,6 +197,10 @@ def haversine(lat1, lon1, lat2, lon2):
 # valores mais baixos deixavam passar oscilações dentro do raio de erro do GPS.
 MIN_GPS_DISTANCE_M = 15.0
 
+# Tempo máximo (s) sem registar uma posição, mesmo sem movimento suficiente,
+# para o vendedor não demorar minutos a aparecer/atualizar no mapa parado.
+LOCATION_HEARTBEAT_SECONDS = 30
+
 # Gerenciador de WebSockets
 class ConnectionManager:
     # __init__
@@ -687,6 +691,7 @@ async def update_vendor_location(
     vendor_id: int,
     lat: float = Body(...),
     lng: float = Body(...),
+    heartbeat: bool = Body(False),
     db: Session = Depends(get_db),
     current_vendor: models.Vendor = Depends(get_current_vendor),
 ):
@@ -715,9 +720,11 @@ async def update_vendor_location(
     # ruído de GPS (poucos metros) não deve ser contabilizado como movimento
     # nem propagado ao mapa, para não dar a impressão de o vendedor estar
     # sempre a deslocar-se enquanto está parado.
-    if last_point is not None:
+    if last_point is not None and not heartbeat:
         moved = haversine(last_point["lat"], last_point["lng"], lat, lng)
-        if moved < MIN_GPS_DISTANCE_M:
+        last_t = datetime.fromisoformat(last_point["t"])
+        stale = (utcnow() - last_t).total_seconds() > LOCATION_HEARTBEAT_SECONDS
+        if moved < MIN_GPS_DISTANCE_M and not stale:
             return {"message": "Localização ignorada (ruído de GPS)"}
 
     vendor.current_lat = lat

--- a/sunny_sales_web/src/pages/VendorDashboard.jsx
+++ b/sunny_sales_web/src/pages/VendorDashboard.jsx
@@ -36,6 +36,11 @@ const PAYMENT_ICONS = {
 
 let watchId = null;
 let lastSentLocation = null;
+let lastSentAt = 0;
+
+// Tempo máximo (ms) sem enviar localização, mesmo sem movimento suficiente,
+// para o vendedor não desaparecer/demorar a aparecer no mapa quando está parado.
+const LOCATION_HEARTBEAT_MS = 25000;
 
 function getGreeting() {
   const h = new Date().getHours();
@@ -93,13 +98,16 @@ export default function VendorDashboard() {
         headers: { Authorization: `Bearer ${token}` },
       });
       lastSentLocation = null;
+      lastSentAt = 0;
       watchId = navigator.geolocation.watchPosition(
         async (pos) => {
           const { latitude: lat, longitude: lng, accuracy } = pos.coords;
           // Descarta leituras pouco precisas ou demasiado próximas da última
           // posição enviada (ruído de GPS), para o pin não "tremer" parado.
           if (accuracy != null && accuracy > 20) return;
+          const stale = Date.now() - lastSentAt > LOCATION_HEARTBEAT_MS;
           if (
+            !stale &&
             lastSentLocation &&
             haversineDistance(lastSentLocation.lat, lastSentLocation.lng, lat, lng) < MIN_GPS_DISTANCE_M
           ) {
@@ -108,10 +116,11 @@ export default function VendorDashboard() {
           try {
             await axios.put(
               `${BASE_URL}/vendors/${vendor.id}/location`,
-              { lat, lng },
+              { lat, lng, heartbeat: stale },
               { headers: { Authorization: `Bearer ${token}` } }
             );
             lastSentLocation = { lat, lng };
+            lastSentAt = Date.now();
           } catch (err) {
             console.error('Erro ao enviar localização:', err);
           }


### PR DESCRIPTION
## Summary
Implements a location heartbeat mechanism to ensure vendors remain visible on the map even when stationary. Previously, vendors could disappear or take a long time to reappear if they weren't moving enough to trigger GPS distance thresholds.

## Key Changes
- **Backend (`main.py`)**:
  - Added `LOCATION_HEARTBEAT_SECONDS = 30` constant to define maximum time without location updates
  - Added optional `heartbeat` parameter to `update_vendor_location` endpoint
  - Modified location update logic to accept updates that exceed the heartbeat timeout, even if movement is below the GPS noise threshold
  - Calculates staleness by comparing current time with the timestamp of the last location point

- **Frontend (`VendorDashboard.jsx`)**:
  - Added `LOCATION_HEARTBEAT_MS = 25000` constant (25 seconds) for client-side heartbeat timing
  - Tracks `lastSentAt` timestamp to monitor when location was last sent
  - Calculates staleness on the client to determine when a heartbeat update is needed
  - Sends `heartbeat: true` flag when location update is triggered by timeout rather than movement
  - Resets location tracking state when geolocation watch is started

## Implementation Details
- The heartbeat timeout (25s client-side, 30s server-side) ensures vendors update their position periodically without relying on movement detection
- GPS noise filtering (15m minimum distance) is still applied for normal movement updates but bypassed for heartbeat updates
- The stale check prevents unnecessary updates when the vendor hasn't moved and the heartbeat timeout hasn't elapsed
- Both client and server track timestamps to independently determine when heartbeat updates are needed

https://claude.ai/code/session_01SzGfzmpH3zBLT66VbYgZaK