### PR TITLE
Make profile_photo optional in vendor schemas

### DIFF
--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -53,7 +53,7 @@ class VendorOut(BaseModel):
     name: str
     email: str
     product: str
-    profile_photo: str
+    profile_photo: Optional[str] = None
     pin_color: Optional[str] = None
     current_lat: Optional[float] = None
     current_lng: Optional[float] = None
@@ -80,7 +80,7 @@ class VendorPublicOut(BaseModel):
     id: int
     name: str
     product: str
-    profile_photo: str
+    profile_photo: Optional[str] = None
     pin_color: Optional[str] = None
     current_lat: Optional[float] = None
     current_lng: Optional[float] = None


### PR DESCRIPTION
## Summary
Updated vendor schema definitions to make the `profile_photo` field optional, allowing vendors to have profiles without a photo.

## Changes
- Modified `VendorOut` schema: changed `profile_photo` from required `str` to `Optional[str] = None`
- Modified `VendorPublicOut` schema: changed `profile_photo` from required `str` to `Optional[str] = None`

## Details
This change aligns the `profile_photo` field with other optional vendor attributes like `pin_color`, `current_lat`, and `current_lng`. Vendors can now be created and displayed without providing a profile photo, improving flexibility in the vendor registration and management workflows.

https://claude.ai/code/session_01Fk2BRCV4tK69aDhysw5Xh5