### PR TITLE
Update info page badge and timeline colors; remove sustainability wave icon

### DIFF
--- a/sunny_sales_web/src/pages/Contacto.jsx
+++ b/sunny_sales_web/src/pages/Contacto.jsx
@@ -66,7 +66,7 @@ export default function Contacto() {
         const errorData = await response.json().catch(() => ({}));
         setErrors({ submit: errorData.detail || 'Erro ao enviar mensagem. Tenta novamente.' });
       }
-    } catch (error) {
+    } catch {
       setLoading(false);
       setErrors({ submit: 'Erro de conexão. Tenta novamente.' });
     }
@@ -109,9 +109,9 @@ export default function Contacto() {
       </div>
 
       <div className="info-badges">
-        <div className="info-badge blue-text"><FiMail size={13} /> sunnysales.geral@gmail.com</div>
-        <div className="info-badge blue-text">Resposta em 24–48 h</div>
-        <div className="info-badge blue-text">Segunda a Sexta</div>
+        <div className="info-badge info-badge-sky"><FiMail size={13} /> sunnysales.geral@gmail.com</div>
+        <div className="info-badge info-badge-sky">Resposta em 24–48 h</div>
+        <div className="info-badge info-badge-sky">Segunda a Sexta</div>
       </div>
 
       <div className="contacto-form-wrap">

--- a/sunny_sales_web/src/pages/InfoPage.css
+++ b/sunny_sales_web/src/pages/InfoPage.css
@@ -116,6 +116,15 @@
   stroke: #0066ff;
 }
 
+.info-badge.info-badge-sky {
+  color: #4BA3C3;
+}
+
+.info-badge.info-badge-sky svg {
+  color: #4BA3C3;
+  stroke: #4BA3C3;
+}
+
 .info-badge-value {
   font-size: 0.95rem;
   font-weight: 800;
@@ -337,6 +346,10 @@
 
 .info-timeline-body.blue-text {
   color: #0066ff;
+}
+
+.info-timeline-body.info-timeline-body-muted {
+  color: #6b7280;
 }
 
 /* ── CTA block ─────────────────────────────────────────── */

--- a/sunny_sales_web/src/pages/SobreProjeto.jsx
+++ b/sunny_sales_web/src/pages/SobreProjeto.jsx
@@ -17,9 +17,9 @@ export default function SobreProjeto() {
       </div>
 
       <div className="info-badges">
-        <div className="info-badge">Praias portuguesas</div>
-        <div className="info-badge">Localização em tempo real</div>
-        <div className="info-badge">Web &amp; Mobile</div>
+        <div className="info-badge info-badge-sky">Praias portuguesas</div>
+        <div className="info-badge info-badge-sky">Localização em tempo real</div>
+        <div className="info-badge info-badge-sky">Web &amp; Mobile</div>
       </div>
 
       <div className="info-section">
@@ -27,21 +27,21 @@ export default function SobreProjeto() {
         <ul className="info-timeline">
           <li>
             <div className="info-timeline-number">1</div>
-            <div className="info-timeline-body blue-text">
+            <div className="info-timeline-body info-timeline-body-muted">
               O vendedor abre a aplicação e ativa a localização, ficando imediatamente visível
               no mapa para todos os banhistas nas proximidades.
             </div>
           </li>
           <li>
             <div className="info-timeline-number">2</div>
-            <div className="info-timeline-body blue-text">
+            <div className="info-timeline-body info-timeline-body-muted">
               O banhista acede ao mapa, filtra por tipo de produto e vê os vendedores mais
               próximos em tempo real.
             </div>
           </li>
           <li>
             <div className="info-timeline-number">3</div>
-            <div className="info-timeline-body blue-text">
+            <div className="info-timeline-body info-timeline-body-muted">
               O vendedor passa e o banhista recebe o produto sem ter de se levantar, de forma
               prática e eficiente para ambos.
             </div>

--- a/sunny_sales_web/src/pages/Sustentabilidade.jsx
+++ b/sunny_sales_web/src/pages/Sustentabilidade.jsx
@@ -67,7 +67,6 @@ export default function Sustentabilidade() {
       </div>
 
       <div className="sustainability-cta">
-        <div className="sustainability-cta-icon">🌊</div>
         <p className="sustainability-cta-text">
           O objetivo é promover <strong>praias mais limpas</strong>, vendedores mais responsáveis
           e um verão verdadeiramente sustentável para toda a costa portuguesa.


### PR DESCRIPTION
### Motivation
- Aplicar as alterações visuais pedidas: badges em azul-céu (#4BA3C3) nas páginas “Sobre o Projeto” e “Contacto”, textos dos passos em cinzento (#6b7280) na secção “Como Funciona”, e remover a imagem/ícone das ondas na secção final de “Sustentabilidade”.
- Eliminar uma variável não utilizada no `catch` de `Contacto.jsx` para reduzir avisos de lint.

### Description
- Adicionadas regras CSS em `sunny_sales_web/src/pages/InfoPage.css` para `.info-badge.info-badge-sky` (cor `#4BA3C3`) e `.info-timeline-body.info-timeline-body-muted` (cor `#6b7280`).
- Atualizado `sunny_sales_web/src/pages/SobreProjeto.jsx` para aplicar `info-badge-sky` aos badges e usar `info-timeline-body-muted` nas descrições do timeline. 
- Atualizado `sunny_sales_web/src/pages/Contacto.jsx` para usar `info-badge-sky` nos badges (email, horário, resposta) e simplificar o `catch` para remover a binding não usada. 
- Atualizado `sunny_sales_web/src/pages/Sustentabilidade.jsx` para remover o elemento da onda (`sustainability-cta-icon`) da chamada final.

### Testing
- Executei `npm run build` e a build do Vite concluiu com sucesso. 
- Iniciei o servidor com `npm run dev` e a aplicação serviu localmente. 
- Executei `npm run lint` e o lint ainda falha devido a problemas preexistentes em `BeachConditions.jsx`, `ModernMapLayout.jsx` e `Sessions.jsx`, sendo que a alteração em `Contacto.jsx` resolveu um aviso anterior. 
- Tentei capturar screenshots com Playwright, mas `npx playwright install chromium` falhou por erro de download (HTTP 403), pelo que não foi possível gerar screenshots.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3a7d501170832e9a8f3183990ad47f)