### PR TITLE
Corrigir envio de email de recuperação de palavra-passe

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -557,6 +557,45 @@ def _send_confirmation_email(name: str, email: str, confirmation_token: str) -> 
         return False
 
 
+def _send_password_reset_email(name: str, email: str, reset_token: str) -> bool:
+    reset_link = f"{BASE_APP_URL}/password-reset/{reset_token}"
+    try:
+        return send_email(
+            to=email,
+            subject="Sunny Sales - Redefinir Palavra-passe",
+            body=f"Olá {name},\n\nRecebemos um pedido para redefinir a palavra-passe da tua conta Sunny Sales.\n\nClica no link para definires uma nova palavra-passe (válido durante 2 horas):\n{reset_link}\n\nSe não pediste esta alteração, ignora este email.\n\nCumprimentos,\nEquipa Sunny Sales",
+            html=f"""<!DOCTYPE html>
+<html>
+<head><meta charset="UTF-8"></head>
+<body style="margin:0;padding:0;background:#f4f4f4;font-family:'Segoe UI',Roboto,sans-serif;">
+  <table width="100%" cellpadding="0" cellspacing="0" style="background:#f4f4f4;padding:40px 0;">
+    <tr><td align="center">
+      <table width="480" cellpadding="0" cellspacing="0" style="background:#ffffff;border-radius:12px;overflow:hidden;box-shadow:0 2px 8px rgba(0,0,0,0.08);">
+        <tr><td style="background:linear-gradient(135deg,#FCB454,#F7931E);padding:30px;text-align:center;">
+          <h1 style="margin:0;color:#ffffff;font-size:24px;">&#9728;&#65039; Sunny Sales</h1>
+        </td></tr>
+        <tr><td style="padding:30px;">
+          <h2 style="color:#333;margin-top:0;">Olá {name}!</h2>
+          <p style="color:#555;font-size:16px;line-height:1.6;">Recebemos um pedido para redefinir a palavra-passe da tua conta <strong>Sunny Sales</strong>. Clica no botão abaixo para definires uma nova palavra-passe:</p>
+          <div style="text-align:center;margin:30px 0;">
+            <a href="{reset_link}" style="background:#FCB454;color:#ffffff;padding:14px 32px;border-radius:8px;text-decoration:none;font-weight:bold;font-size:16px;display:inline-block;">Redefinir Palavra-passe</a>
+          </div>
+          <p style="color:#888;font-size:13px;">Este link é válido durante 2 horas. Se o botão não funcionar, copia e cola este link no teu navegador:</p>
+          <p style="color:#888;font-size:13px;word-break:break-all;">{reset_link}</p>
+          <hr style="border:none;border-top:1px solid #eee;margin:24px 0;">
+          <p style="color:#aaa;font-size:12px;text-align:center;">Se não pediste esta alteração, ignora este email.<br>Equipa Sunny Sales</p>
+        </td></tr>
+      </table>
+    </td></tr>
+  </table>
+</body>
+</html>""",
+        )
+    except Exception as exc:
+        print(f"[Email] Falha ao enviar email de recuperação para {email}: {exc}")
+        return False
+
+
 @app.post("/vendors/resend-confirmation")
 async def resend_confirmation_email(
     email: str = Body(..., embed=True),
@@ -954,12 +993,10 @@ def confirm_email(token: str, db: Session = Depends(get_db)):
 
 @app.post("/password-reset-request")
 async def password_reset_request(
-    request: Request,
     background_tasks: BackgroundTasks,
+    email: str = Body(..., embed=True),
     db: Session = Depends(get_db),
 ):
-    form = await request.form()
-    email = form.get("email", "")
     vendor = db.query(models.Vendor).filter(models.Vendor.email == email).first()
     if vendor:
         token = uuid4().hex
@@ -967,11 +1004,9 @@ async def password_reset_request(
         vendor.password_reset_expires = utcnow() + timedelta(hours=2)
         db.commit()
         background_tasks.add_task(
-            send_email,
-            to=email,
-            subject="Redefinir Palavra-passe",
-            body=f"Clica no link para redefenires a tua palavra-passe: {BASE_APP_URL}/password-reset/{token}",
+            _send_password_reset_email, vendor.name, vendor.email, token
         )
+    # Resposta neutra para não revelar se o email existe
     return {"status": "ok"}
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -196,9 +196,9 @@ def test_login_with_vendor_name(client):
 def test_password_reset_flow(client):
     register_vendor(client)
     confirm_latest_email(client)
-    client.post("/password-reset-request", data={"email": "vendor@example.com"})
+    client.post("/password-reset-request", json={"email": "vendor@example.com"})
     body = client.sent_emails[-1]["body"]
-    token = body.split("/password-reset/")[1]
+    token = body.split("/password-reset/")[1].split()[0].strip()
     resp = client.post(f"/password-reset/{token}", data={"new_password": "Newpass1"})
     assert resp.status_code == 200
     resp = client.post("/token", json={"email": "vendor@example.com", "password": "Newpass1"})
@@ -371,9 +371,9 @@ def test_routes_flow(client):
 def test_password_reset_form(client):
     register_vendor(client)
     confirm_latest_email(client)
-    client.post("/password-reset-request", data={"email": "vendor@example.com"})
+    client.post("/password-reset-request", json={"email": "vendor@example.com"})
     body = client.sent_emails[-1]["body"]
-    token = body.split("/password-reset/")[1]
+    token = body.split("/password-reset/")[1].split()[0].strip()
 
     resp = client.get(f"/password-reset/{token}")
     assert resp.status_code == 200


### PR DESCRIPTION
O endpoint /password-reset-request lia o corpo como form data
(await request.form()), mas o frontend (ForgotPassword.jsx) envia JSON
via axios. Com Content-Type application/json, request.form() ficava
vazio, o email resolvia para "" e nenhum vendedor era encontrado,
pelo que nenhum email era enviado (resposta sempre {"status": "ok"}).

- Endpoint passa a aceitar JSON com Body(..., embed=True), alinhado
  com /vendors/resend-confirmation.
- Novo helper _send_password_reset_email com template HTML, à imagem
  do email de confirmação, enviado em background com tratamento de erros.
- Testes atualizados para enviar JSON e extrair o token de forma robusta.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PQRfZn4PxVo4FoSKm7ZBY1