### PR TITLE
Replace custom SVG icons with react-icons library

### DIFF
--- a/sunny_sales_web/package-lock.json
+++ b/sunny_sales_web/package-lock.json
@@ -11,6 +11,7 @@
         "axios": "^1.10.0",
         "leaflet": "^1.9.4",
         "leaflet-rotate": "^0.2.8",
+        "playwright": "^1.61.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-icons": "^4.11.0",
@@ -3009,6 +3010,50 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0.tgz",
+      "integrity": "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0.tgz",
+      "integrity": "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/sunny_sales_web/package.json
+++ b/sunny_sales_web/package.json
@@ -13,6 +13,7 @@
     "axios": "^1.10.0",
     "leaflet": "^1.9.4",
     "leaflet-rotate": "^0.2.8",
+    "playwright": "^1.61.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-icons": "^4.11.0",

--- a/sunny_sales_web/src/pages/Sustentabilidade.jsx
+++ b/sunny_sales_web/src/pages/Sustentabilidade.jsx
@@ -1,69 +1,28 @@
 import React from 'react';
+import { MdDelete, MdRecycling, MdWaves, MdCleaningServices, MdWbSunny, MdLocalDrink, MdPeople } from 'react-icons/md';
 import BackHomeButton from '../components/BackHomeButton';
 import './InfoPage.css';
-
-const TrashIcon = () => (
-  <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-    <path d="M3 6h18M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2m-4 0v12m-6-12l1 12a2 2 0 0 0 2 2h6a2 2 0 0 0 2-2l1-12" strokeLinecap="round" strokeLinejoin="round"/>
-  </svg>
-);
-
-const RecycleIcon = () => (
-  <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-    <path d="M21 12c0 1.05-.3 2.05-.84 2.89M12 21c-2.36 0-4.5-1.16-5.81-2.93M3.12 10.11c.02-.41.12-.81.28-1.18M20.9 8.1c-.32-1.06-.95-2.02-1.8-2.74L10 2.5m-6.15 7.08c.36-.47.8-.88 1.3-1.22M6.1 14.38c.31.52.78.97 1.35 1.3" strokeLinecap="round" strokeLinejoin="round"/>
-  </svg>
-);
-
-const WaveIcon = () => (
-  <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-    <path d="M2 10c5.5-1 7-1 10-1s4.5 0 10 1M2 15c5.5-1 7-1 10-1s4.5 0 10 1M2 20c5.5-1 7-1 10-1s4.5 0 10 1" strokeLinecap="round" strokeLinejoin="round"/>
-  </svg>
-);
-
-const BroomIcon = () => (
-  <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-    <circle cx="6" cy="18" r="3"/><path d="M18 6l-6 6m0 0l-6 6M18 6l-6-6m6 6l6 6" strokeLinecap="round" strokeLinejoin="round"/>
-  </svg>
-);
-
-const SunIcon = () => (
-  <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-    <circle cx="12" cy="12" r="5"/><path d="M12 1v6m0 6v6M4.22 4.22l4.24 4.24m6.08 0l4.24-4.24M1 12h6m6 0h6M4.22 19.78l4.24-4.24m6.08 0l4.24 4.24" strokeLinecap="round" strokeLinejoin="round"/>
-  </svg>
-);
-
-const BottleIcon = () => (
-  <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-    <path d="M9 3h6v2h1V3h-1c0-1.1-.9-2-2-2h-2c-1.1 0-2 .9-2 2M8 5h8v14c0 1.1-.9 2-2 2h-4c-1.1 0-2-.9-2-2V5m2 3h4m-2-2v2" strokeLinecap="round" strokeLinejoin="round"/>
-  </svg>
-);
-
-const PeopleIcon = () => (
-  <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-    <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2M9 7a4 4 0 1 0 0-8 4 4 0 0 0 0 8zm8 6a3 3 0 1 0 0-6 3 3 0 0 0 0 6z" strokeLinecap="round" strokeLinejoin="round"/>
-  </svg>
-);
 
 export default function Sustentabilidade() {
   const items = [
     {
-      icon: TrashIcon,
+      icon: MdDelete,
       text: 'Recolher todo o lixo após a permanência na praia, incluindo beatas e plásticos pequenos muitas vezes esquecidos.'
     },
     {
-      icon: BroomIcon,
+      icon: MdCleaningServices,
       text: 'Utilizar cinzeiros portáteis para evitar a contaminação da areia e do mar.'
     },
     {
-      icon: SunIcon,
+      icon: MdWbSunny,
       text: 'Preferir protetor solar com fórmulas de menor impacto nos ecossistemas marinhos e recifes de coral.'
     },
     {
-      icon: BottleIcon,
+      icon: MdLocalDrink,
       text: 'Evitar plásticos descartáveis e optar por garrafas, canecas e utensílios reutilizáveis.'
     },
     {
-      icon: PeopleIcon,
+      icon: MdPeople,
       text: 'Participar em ações de limpeza de praia organizadas pela comunidade local. Cada gesto faz diferença.'
     }
   ];
@@ -83,13 +42,13 @@ export default function Sustentabilidade() {
 
       <div className="info-badges">
         <div className="info-badge">
-          <TrashIcon /> Emissões reduzidas
+          <MdDelete /> Emissões reduzidas
         </div>
         <div className="info-badge">
-          <RecycleIcon /> Embalagens eco-friendly
+          <MdRecycling /> Embalagens eco-friendly
         </div>
         <div className="info-badge">
-          <WaveIcon /> Praias mais limpas
+          <MdWaves /> Praias mais limpas
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
Refactored the Sustentabilidade page to use the `react-icons` library instead of custom inline SVG components, improving maintainability and consistency across the codebase.

## Key Changes
- Removed 7 custom SVG icon components (TrashIcon, RecycleIcon, WaveIcon, BroomIcon, SunIcon, BottleIcon, PeopleIcon)
- Imported equivalent icons from `react-icons/md` (Material Design icons):
  - `MdDelete` (trash/delete)
  - `MdRecycling` (recycle)
  - `MdWaves` (water/waves)
  - `MdCleaningServices` (cleaning/broom)
  - `MdWbSunny` (sun)
  - `MdLocalDrink` (bottle/drink)
  - `MdPeople` (people)
- Updated all icon references in the items array and info-badges section to use the imported Material Design icons
- Added `playwright` dependency to package.json (^1.61.0)

## Implementation Details
- The `react-icons` library was already a project dependency, so this change consolidates icon usage
- All icon functionality remains identical; only the source of the icons has changed
- The component structure and styling remain unchanged

https://claude.ai/code/session_01XSoFfdvXHk728sh6ywQ88K