### PR TITLE
Remove license requirement from vendor registration

### DIFF
--- a/sunny_sales_web/src/pages/TermsScreen.jsx
+++ b/sunny_sales_web/src/pages/TermsScreen.jsx
@@ -46,32 +46,40 @@ export default function TermsScreen() {
           <li>Cumprir a legislação aplicável nas suas atividades comerciais</li>
           <li>Garantir a qualidade e segurança dos produtos vendidos</li>
           <li>Não utilizar a aplicação para fins ilegais ou fraudulentos</li>
+          <li>Manter os dados de contacto atualizados e precisos</li>
         </ul>
       </div>
 
       <div className="terms-section">
-        <h3 className="terms-section-title">6. Suspensão e Cancelamento</h3>
+        <h3 className="terms-section-title">6. Registro Simplificado</h3>
+        <p className="terms-text">
+          O registo como vendedor não requer apresentação de documentação de licença. O vendedor é responsável por garantir que a sua atividade comercial está em conformidade com a legislação aplicável na sua jurisdição.
+        </p>
+      </div>
+
+      <div className="terms-section">
+        <h3 className="terms-section-title">7. Suspensão e Cancelamento</h3>
         <p className="terms-text">
           A administração da Sunny Sales reserva-se o direito de suspender ou cancelar a conta de qualquer vendedor que viole estes termos, utilize a aplicação de forma abusiva ou prejudique outros utilizadores.
         </p>
       </div>
 
       <div className="terms-section">
-        <h3 className="terms-section-title">7. Limitação de Responsabilidade</h3>
+        <h3 className="terms-section-title">8. Limitação de Responsabilidade</h3>
         <p className="terms-text">
           A Sunny Sales não se responsabiliza por quaisquer perdas, danos ou prejuízos resultantes de transações comerciais entre vendedores e clientes. A utilização da aplicação é feita sob responsabilidade do utilizador.
         </p>
       </div>
 
       <div className="terms-section">
-        <h3 className="terms-section-title">8. Alterações aos Termos</h3>
+        <h3 className="terms-section-title">9. Alterações aos Termos</h3>
         <p className="terms-text">
           Estes Termos e Condições podem ser atualizados periodicamente. Notificaremos os utilizadores através da aplicação em caso de alterações significativas.
         </p>
       </div>
 
       <div className="terms-section">
-        <h3 className="terms-section-title">9. Contacto</h3>
+        <h3 className="terms-section-title">10. Contacto</h3>
         <p className="terms-text">
           Para qualquer dúvida ou questão relacionada com estes termos, o utilizador pode contactar a equipa de suporte através do email:{' '}
           <a href="mailto:suporte@sunnysales.com" className="info-link">

--- a/sunny_sales_web/src/pages/VendorRegister.jsx
+++ b/sunny_sales_web/src/pages/VendorRegister.jsx
@@ -236,10 +236,8 @@ export default function VendorRegister() {
         <h4>Termos e Condições</h4>
         <p>Ao registar-se como vendedor na plataforma Sunny Sales, declara e aceita que:</p>
         <ol>
-          <li>Possui licença de venda válida emitida pela câmara municipal competente.</li>
           <li>Todos os dados fornecidos são verdadeiros e atualizados.</li>
-          <li>É responsável por manter a licença válida e atualizada na plataforma.</li>
-          <li>A plataforma reserva-se o direito de suspender contas com licenças expiradas ou dados inválidos.</li>
+          <li>A plataforma reserva-se o direito de suspender contas com dados inválidos ou que violem estes termos.</li>
           <li>Os dados pessoais serão tratados de acordo com o RGPD e a legislação portuguesa.</li>
           <li>A plataforma não se responsabiliza por infrações cometidas pelo vendedor.</li>
           <li>Aceita receber comunicações relacionadas com a operação da plataforma.</li>


### PR DESCRIPTION
## Summary
This PR updates the Terms and Conditions and vendor registration flow to remove the requirement for vendors to possess a valid sales license. Instead, vendors are now responsible for ensuring their commercial activities comply with applicable legislation in their jurisdiction.

## Key Changes

- **TermsScreen.jsx**
  - Added new requirement: "Manter os dados de contacto atualizados e precisos" (Keep contact data updated and accurate)
  - Added new section 6 "Registro Simplificado" (Simplified Registration) explaining that license documentation is not required during registration
  - Renumbered subsequent sections (7-10) to accommodate the new section

- **VendorRegister.jsx**
  - Removed requirement: "Possui licença de venda válida emitida pela câmara municipal competente" (Must possess valid sales license from municipal chamber)
  - Removed requirement: "É responsável por manter a licença válida e atualizada na plataforma" (Responsible for maintaining valid and updated license on platform)
  - Updated suspension clause from "licenças expiradas ou dados inválidos" to "dados inválidos ou que violem estes termos" (invalid data or terms violations)

## Implementation Details
The changes shift the vendor registration model from a license-verification approach to a simplified registration process where vendors self-certify compliance with local legislation. The platform maintains the right to suspend accounts for invalid data or terms violations, but no longer requires upfront license documentation.

https://claude.ai/code/session_01QJ2ogdriiuL7JCAuVqmjeE