### PR TITLE
Add dynamic color support to client location markers

### DIFF
--- a/sunny_sales_web/src/pages/ModernMapLayout.jsx
+++ b/sunny_sales_web/src/pages/ModernMapLayout.jsx
@@ -86,12 +86,15 @@ function AnimatedVendorMarker({ position, icon, eventHandlers }) {
   );
 }
 
-function getClientPinHtml(heading) {
+function getClientPinHtml(heading, color) {
   const hasHeading = heading !== null && !isNaN(heading);
   const arrow = hasHeading
     ? `<svg viewBox="0 0 20 20" width="12" height="12" style="display:block;flex-shrink:0;"><polygon points="10,1 6.5,14 10,11.5 13.5,14" fill="white"/></svg>`
     : '';
-  return `<div class="user-location-marker"><div class="user-location-pulse"></div><div class="user-location-dot">${arrow}</div></div>`;
+  const safeColor = color ? escapeHtml(color) : '';
+  const pulseStyle = safeColor ? ` style="background:${safeColor}33;"` : '';
+  const dotStyle = safeColor ? ` style="background:${safeColor};box-shadow:0 2px 8px ${safeColor}88;"` : '';
+  return `<div class="user-location-marker"><div class="user-location-pulse"${pulseStyle}></div><div class="user-location-dot"${dotStyle}>${arrow}</div></div>`;
 }
 
 function escapeHtml(str) {
@@ -531,7 +534,7 @@ export default function ModernMapLayout() {
                   icon={isOwn
                     ? L.divIcon({
                         className: 'client-pin',
-                        html: getClientPinHtml(heading),
+                        html: getClientPinHtml(heading, pinColor),
                         iconSize: [50, 50],
                         iconAnchor: [25, 25],
                       })


### PR DESCRIPTION
## Summary
Enhanced the client location marker rendering to support dynamic color customization, allowing pins to be displayed in different colors based on application state or user preferences.

## Key Changes
- Modified `getClientPinHtml()` function to accept an optional `color` parameter
- Added HTML sanitization for the color value using the existing `escapeHtml()` utility to prevent injection attacks
- Implemented dynamic inline styles for both the pulse and dot elements:
  - Pulse element uses the color with 20% opacity (`${color}33`)
  - Dot element uses full color with a matching shadow effect (`${color}88`)
- Updated the marker icon creation to pass the `pinColor` variable to `getClientPinHtml()`

## Implementation Details
- Color values are safely escaped before being inserted into inline styles
- Fallback to default styling when no color is provided (empty string check)
- The pulse and dot elements now have distinct visual styling that complements the chosen color
- Shadow effect on the dot uses 53% opacity of the color for better visual depth

https://claude.ai/code/session_01WQD1zfmhu8UjSThBCCuGKV