### PR TITLE
Add CORS proxy for IPMA tides API

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -25,6 +25,7 @@ import smtplib
 from email.message import EmailMessage
 from math import radians, sin, cos, sqrt, atan2
 from supabase import create_client
+import httpx
 
 ALLOWED_IMAGE_TYPES = {"image/jpeg", "image/png", "image/gif", "image/webp"}
 ALLOWED_IMAGE_EXTENSIONS = {".jpg", ".jpeg", ".png", ".gif", ".webp"}
@@ -122,6 +123,20 @@ app.add_middleware(
 @app.get("/api/status")
 def read_root():
     return {"status": "ok"}
+
+# Proxy para a API de marés do IPMA, que não envia cabeçalhos CORS e
+# por isso não pode ser chamada diretamente do browser.
+@app.get("/api/tides")
+async def get_tides():
+    async with httpx.AsyncClient(timeout=10) as client:
+        try:
+            resp = await client.get(
+                "https://api.ipma.pt/open-data/forecast/tides/prediction-daily.json"
+            )
+            resp.raise_for_status()
+        except httpx.HTTPError as exc:
+            raise HTTPException(status_code=502, detail=f"Tides upstream error: {exc}")
+    return JSONResponse(content=resp.json())
 
 if not supabase:
     app.mount("/profile_photos", StaticFiles(directory=PROFILE_PHOTO_DIR), name="profile_photos")

--- a/sunny_sales_web/src/components/WeatherCard.jsx
+++ b/sunny_sales_web/src/components/WeatherCard.jsx
@@ -3,6 +3,7 @@ import {
   FiSun, FiCloud, FiCloudRain, FiCloudSnow, FiCloudLightning, FiWind,
   FiArrowUp, FiArrowDown,
 } from 'react-icons/fi';
+import { BASE_URL } from '../config';
 import './WeatherCard.css';
 
 const WMO = {
@@ -133,9 +134,7 @@ export default function WeatherCard() {
 
         // Tides — fetched independently so a failure never blocks weather
         try {
-          const tRes = await fetch(
-            'https://api.ipma.pt/open-data/forecast/tides/prediction-daily.json'
-          );
+          const tRes = await fetch(`${BASE_URL.replace(/\/$/, '')}/api/tides`);
           if (tRes.ok) {
             const tData = await tRes.json();
             setTides(parseTides(tData, lat, lon));


### PR DESCRIPTION
## Summary
This PR adds a backend proxy endpoint for the IPMA tides API to work around CORS limitations, allowing the frontend to fetch tidal data without browser CORS errors.

## Key Changes
- **Backend (`main.py`)**: Added new `/api/tides` endpoint that proxies requests to the IPMA tides API
  - Uses `httpx.AsyncClient` for async HTTP requests with a 10-second timeout
  - Includes error handling that returns a 502 status code if the upstream API fails
  - Returns the tidal data as JSON to the frontend
  
- **Frontend (`WeatherCard.jsx`)**: Updated tides data fetching to use the new backend proxy
  - Changed from directly calling `https://api.ipma.pt/open-data/forecast/tides/prediction-daily.json` to calling the local `/api/tides` endpoint
  - Uses `BASE_URL` configuration for the API endpoint

## Implementation Details
- The IPMA tides API does not send CORS headers, making it inaccessible from browser-based requests
- The proxy approach isolates tides fetch failures from weather data fetching, ensuring one doesn't block the other
- Error handling distinguishes upstream API failures with appropriate HTTP status codes

https://claude.ai/code/session_016rfrx39UH6iEXgUrGQ5hcD