### PR TITLE
Fix contact form email delivery

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -21,6 +21,8 @@ import json
 import base64
 import hmac
 import hashlib
+import re
+from html import escape
 from math import radians, sin, cos, sqrt, atan2
 from supabase import create_client
 import httpx
@@ -170,6 +172,7 @@ BASE_APP_URL = os.getenv("BASE_APP_URL", "https://ss-tester.onrender.com")
 
 RESEND_API_KEY = os.getenv("RESEND_API_KEY", "")
 RESEND_FROM = os.getenv("RESEND_FROM", "Sunny Sales <onboarding@resend.dev>")
+CONTACT_EMAIL_TO = os.getenv("CONTACT_EMAIL_TO", "sunnysales.geral@gmail.com")
 
 
 def send_email(to: str, subject: str, body: str, html: str | None = None) -> bool:
@@ -618,6 +621,7 @@ async def resend_confirmation_email(
 
 @app.post("/vendors/")
 async def create_vendor(
+    background_tasks: BackgroundTasks,
     name: str = Form(...),
     email: str = Form(...),
     password: str = Form(...),
@@ -632,7 +636,6 @@ async def create_vendor(
     iban: str = Form(""),
     business_name: str = Form(""),
     terms_accepted: bool = Form(...),
-    background_tasks: BackgroundTasks,
     db: Session = Depends(get_db),
 ):
     if not terms_accepted:
@@ -1386,33 +1389,64 @@ async def contact_form(
     email: str = Body(..., embed=True),
     assunto: str = Body(..., embed=True),
     mensagem: str = Body(..., embed=True),
-    background_tasks: BackgroundTasks,
 ):
-    """Handle contact form submissions and send email notification."""
-    if not nome or not email or not assunto or not mensagem:
+    """Recebe o formulário de contacto e confirma o envio real do email."""
+    # Normalizar os campos recebidos para evitar espaços acidentais no início ou no fim.
+    contact_name = nome.strip()
+    contact_email = email.strip()
+    contact_subject = assunto.strip()
+    contact_message = mensagem.strip()
+
+    # Validar todos os campos antes de tentar enviar o email.
+    if not contact_name or not contact_email or not contact_subject or not contact_message:
         raise HTTPException(status_code=400, detail="Todos os campos são obrigatórios.")
 
-    if len(mensagem) < 10:
+    # Validar o formato do email para evitar mensagens sem remetente de resposta válido.
+    if not re.match(r"^[^\s@]+@[^\s@]+\.[^\s@]+$", contact_email):
+        raise HTTPException(status_code=400, detail="Introduz um email válido.")
+
+    if len(contact_message) < 10:
         raise HTTPException(status_code=400, detail="Mensagem deve ter no mínimo 10 caracteres.")
+
+    # Escapar o conteúdo do utilizador antes de montar o HTML do email.
+    safe_name = escape(contact_name)
+    safe_email = escape(contact_email)
+    safe_subject = escape(contact_subject)
+    safe_message = escape(contact_message).replace("\n", "<br>")
 
     html_body = f"""<html><body>
     <h2>Nova mensagem de contacto do Sunny Sales</h2>
-    <p><strong>Nome:</strong> {nome}</p>
-    <p><strong>Email:</strong> {email}</p>
-    <p><strong>Assunto:</strong> {assunto}</p>
+    <p><strong>Nome:</strong> {safe_name}</p>
+    <p><strong>Email:</strong> {safe_email}</p>
+    <p><strong>Assunto:</strong> {safe_subject}</p>
     <p><strong>Mensagem:</strong></p>
-    <p>{mensagem.replace(chr(10), '<br>')}</p>
+    <p>{safe_message}</p>
     </body></html>"""
 
-    background_tasks.add_task(
-        send_email,
-        to="sunnysales.geral@gmail.com",
-        subject=f"[Sunny Sales] Contacto: {assunto}",
-        body=f"Nome: {nome}\nEmail: {email}\nAssunto: {assunto}\n\nMensagem:\n{mensagem}",
-        html=html_body,
-    )
+    try:
+        email_sent = send_email(
+            to=CONTACT_EMAIL_TO,
+            subject=f"[Sunny Sales] Contacto: {contact_subject}",
+            body=(
+                f"Nome: {contact_name}\n"
+                f"Email: {contact_email}\n"
+                f"Assunto: {contact_subject}\n\n"
+                f"Mensagem:\n{contact_message}"
+            ),
+            html=html_body,
+        )
+    except httpx.HTTPError as exc:
+        # Devolver erro claro quando o fornecedor de email rejeita ou falha o envio.
+        raise HTTPException(status_code=502, detail=f"Erro ao enviar email: {exc}")
+
+    if not email_sent:
+        raise HTTPException(
+            status_code=503,
+            detail="Serviço de email não configurado. Define RESEND_API_KEY para ativar o envio.",
+        )
 
     return {"status": "success", "message": "Mensagem enviada com sucesso. Responderemos em breve!"}
+
 
 
 # --------------------------

--- a/sunny_sales_web/src/pages/Contacto.css
+++ b/sunny_sales_web/src/pages/Contacto.css
@@ -196,3 +196,7 @@
     align-self: stretch;
   }
 }
+
+.contacto-submit-error {
+  text-align: center;
+}

--- a/sunny_sales_web/src/pages/Contacto.jsx
+++ b/sunny_sales_web/src/pages/Contacto.jsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { FiMail, FiSend, FiCheckCircle, FiUser, FiMessageSquare } from 'react-icons/fi';
 import BackHomeButton from '../components/BackHomeButton';
+import { BASE_URL } from '../config';
 import './InfoPage.css';
 import './Contacto.css';
 
@@ -46,7 +47,8 @@ export default function Contacto() {
     }
     setLoading(true);
     try {
-      const response = await fetch('/api/contact', {
+      // Enviar o pedido para o backend configurado, tanto em produção como em desenvolvimento.
+      const response = await fetch(`${BASE_URL.replace(/\/$/, '')}/api/contact`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -61,7 +63,7 @@ export default function Contacto() {
         setEnviado(true);
       } else {
         setLoading(false);
-        const errorData = await response.json();
+        const errorData = await response.json().catch(() => ({}));
         setErrors({ submit: errorData.detail || 'Erro ao enviar mensagem. Tenta novamente.' });
       }
     } catch (error) {
@@ -184,6 +186,8 @@ export default function Contacto() {
             </div>
             {errors.mensagem && <span className="contacto-error">{errors.mensagem}</span>}
           </div>
+
+          {errors.submit && <div className="contacto-error contacto-submit-error">{errors.submit}</div>}
 
           <button
             type="submit"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -25,6 +25,7 @@ def client(tmp_path):
 
     def fake_send_email(to, subject, body, html=None):
         sent_emails.append({"to": to, "subject": subject, "body": body, "html": html})
+        return True
 
     main.send_email = fake_send_email
 
@@ -91,6 +92,41 @@ def confirm_latest_email(client):
     token = body.split("/confirm-email/")[1].split()[0].strip()
     return client.get(f"/confirm-email/{token}")
 
+
+
+def test_contact_form_sends_email_to_sunny_sales(client):
+    """Garante que o formulário de contacto envia email para a caixa correta."""
+
+    resp = client.post(
+        "/api/contact",
+        json={
+            "nome": "Cliente Teste",
+            "email": "cliente@example.com",
+            "assunto": "Informação geral",
+            "mensagem": "Quero saber mais informações sobre a Sunny Sales.",
+        },
+    )
+
+    assert resp.status_code == 200
+    assert client.sent_emails[-1]["to"] == "sunnysales.geral@gmail.com"
+    assert "cliente@example.com" in client.sent_emails[-1]["body"]
+
+
+def test_contact_form_rejects_invalid_email(client):
+    """Valida que o backend rejeita emails de contacto inválidos."""
+
+    resp = client.post(
+        "/api/contact",
+        json={
+            "nome": "Cliente Teste",
+            "email": "email-invalido",
+            "assunto": "Informação geral",
+            "mensagem": "Esta mensagem tem caracteres suficientes.",
+        },
+    )
+
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == "Introduz um email válido."
 
 def test_vendor_registration(client):
     resp = register_vendor(client)


### PR DESCRIPTION
### Motivation
- Garantir que o envio do formulário de contacto falha visivelmente no frontend quando o serviço de email não está configurado ou falha.
- Evitar envio de mensagens com campos malformados ou conteúdo não-escapado que possam gerar problemas de entrega ou XSS.
- Corrigir uma assinatura de endpoint que tornava o ficheiro Python inválido após alterações anteriores.

### Description
- Atualizado `backend/app/main.py` para validar e normalizar campos de `POST /api/contact`, escapar conteúdo HTML com `html.escape`, e enviar o email de forma síncrona retornando erro quando o envio não é possível; adicionado `CONTACT_EMAIL_TO` como variável de ambiente (default `sunnysales.geral@gmail.com`).
- Reparada a ordem dos parâmetros em `create_vendor` para manter a assinatura válida (`BackgroundTasks` colocado antes dos campos de `Form`).
- Alterado `sunny_sales_web/src/pages/Contacto.jsx` para usar `BASE_URL` ao chamar a API e para mostrar mensagens de erro de submissão (`errors.submit`).
- Adicionada classe CSS `.contacto-submit-error` em `sunny_sales_web/src/pages/Contacto.css` para formatar erros de submissão.
- Actualizados/expandidos testes em `tests/test_main.py` para simular envio de email (mock retornando `True`) e adicionar dois testes que verificam envio para `sunnysales.geral@gmail.com` e rejeição de email inválido.

### Testing
- Executado `pytest tests/test_main.py -q` com resultado: all tests passed (`17 passed`) and warnings only.
- Construído o frontend com `cd sunny_sales_web && npm run build` com sucesso e saída de build gerada (Vite build completed).
- Verificações estáticas `git diff --check` e `python -m py_compile backend/app/main.py` foram executadas durante a alteração e não reportaram erros.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3a6ed0b570832e80d49a02c871d8e5)