### PR TITLE
Fix seller map pin to show navigation style for own view

### DIFF
--- a/sunny_sales_web/src/pages/ModernMapLayout.css
+++ b/sunny_sales_web/src/pages/ModernMapLayout.css
@@ -760,7 +760,6 @@ body {
 /* ── Client / user location pin ───────────────────────── */
 
 .client-pin,
-.vendor-own-pin,
 .vendor-pin {
   background: transparent !important;
   border: none !important;
@@ -799,10 +798,6 @@ body {
   height: 4px;
   border-radius: 50%;
   background: rgba(0, 0, 0, 0.25);
-}
-
-.vendor-own-pin .vendor-pin-marker::after {
-  filter: drop-shadow(0 3px 8px rgba(0, 0, 0, 0.5));
 }
 
 .user-location-marker {

--- a/sunny_sales_web/src/pages/ModernMapLayout.jsx
+++ b/sunny_sales_web/src/pages/ModernMapLayout.jsx
@@ -528,12 +528,19 @@ export default function ModernMapLayout() {
                 <AnimatedVendorMarker
                   key={v.id}
                   position={[v.current_lat, v.current_lng]}
-                  icon={L.divIcon({
-                    className: isOwn ? 'vendor-own-pin' : 'vendor-pin',
-                    html: getVendorPinHtml(pinColor),
-                    iconSize: [30, 37],
-                    iconAnchor: [15, 36],
-                  })}
+                  icon={isOwn
+                    ? L.divIcon({
+                        className: 'client-pin',
+                        html: getClientPinHtml(heading),
+                        iconSize: [50, 50],
+                        iconAnchor: [25, 25],
+                      })
+                    : L.divIcon({
+                        className: 'vendor-pin',
+                        html: getVendorPinHtml(pinColor),
+                        iconSize: [30, 37],
+                        iconAnchor: [15, 36],
+                      })}
                   eventHandlers={{
                     click: () => focusVendor(v),
                   }}


### PR DESCRIPTION
The logged-in seller saw the same colored teardrop pin used to display
sellers to buyers. Now the seller's own marker uses the navigation-style
dot/arrow icon, while the colored teardrop pin remains only for the
buyer-facing view of a seller.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RHRGE9aXHU4rbXQtNLwRis