### PR TITLE
Remove vendor license validation from registration flow

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -492,16 +492,6 @@ def delete_session(
 # --------------------------
 # Registo de vendedor
 # --------------------------
-ALLOWED_DOC_TYPES = {"application/pdf", "image/jpeg", "image/png", "image/webp"}
-ALLOWED_DOC_EXTENSIONS = {".pdf", ".jpg", ".jpeg", ".png", ".webp"}
-LICENSE_DOC_DIR = "license_docs"
-LICENSE_DOC_BUCKET = "license-docs"
-
-if not supabase:
-    os.makedirs(LICENSE_DOC_DIR, exist_ok=True)
-
-BUCKET_MAP[LICENSE_DOC_DIR] = LICENSE_DOC_BUCKET
-
 
 def _validate_nif(nif: str) -> bool:
     if len(nif) != 9 or not nif.isdigit():
@@ -523,11 +513,6 @@ async def create_vendor(
     password: str = Form(...),
     product: str = Form(...),
     profile_photo: UploadFile = File(...),
-    license_number: str = Form(...),
-    license_municipality: str = Form(...),
-    license_expiry: str = Form(...),
-    license_type: str = Form(...),
-    license_document: UploadFile = File(...),
     nif: str = Form(...),
     id_document_number: str = Form(...),
     phone: str = Form(...),
@@ -555,16 +540,9 @@ async def create_vendor(
 
     validate_password(password)
     validate_upload(profile_photo, ALLOWED_IMAGE_TYPES, ALLOWED_IMAGE_EXTENSIONS, "foto de perfil")
-    validate_upload(license_document, ALLOWED_DOC_TYPES, ALLOWED_DOC_EXTENSIONS, "documento de licença")
-
-    try:
-        parsed_expiry = datetime.strptime(license_expiry, "%Y-%m-%d")
-    except ValueError:
-        raise HTTPException(status_code=400, detail="Data de validade da licença inválida (formato: AAAA-MM-DD)")
 
     hashed_password = pwd_context.hash(password)
     photo_path = _upload_file(profile_photo, PROFILE_PHOTO_DIR)
-    license_doc_path = _upload_file(license_document, LICENSE_DOC_DIR)
 
     confirmation_token = uuid4().hex
     new_vendor = models.Vendor(
@@ -576,11 +554,6 @@ async def create_vendor(
         pin_color="#7B61FF",
         email_confirmed=False,
         confirmation_token=confirmation_token,
-        license_number=license_number,
-        license_municipality=license_municipality,
-        license_expiry=parsed_expiry,
-        license_type=license_type,
-        license_document=license_doc_path,
         nif=nif,
         id_document_number=id_document_number,
         phone=phone,

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -32,13 +32,6 @@ class Vendor(Base):
     session_token = Column(String, nullable=True, index=True)
     payment_methods = Column(String, nullable=True)
 
-    # Licença
-    license_number = Column(String, nullable=True)
-    license_municipality = Column(String, nullable=True)
-    license_expiry = Column(DateTime, nullable=True)
-    license_type = Column(String, nullable=True)
-    license_document = Column(String, nullable=True)
-
     # Identificação e compliance
     nif = Column(String, nullable=True, unique=True, index=True)
     id_document_number = Column(String, nullable=True)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -30,10 +30,6 @@ class VendorCreate(BaseModel):
     password: str
     product: Literal["Bolas de Berlim", "Gelados", "Acessórios de Praia"]
     profile_photo: str
-    license_number: str
-    license_municipality: str
-    license_expiry: str
-    license_type: str
     nif: str
     id_document_number: str
     phone: str
@@ -57,10 +53,6 @@ class VendorOut(BaseModel):
     subscription_valid_until: Optional[datetime] = None
     last_seen: Optional[str] = None
     payment_methods: Optional[str] = None
-    license_number: Optional[str] = None
-    license_municipality: Optional[str] = None
-    license_expiry: Optional[datetime] = None
-    license_type: Optional[str] = None
     nif: Optional[str] = None
     phone: Optional[str] = None
     beaches: Optional[str] = None

--- a/sunny_sales_web/src/pages/VendorRegister.jsx
+++ b/sunny_sales_web/src/pages/VendorRegister.jsx
@@ -4,30 +4,9 @@ import { BASE_URL } from '../config';
 import ImageCropper from '../components/ImageCropper';
 import './VendorRegister.css';
 
-const MUNICIPALITIES = [
-  "Albufeira", "Alcoutim", "Aljezur", "Castro Marim", "Faro",
-  "Lagoa", "Lagos", "Loulé", "Monchique", "Olhão",
-  "Portimão", "São Brás de Alportel", "Silves", "Tavira",
-  "Vila do Bispo", "Vila Real de Santo António",
-  "Almada", "Cascais", "Grândola", "Lisboa", "Oeiras",
-  "Santiago do Cacém", "Sesimbra", "Setúbal", "Sines",
-  "Sintra", "Torres Vedras", "Peniche", "Nazaré",
-  "Espinho", "Matosinhos", "Porto", "Vila Nova de Gaia",
-  "Viana do Castelo", "Caminha", "Vila do Conde", "Póvoa de Varzim",
-];
-
-const LICENSE_TYPES = [
-  "Vendedor Ambulante / Itinerante",
-  "Barraca Fixa",
-  "Concessão de Praia",
-  "Venda Ambulante de Gelados",
-  "Aluguer de Equipamentos",
-];
-
-
 export default function VendorRegister() {
   const [step, setStep] = useState(1);
-  const totalSteps = 4;
+  const totalSteps = 3;
 
   const [name, setName] = useState('');
   const [email, setEmail] = useState('');
@@ -35,12 +14,6 @@ export default function VendorRegister() {
   const [product, setProduct] = useState('');
   const [photo, setPhoto] = useState(null);
   const [cropSrc, setCropSrc] = useState(null);
-
-  const [licenseNumber, setLicenseNumber] = useState('');
-  const [licenseMunicipality, setLicenseMunicipality] = useState('');
-  const [licenseExpiry, setLicenseExpiry] = useState('');
-  const [licenseType, setLicenseType] = useState('');
-  const [licenseDocument, setLicenseDocument] = useState(null);
 
   const [nif, setNif] = useState('');
   const [idDocumentNumber, setIdDocumentNumber] = useState('');
@@ -71,23 +44,9 @@ export default function VendorRegister() {
     setPhoto(blob);
   };
 
-  const handleLicenseDocChange = (e) => {
-    const file = e.target.files[0];
-    if (file) setLicenseDocument(file);
-  };
-
   const validateStep = (s) => {
     setError('');
     if (s === 1) {
-      if (!licenseNumber || !licenseMunicipality || !licenseExpiry || !licenseType) {
-        setError('Preencha todos os campos de licença.');
-        return false;
-      }
-      if (!licenseDocument) {
-        setError('Faça upload do comprovativo de licença.');
-        return false;
-      }
-    } else if (s === 2) {
       if (!name || !email || !password || !nif || !idDocumentNumber || !phone || !address) {
         setError('Preencha todos os campos de identificação.');
         return false;
@@ -114,7 +73,7 @@ export default function VendorRegister() {
           return false;
         }
       }
-    } else if (s === 3) {
+    } else if (s === 2) {
       if (!product) {
         setError('Selecione um produto principal.');
         return false;
@@ -123,7 +82,7 @@ export default function VendorRegister() {
         setError('É necessária uma foto de perfil.');
         return false;
       }
-    } else if (s === 4) {
+    } else if (s === 3) {
       if (!termsAccepted) {
         setError('É necessário aceitar os Termos e Condições.');
         return false;
@@ -146,7 +105,7 @@ export default function VendorRegister() {
     setError('');
     setSuccess('');
 
-    if (!validateStep(4)) return;
+    if (!validateStep(3)) return;
 
     const formData = new FormData();
     formData.append('name', name);
@@ -154,11 +113,6 @@ export default function VendorRegister() {
     formData.append('password', password);
     formData.append('product', product);
     formData.append('profile_photo', new File([photo], 'profile.jpg', { type: 'image/jpeg' }));
-    formData.append('license_number', licenseNumber);
-    formData.append('license_municipality', licenseMunicipality);
-    formData.append('license_expiry', licenseExpiry);
-    formData.append('license_type', licenseType);
-    formData.append('license_document', licenseDocument);
     formData.append('nif', nif);
     formData.append('id_document_number', idDocumentNumber);
     formData.append('phone', phone);
@@ -186,7 +140,6 @@ export default function VendorRegister() {
   };
 
   const stepTitles = [
-    'Validação de Licença',
     'Identificação',
     'Dados Operacionais',
     'Confirmação',
@@ -208,43 +161,6 @@ export default function VendorRegister() {
   );
 
   const renderStep1 = () => (
-    <>
-      <h3 className="vr-step-title">Validação de Licença</h3>
-      <span className="input-span">
-        <label className="label">Número de Licença / Concessão *</label>
-        <input type="text" placeholder="Ex: LIC-2024-001234" value={licenseNumber} onChange={(e) => setLicenseNumber(e.target.value)} />
-      </span>
-      <span className="input-span">
-        <label className="label">Câmara Municipal *</label>
-        <select value={licenseMunicipality} onChange={(e) => setLicenseMunicipality(e.target.value)}>
-          <option value="">Selecione a câmara</option>
-          {MUNICIPALITIES.map((m) => (
-            <option key={m} value={m}>{m}</option>
-          ))}
-        </select>
-      </span>
-      <span className="input-span">
-        <label className="label">Data de Validade *</label>
-        <input type="date" value={licenseExpiry} onChange={(e) => setLicenseExpiry(e.target.value)} />
-      </span>
-      <span className="input-span">
-        <label className="label">Tipo de Licença *</label>
-        <select value={licenseType} onChange={(e) => setLicenseType(e.target.value)}>
-          <option value="">Selecione o tipo</option>
-          {LICENSE_TYPES.map((t) => (
-            <option key={t} value={t}>{t}</option>
-          ))}
-        </select>
-      </span>
-      <span className="input-span">
-        <label className="label">Comprovativo de Licença (PDF ou imagem) *</label>
-        <input type="file" accept=".pdf,.jpg,.jpeg,.png,.webp" onChange={handleLicenseDocChange} />
-        {licenseDocument && <span className="vr-file-feedback">{licenseDocument.name}</span>}
-      </span>
-    </>
-  );
-
-  const renderStep2 = () => (
     <>
       <h3 className="vr-step-title">Identificação e Contacto</h3>
       <span className="input-span">
@@ -278,7 +194,7 @@ export default function VendorRegister() {
     </>
   );
 
-  const renderStep3 = () => (
+  const renderStep2 = () => (
     <>
       <h3 className="vr-step-title">Dados Operacionais</h3>
       <span className="input-span">
@@ -302,7 +218,7 @@ export default function VendorRegister() {
     </>
   );
 
-  const renderStep4 = () => (
+  const renderStep3 = () => (
     <>
       <h3 className="vr-step-title">Confirmação e Termos</h3>
       <div className="vr-summary-box">
@@ -310,9 +226,6 @@ export default function VendorRegister() {
         <p><strong>Email:</strong> {email}</p>
         <p><strong>NIF:</strong> {nif}</p>
         <p><strong>Telemóvel:</strong> {phone}</p>
-        <p><strong>Licença:</strong> {licenseNumber} ({licenseMunicipality})</p>
-        <p><strong>Tipo:</strong> {licenseType}</p>
-        <p><strong>Validade:</strong> {licenseExpiry}</p>
         <p><strong>Produto:</strong> {product}</p>
         {businessName && <p><strong>Firma:</strong> {businessName}</p>}
       </div>
@@ -363,7 +276,6 @@ export default function VendorRegister() {
         {step === 1 && renderStep1()}
         {step === 2 && renderStep2()}
         {step === 3 && renderStep3()}
-        {step === 4 && renderStep4()}
 
         <div className="vr-btn-row">
           {step > 1 && (

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -61,10 +61,6 @@ def register_vendor(client, email="vendor@example.com", password="Secret123", na
         "email": email,
         "password": password,
         "product": "Bolas de Berlim",
-        "license_number": "LIC-123",
-        "license_municipality": "Lisboa",
-        "license_expiry": "2030-01-01",
-        "license_type": "Ambulante",
         "nif": make_nif(),
         "id_document_number": "12345678",
         "phone": "912345678",
@@ -75,7 +71,6 @@ def register_vendor(client, email="vendor@example.com", password="Secret123", na
     }
     files = {
         "profile_photo": ("test.png", b"fakeimage", "image/png"),
-        "license_document": ("license.pdf", b"fakedoc", "application/pdf"),
     }
     return client.post("/vendors/", data=data, files=files)
 


### PR DESCRIPTION
## Summary
This PR removes the license validation step from the vendor registration process, simplifying the onboarding flow from 4 steps to 3 steps. License-related fields and document uploads are no longer collected during registration.

## Key Changes

**Frontend (VendorRegister.jsx):**
- Removed Step 1 (License Validation) entirely, reducing total steps from 4 to 3
- Removed license-related state variables: `licenseNumber`, `licenseMunicipality`, `licenseExpiry`, `licenseType`, and `licenseDocument`
- Removed `MUNICIPALITIES` and `LICENSE_TYPES` constants
- Removed `handleLicenseDocChange` function
- Updated step validation logic to remove license field checks
- Removed license fields from form submission payload
- Removed license information from the confirmation summary
- Renumbered remaining steps (Step 2→1, Step 3→2, Step 4→3)

**Backend (main.py):**
- Removed license document upload configuration: `ALLOWED_DOC_TYPES`, `ALLOWED_DOC_EXTENSIONS`, `LICENSE_DOC_DIR`, `LICENSE_DOC_BUCKET`
- Removed license document directory initialization and bucket mapping
- Removed license-related form parameters from `create_vendor` endpoint
- Removed license document validation and upload logic
- Removed license expiry date parsing

**Database Models (models.py):**
- Removed 5 license-related columns from Vendor model: `license_number`, `license_municipality`, `license_expiry`, `license_type`, `license_document`

**Schemas (schemas.py):**
- Removed license fields from `VendorCreate` schema
- Removed license fields from `VendorOut` schema

**Tests (test_main.py):**
- Updated `register_vendor` test helper to remove license test data
- Removed license document file from test payload

## Implementation Details
The registration flow now focuses on essential vendor information (identification, operational data, and terms acceptance) without requiring upfront license validation. This simplifies the onboarding experience while potentially allowing license validation to be handled separately or post-registration.

https://claude.ai/code/session_01BDRYU4Qph5rHoT7ixPeryr