### PR TITLE
Validate subscription durations and expiry

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -209,6 +209,13 @@ STRIPE_PLAN_PRICE_IDS = {
     "mensal": os.getenv("STRIPE_PRICE_ID_MENSAL", "price_1TjhCMIUkNjcmfnZECNOhR4y"),
 }
 
+# Duração real de cada plano vendido no front-end e no Stripe.
+SUBSCRIPTION_PLAN_DURATIONS_DAYS = {
+    "semanal": 7,
+    "quinzenal": 15,
+    "mensal": 30,
+}
+
 
 def validate_password(password: str):
     if len(password) < 8 or password.lower() == password or not any(c.isdigit() for c in password):
@@ -364,16 +371,52 @@ def get_admin(request: Request):
 # --------------------------
 # Subscrição
 # --------------------------
-def verify_active_subscription(vendor: models.Vendor, db: Session):
-    """Ensure subscription is active and not expired."""
+def refresh_subscription_status(vendor: models.Vendor, db: Session) -> models.Vendor:
+    """Atualiza o estado da subscrição caso a data de validade já tenha passado."""
     if (
         vendor.subscription_active
         and vendor.subscription_valid_until
-        and vendor.subscription_valid_until < utcnow()
+        and vendor.subscription_valid_until <= utcnow()
     ):
         vendor.subscription_active = False
         db.commit()
         db.refresh(vendor)
+    return vendor
+
+
+def apply_subscription_payment(vendor: models.Vendor, plan: str, db: Session) -> models.PaidWeek:
+    """Aplica um pagamento e calcula a validade com base no plano comprado."""
+    duration_days = SUBSCRIPTION_PLAN_DURATIONS_DAYS.get(plan)
+    if duration_days is None:
+        raise HTTPException(status_code=400, detail="Invalid plan")
+
+    now = utcnow()
+    # Se a subscrição ainda estiver ativa, o novo período é acumulado no fim da validade atual.
+    starts_at = (
+        vendor.subscription_valid_until
+        if (
+            vendor.subscription_active
+            and vendor.subscription_valid_until
+            and vendor.subscription_valid_until > now
+        )
+        else now
+    )
+    ends_at = starts_at + timedelta(days=duration_days)
+
+    vendor.subscription_active = True
+    vendor.subscription_valid_until = ends_at
+    paid = models.PaidWeek(
+        vendor_id=vendor.id,
+        start_date=starts_at,
+        end_date=ends_at,
+    )
+    db.add(paid)
+    return paid
+
+
+def verify_active_subscription(vendor: models.Vendor, db: Session):
+    """Confirma que a subscrição está ativa e ainda dentro da validade."""
+    refresh_subscription_status(vendor, db)
     if not vendor.subscription_active:
         raise HTTPException(status_code=403, detail="Subscription inactive")
 
@@ -1216,6 +1259,7 @@ def create_checkout_session(
             success_url=SUCCESS_URL,
             cancel_url=CANCEL_URL,
             metadata={"vendor_id": vendor_id, "plan": plan},
+            client_reference_id=str(vendor_id),
         )
         return {"checkout_url": session.url}
     except Exception as exc:
@@ -1312,11 +1356,12 @@ async def stripe_webhook(request: Request, db: Session = Depends(get_db)):
         session = event["data"]["object"]
         if session.get("payment_status") != "paid":
             return {"status": "ignored"}
-        vendor_id = int(session.get("client_reference_id") or session.get("metadata", {}).get("vendor_id") or 0)
+        metadata = session.get("metadata", {}) or {}
+        vendor_id = int(session.get("client_reference_id") or metadata.get("vendor_id") or 0)
+        plan = metadata.get("plan", "semanal")
         vendor = db.query(models.Vendor).filter(models.Vendor.id == vendor_id).first()
         if vendor:
-            vendor.subscription_active = True
-            vendor.subscription_valid_until = utcnow() + timedelta(days=7)
+            paid = apply_subscription_payment(vendor, plan, db)
             receipt_url = None
             invoice_id = session.get("invoice")
             if invoice_id:
@@ -1325,13 +1370,7 @@ async def stripe_webhook(request: Request, db: Session = Depends(get_db)):
                     receipt_url = invoice.get("hosted_invoice_url") or invoice.get("invoice_pdf")
                 except Exception:
                     receipt_url = None
-            paid = models.PaidWeek(
-                vendor_id=vendor_id,
-                start_date=utcnow(),
-                end_date=utcnow() + timedelta(days=7),
-                receipt_url=receipt_url,
-            )
-            db.add(paid)
+            paid.receipt_url = receipt_url
             db.commit()
     return {"status": "success"}
 
@@ -1350,14 +1389,7 @@ def activate_subscription_manual(
     if not vendor:
         raise HTTPException(status_code=404, detail="Vendor not found")
 
-    vendor.subscription_active = True
-    vendor.subscription_valid_until = utcnow() + timedelta(days=7)
-    paid = models.PaidWeek(
-        vendor_id=vendor_id,
-        start_date=utcnow(),
-        end_date=utcnow() + timedelta(days=7),
-    )
-    db.add(paid)
+    apply_subscription_payment(vendor, "semanal", db)
     db.commit()
     return {"status": "activated"}
 
@@ -1379,8 +1411,11 @@ def admin_deactivate_vendor(vendor_id: int, db: Session = Depends(get_db), admin
     return {"status": "deactivated"}
 
 @app.get("/vendors/me", response_model=schemas.VendorOut)
-def get_my_vendor_profile(current_vendor: models.Vendor = Depends(get_current_vendor)):
-    return current_vendor
+def get_my_vendor_profile(
+    current_vendor: models.Vendor = Depends(get_current_vendor),
+    db: Session = Depends(get_db),
+):
+    return refresh_subscription_status(current_vendor, db)
 
 
 @app.post("/api/contact")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3,6 +3,7 @@ import os
 import importlib
 import itertools
 import shutil
+from datetime import datetime, timedelta
 
 import pytest
 from fastapi.testclient import TestClient
@@ -449,5 +450,75 @@ def test_paid_weeks_listing(client):
     assert len(weeks) == 1
     assert weeks[0]["receipt_url"] == "http://r"
 
+def test_stripe_webhook_applies_plan_duration(client):
+    """Valida que cada plano pago fica ativo durante a duração contratada."""
 
+    from backend.app import main
+
+    expected_days_by_plan = {
+        "semanal": 7,
+        "quinzenal": 15,
+        "mensal": 30,
+    }
+
+    for plan, expected_days in expected_days_by_plan.items():
+        resp = register_vendor(client, email=f"{plan}@example.com")
+        vendor_id = resp.json()["id"]
+        confirm_latest_email(client)
+        token = get_token(client, email=f"{plan}@example.com")
+
+        event = {
+            "type": "checkout.session.completed",
+            "data": {
+                "object": {
+                    "metadata": {"vendor_id": vendor_id, "plan": plan},
+                    "payment_status": "paid",
+                }
+            },
+        }
+        before_payment = main.utcnow()
+        resp = client.post("/stripe/webhook", json=event)
+        after_payment = main.utcnow()
+        assert resp.status_code == 200
+
+        resp = client.get("/vendors/me", headers={"Authorization": f"Bearer {token}"})
+        assert resp.status_code == 200
+        vendor = resp.json()
+        valid_until = datetime.fromisoformat(vendor["subscription_valid_until"])
+        minimum_valid_until = before_payment + timedelta(days=expected_days)
+        maximum_valid_until = after_payment + timedelta(days=expected_days)
+
+        assert vendor["subscription_active"] is True
+        assert minimum_valid_until <= valid_until <= maximum_valid_until
+
+def test_subscription_expires_when_validity_passes(client):
+    """Valida que uma subscrição vencida é desativada antes de devolver o perfil."""
+
+    from backend.app import database, main, models
+
+    resp = register_vendor(client)
+    vendor_id = resp.json()["id"]
+    confirm_latest_email(client)
+    token = activate_subscription(client, vendor_id)
+
+    db = database.SessionLocal()
+    try:
+        vendor = db.query(models.Vendor).filter(models.Vendor.id == vendor_id).first()
+        vendor.subscription_active = True
+        vendor.subscription_valid_until = main.utcnow() - timedelta(seconds=1)
+        db.commit()
+    finally:
+        db.close()
+
+    resp = client.get("/vendors/me", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 200
+    vendor = resp.json()
+    assert vendor["subscription_active"] is False
+
+    resp = client.post(
+        f"/vendors/{vendor_id}/routes/start",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 403
+    assert resp.json()["detail"] == "Subscription inactive"
 


### PR DESCRIPTION
### Motivation

- Garantir que pagamentos de subscrição aplicam a duração correta por plano (semanal 7d, quinzenal 15d, mensal 30d) e que subscrições expiradas são desativadas automaticamente para evitar acesso indevido.

### Description

- Adiciona `SUBSCRIPTION_PLAN_DURATIONS_DAYS` e centraliza a lógica de aplicação de pagamento em `apply_subscription_payment(vendor, plan, db)` para calcular `start`/`end`, acumular períodos quando a subscrição já está ativa e criar o registo `PaidWeek`.
- Introduz `refresh_subscription_status(vendor, db)` que desativa subscrições cujo `subscription_valid_until` passou, e substitui a verificação anterior para usar esta rotina em `verify_active_subscription`.
- Atualiza `create_checkout_session` para incluir `client_reference_id` e faz o `stripe_webhook` ler o `plan` dos `metadata`, chamando `apply_subscription_payment` e gravando `receipt_url` no `PaidWeek`.
- Altera o endpoint de ativação manual para reutilizar `apply_subscription_payment` (mantendo o comportamento semanal por defeito) e faz `/vendors/me` devolver sempre o estado da subscrição já refrescado via `refresh_subscription_status`.
- Adiciona testes no `tests/test_main.py` que validam que cada plano define a validade esperada e que subscrições vencidas são desativadas e bloqueiam operações protegidas.

### Testing

- Executado `python -m pytest -q` e todos os testes automatizados passaram: `19 passed, 0 failed` (existem avisos de ambiente/dependências: 22 warnings). 
- Arquivos alterados: `backend/app/main.py`, `tests/test_main.py`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3a8963893c832e80a26901d6fd255e)