### PR TITLE
Fix initial vendor location sharing

### DIFF
--- a/mobile/src/pages/MainScreen.jsx
+++ b/mobile/src/pages/MainScreen.jsx
@@ -92,16 +92,27 @@ export default function MainScreen({ auth, onLogout, onUserUpdate }) {
     };
   }, []);
 
-  const sendLocation = useCallback(async (lat, lng) => {
+  const readApiError = async (response, fallbackMessage) => {
+    // Tenta aproveitar a mensagem detalhada do backend para mostrar erros claros ao vendedor.
     try {
-      setPosition([lat, lng]);
-      await fetch(`${BASE_URL}/vendors/${vendorId}/location`, {
-        method: 'PUT',
-        headers: { ...authHeader, 'Content-Type': 'application/json' },
-        body: JSON.stringify({ lat, lng }),
-      });
-    } catch (err) {
-      console.error('Erro ao enviar localização:', err);
+      const payload = await response.json();
+      return payload.detail || fallbackMessage;
+    } catch {
+      return fallbackMessage;
+    }
+  };
+
+  const sendLocation = useCallback(async (lat, lng) => {
+    setPosition([lat, lng]);
+    const response = await fetch(`${BASE_URL}/vendors/${vendorId}/location`, {
+      method: 'PUT',
+      headers: { ...authHeader, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ lat, lng }),
+    });
+
+    if (!response.ok) {
+      const message = await readApiError(response, 'Erro ao enviar localização');
+      throw new Error(message);
     }
   }, [vendorId, token]);
 
@@ -125,8 +136,25 @@ export default function MainScreen({ auth, onLogout, onUserUpdate }) {
         throw new Error(err.detail || 'Erro ao iniciar partilha');
       }
 
-      listenerRef.current = await LocationTracker.addListener('locationUpdate', ({ lat, lng }) => {
-        sendLocation(lat, lng);
+      const currentPosition = position || await Geolocation.getCurrentPosition({ enableHighAccuracy: true });
+      const currentLat = Array.isArray(currentPosition)
+        ? currentPosition[0]
+        : currentPosition.coords.latitude;
+      const currentLng = Array.isArray(currentPosition)
+        ? currentPosition[1]
+        : currentPosition.coords.longitude;
+
+      // Publica logo a primeira posição para o vendedor aparecer no mapa público
+      // sem depender de um novo evento do serviço nativo, que pode demorar se estiver parado.
+      await sendLocation(currentLat, currentLng);
+
+      listenerRef.current = await LocationTracker.addListener('locationUpdate', async ({ lat, lng }) => {
+        try {
+          await sendLocation(lat, lng);
+        } catch (err) {
+          console.error('Erro ao enviar localização:', err);
+          setError(err.message);
+        }
       });
       await LocationTracker.startTracking();
       setSharing(true);


### PR DESCRIPTION
### Motivation
- Vendors sometimes did not appear on the public map immediately after enabling sharing because the native background location service can take time to emit the next update.  
- Backend errors while sending location were silently ignored in the mobile app, leaving sellers unaware when updates failed.

### Description
- Add helper `readApiError` and update `sendLocation` to inspect the backend response and throw a clear `Error` when the request is not `ok`.  
- On `startSharing`, capture the device's current GPS position and call `sendLocation` immediately so the vendor is published to the public map without waiting for the first native background event.  
- Make the native `locationUpdate` handler async and catch/propagate send errors into component state with `setError` while keeping background tracking active.

### Testing
- Built the mobile bundle with `npm --prefix mobile run build` which completed successfully.  
- Ran backend test suite with `pytest -q` and all tests passed (`17 passed`).  
- Verified the modified file is `mobile/src/pages/MainScreen.jsx` and committed as part of the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3a78ba2818832eadb36f6bf1a2e3d1)