### PR TITLE
Add NIF validation and update product category naming

### DIFF
--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -20,7 +20,7 @@ class VendorProfileUpdate(BaseModel):
     name: Optional[str] = None
     email: Optional[str] = None
     password: Optional[str] = None
-    product: Optional[Literal["Bolas de Berlim", "Gelados", "Acessórios"]] = None
+    product: Optional[Literal["Bolas de Berlim", "Gelados", "Acessórios de Praia"]] = None
     profile_photo: Optional[str] = None
     pin_color: Optional[str] = None
 
@@ -28,7 +28,7 @@ class VendorCreate(BaseModel):
     name: str
     email: str
     password: str
-    product: Literal["Bolas de Berlim", "Gelados", "Acessórios"]
+    product: Literal["Bolas de Berlim", "Gelados", "Acessórios de Praia"]
     profile_photo: str
     license_number: str
     license_municipality: str

--- a/sunny_sales_web/src/pages/VendorRegister.jsx
+++ b/sunny_sales_web/src/pages/VendorRegister.jsx
@@ -100,6 +100,20 @@ export default function VendorRegister() {
         setError('O NIF deve ter exatamente 9 dígitos.');
         return false;
       }
+      if (!'12356789'.includes(nif[0])) {
+        setError('NIF inválido.');
+        return false;
+      }
+      {
+        let check = 0;
+        for (let i = 0; i < 8; i++) check += parseInt(nif[i]) * (9 - i);
+        const remainder = check % 11;
+        const control = remainder < 2 ? 0 : 11 - remainder;
+        if (parseInt(nif[8]) !== control) {
+          setError('NIF inválido (dígito de controlo incorreto).');
+          return false;
+        }
+      }
     } else if (s === 3) {
       if (!product) {
         setError('Selecione um produto principal.');
@@ -157,6 +171,7 @@ export default function VendorRegister() {
       setSuccess('Registo efetuado com sucesso! Verifique o seu email para confirmar a conta.');
     } catch (err) {
       console.error('Erro:', err);
+      console.error('Resposta do servidor:', err.response?.data);
       const detail = err.response?.data?.detail;
       if (Array.isArray(detail)) {
         setError(detail.map((e) => e.msg).join('; '));


### PR DESCRIPTION
## Summary
This PR enhances vendor registration by implementing proper Portuguese NIF (tax ID) validation and updates product category naming for consistency.

## Key Changes
- **NIF Validation**: Added comprehensive validation for Portuguese NIF numbers in the vendor registration form:
  - Validates that the first digit is one of the valid starting digits (1, 2, 3, 5, 6, 7, 8, 9)
  - Implements the official NIF check digit algorithm (modulo 11 calculation)
  - Provides specific error messages for invalid NIFs
  
- **Product Category Update**: Changed "Acessórios" to "Acessórios de Praia" in both frontend and backend schemas for clarity and consistency

- **Improved Error Logging**: Enhanced server error debugging by logging the full server response data in addition to the error object

## Implementation Details
The NIF validation follows the Portuguese standard algorithm:
1. Multiply each of the first 8 digits by (9 - position)
2. Sum all products
3. Calculate remainder when divided by 11
4. Control digit is 0 if remainder < 2, otherwise 11 - remainder
5. Validate that the 9th digit matches the calculated control digit

This ensures only valid Portuguese tax IDs are accepted during vendor registration.

https://claude.ai/code/session_01EuNxpZpWrUdPZyy9osDGic