### PR TITLE
Permite editar todos os dados de registo no perfil do vendedor

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -54,6 +54,8 @@ def ensure_latest_schema():
             ("session_token", "ALTER TABLE vendors ADD COLUMN session_token TEXT"),
             ("email_confirmed", "ALTER TABLE vendors ADD COLUMN email_confirmed BOOLEAN DEFAULT false"),
             ("confirmation_token", "ALTER TABLE vendors ADD COLUMN confirmation_token TEXT"),
+            ("pending_email", "ALTER TABLE vendors ADD COLUMN pending_email TEXT"),
+            ("email_change_token", "ALTER TABLE vendors ADD COLUMN email_change_token TEXT"),
             ("password_reset_token", "ALTER TABLE vendors ADD COLUMN password_reset_token TEXT"),
             ("password_reset_expires", "ALTER TABLE vendors ADD COLUMN password_reset_expires TIMESTAMP"),
             ("payment_methods", "ALTER TABLE vendors ADD COLUMN payment_methods TEXT"),

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -603,6 +603,46 @@ def _send_confirmation_email(name: str, email: str, confirmation_token: str) -> 
         return False
 
 
+def _send_email_change_confirmation(name: str, new_email: str, change_token: str) -> bool:
+    """Envia para o NOVO email um link para confirmar a alteração de email."""
+    confirm_link = f"{BASE_APP_URL}/confirm-email-change/{change_token}"
+    try:
+        return send_email(
+            to=new_email,
+            subject="Sunny Sales - Confirma o teu novo email",
+            body=f"Olá {name},\n\nPediste para alterar o email da tua conta Sunny Sales para este endereço.\n\nClica no link para confirmares a alteração:\n{confirm_link}\n\nSe não pediste esta alteração, ignora este email.\n\nCumprimentos,\nEquipa Sunny Sales",
+            html=f"""<!DOCTYPE html>
+<html>
+<head><meta charset="UTF-8"></head>
+<body style="margin:0;padding:0;background:#f4f4f4;font-family:'Segoe UI',Roboto,sans-serif;">
+  <table width="100%" cellpadding="0" cellspacing="0" style="background:#f4f4f4;padding:40px 0;">
+    <tr><td align="center">
+      <table width="480" cellpadding="0" cellspacing="0" style="background:#ffffff;border-radius:12px;overflow:hidden;box-shadow:0 2px 8px rgba(0,0,0,0.08);">
+        <tr><td style="background:linear-gradient(135deg,#FCB454,#F7931E);padding:30px;text-align:center;">
+          <h1 style="margin:0;color:#ffffff;font-size:24px;">&#9728;&#65039; Sunny Sales</h1>
+        </td></tr>
+        <tr><td style="padding:30px;">
+          <h2 style="color:#333;margin-top:0;">Olá {name}!</h2>
+          <p style="color:#555;font-size:16px;line-height:1.6;">Pediste para alterar o email da tua conta <strong>Sunny Sales</strong> para este endereço. Para confirmares a alteração, clica no botão abaixo:</p>
+          <div style="text-align:center;margin:30px 0;">
+            <a href="{confirm_link}" style="background:#FCB454;color:#ffffff;padding:14px 32px;border-radius:8px;text-decoration:none;font-weight:bold;font-size:16px;display:inline-block;">Confirmar Novo Email</a>
+          </div>
+          <p style="color:#888;font-size:13px;">Se o botão não funcionar, copia e cola este link no teu navegador:</p>
+          <p style="color:#888;font-size:13px;word-break:break-all;">{confirm_link}</p>
+          <hr style="border:none;border-top:1px solid #eee;margin:24px 0;">
+          <p style="color:#aaa;font-size:12px;text-align:center;">Se não pediste esta alteração, ignora este email.<br>Equipa Sunny Sales</p>
+        </td></tr>
+      </table>
+    </td></tr>
+  </table>
+</body>
+</html>""",
+        )
+    except Exception as exc:
+        print(f"[Email] Falha ao enviar email de alteração para {new_email}: {exc}")
+        return False
+
+
 def _send_password_reset_email(name: str, email: str, reset_token: str) -> bool:
     reset_link = f"{BASE_APP_URL}/password-reset/{reset_token}"
     try:
@@ -766,6 +806,7 @@ def list_vendors(
 @app.patch("/vendors/{vendor_id}/profile", response_model=schemas.VendorOut)
 async def update_vendor_profile(
     vendor_id: int,
+    background_tasks: BackgroundTasks,
     name: str = Form(None),
     email: str = Form(None),
     password: str = Form(None),
@@ -775,6 +816,14 @@ async def update_vendor_profile(
     profile_photo: UploadFile = File(None),
     pin_color: str = Form(None),
     payment_methods: str = Form(None),
+    nif: str = Form(None),
+    id_document_number: str = Form(None),
+    phone: str = Form(None),
+    address: str = Form(None),
+    beaches: str = Form(None),
+    product_categories: str = Form(None),
+    iban: str = Form(None),
+    business_name: str = Form(None),
     db: Session = Depends(get_db),
     current_vendor: models.Vendor = Depends(get_current_vendor),
 ):
@@ -786,11 +835,26 @@ async def update_vendor_profile(
 
     if name:
         vendor.name = name
+    # Alteração de email: não muda já o email; envia link de confirmação para o
+    # novo endereço e só ao confirmar é que o email passa a estar ativo.
     if email and email != vendor.email:
-        existing = db.query(models.Vendor).filter(models.Vendor.email == email).first()
-        if existing:
+        existing = (
+            db.query(models.Vendor)
+            .filter(models.Vendor.email == email, models.Vendor.id != vendor_id)
+            .first()
+        )
+        pending = (
+            db.query(models.Vendor)
+            .filter(models.Vendor.pending_email == email, models.Vendor.id != vendor_id)
+            .first()
+        )
+        if existing or pending:
             raise HTTPException(status_code=400, detail="Email already in use")
-        vendor.email = email
+        vendor.pending_email = email
+        vendor.email_change_token = uuid4().hex
+        background_tasks.add_task(
+            _send_email_change_confirmation, vendor.name, email, vendor.email_change_token
+        )
     # manter compatibilidade com parametro antigo 'password'
     if new_password or password:
         new_pass = new_password if new_password is not None else password
@@ -812,6 +876,31 @@ async def update_vendor_profile(
         vendor.pin_color = pin_color
     if payment_methods is not None:
         vendor.payment_methods = payment_methods
+    if nif is not None and nif != (vendor.nif or ""):
+        if not _validate_nif(nif):
+            raise HTTPException(status_code=400, detail="NIF inválido")
+        existing_nif = (
+            db.query(models.Vendor)
+            .filter(models.Vendor.nif == nif, models.Vendor.id != vendor_id)
+            .first()
+        )
+        if existing_nif:
+            raise HTTPException(status_code=400, detail="NIF já registado")
+        vendor.nif = nif
+    if id_document_number is not None:
+        vendor.id_document_number = id_document_number or None
+    if phone is not None:
+        vendor.phone = phone or None
+    if address is not None:
+        vendor.address = address or None
+    if beaches is not None:
+        vendor.beaches = beaches
+    if product_categories is not None:
+        vendor.product_categories = product_categories
+    if iban is not None:
+        vendor.iban = iban or None
+    if business_name is not None:
+        vendor.business_name = business_name or None
 
     db.commit()
     db.refresh(vendor)
@@ -1074,6 +1163,63 @@ def confirm_email(token: str, db: Session = Depends(get_db)):
         heading="Email confirmado com sucesso!",
         heading_color="#2e7d32",
         message=f"Olá <strong>{vendor.name}</strong>, a tua conta Sunny Sales está agora ativa. Já podes iniciar sessão.",
+        button_label="Fazer Login",
+    ))
+
+
+@app.get("/confirm-email-change/{token}", response_class=HTMLResponse)
+def confirm_email_change(token: str, db: Session = Depends(get_db)):
+    vendor = (
+        db.query(models.Vendor)
+        .filter(models.Vendor.email_change_token == token)
+        .first()
+    )
+    if not vendor or not vendor.pending_email:
+        return HTMLResponse(
+            status_code=404,
+            content=_status_page(
+                title="Link Inválido",
+                icon="&#10060;",
+                heading="Link inválido ou expirado",
+                heading_color="#c62828",
+                message="Este link de alteração de email já não é válido.",
+                button_label="Ir para a página inicial",
+            ),
+        )
+
+    # Garantir que o novo email continua livre antes de o aplicar
+    taken = (
+        db.query(models.Vendor)
+        .filter(models.Vendor.email == vendor.pending_email, models.Vendor.id != vendor.id)
+        .first()
+    )
+    if taken:
+        vendor.pending_email = None
+        vendor.email_change_token = None
+        db.commit()
+        return HTMLResponse(
+            status_code=400,
+            content=_status_page(
+                title="Email Indisponível",
+                icon="&#10060;",
+                heading="Email já em uso",
+                heading_color="#c62828",
+                message="Este email já está associado a outra conta. Tenta alterar para um email diferente.",
+                button_label="Ir para a página inicial",
+            ),
+        )
+
+    vendor.email = vendor.pending_email
+    vendor.pending_email = None
+    vendor.email_change_token = None
+    vendor.email_confirmed = True
+    db.commit()
+    return HTMLResponse(content=_status_page(
+        title="Email Alterado",
+        icon="&#9989;",
+        heading="Email alterado com sucesso!",
+        heading_color="#2e7d32",
+        message=f"Olá <strong>{vendor.name}</strong>, o teu email foi atualizado. Usa o novo email para iniciar sessão.",
         button_label="Fazer Login",
     ))
 

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -27,6 +27,9 @@ class Vendor(Base):
     subscription_valid_until = Column(DateTime, nullable=True)
     email_confirmed = Column(Boolean, default=False)
     confirmation_token = Column(String, nullable=True, index=True)
+    # Alteração de email: guarda o novo email até este ser confirmado por link
+    pending_email = Column(String, nullable=True)
+    email_change_token = Column(String, nullable=True, index=True)
     password_reset_token = Column(String, nullable=True, index=True)
     password_reset_expires = Column(DateTime, nullable=True)
     session_token = Column(String, nullable=True, index=True)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -23,6 +23,14 @@ class VendorProfileUpdate(BaseModel):
     product: Optional[Literal["Bolas de Berlim", "Gelados", "Acessórios de Praia"]] = None
     profile_photo: Optional[str] = None
     pin_color: Optional[str] = None
+    nif: Optional[str] = None
+    id_document_number: Optional[str] = None
+    phone: Optional[str] = None
+    address: Optional[str] = None
+    beaches: Optional[str] = None
+    product_categories: Optional[str] = None
+    iban: Optional[str] = None
+    business_name: Optional[str] = None
 
 class VendorCreate(BaseModel):
     name: str
@@ -54,11 +62,16 @@ class VendorOut(BaseModel):
     last_seen: Optional[str] = None
     payment_methods: Optional[str] = None
     nif: Optional[str] = None
+    id_document_number: Optional[str] = None
     phone: Optional[str] = None
+    address: Optional[str] = None
     beaches: Optional[str] = None
     product_categories: Optional[str] = None
+    iban: Optional[str] = None
     business_name: Optional[str] = None
     terms_accepted: Optional[bool] = None
+    # Email novo a aguardar confirmação (alteração de email pendente)
+    pending_email: Optional[str] = None
     model_config = ConfigDict(from_attributes=True)
 
 

--- a/mobile/src/index.css
+++ b/mobile/src/index.css
@@ -515,6 +515,23 @@ body {
   text-align: center;
 }
 
+.info-msg {
+  background: #eff6ff;
+  color: #1d4ed8;
+  border: 1px solid #bfdbfe;
+  border-radius: var(--radius-sm);
+  padding: 12px 14px;
+  font-size: 14px;
+  text-align: center;
+}
+
+.input-hint {
+  display: block;
+  font-size: 12px;
+  color: var(--text-muted, #6b7280);
+  margin-top: 4px;
+}
+
 /* ── Loading dots ─────────────────────────────── */
 .loading-dots {
   display: flex;

--- a/mobile/src/pages/ProfileScreen.jsx
+++ b/mobile/src/pages/ProfileScreen.jsx
@@ -8,6 +8,9 @@ export default function ProfileScreen({ auth, onClose, onUserUpdate }) {
   const { token, user, vendorId } = auth;
   const [name, setName] = useState(user?.name || '');
   const [email, setEmail] = useState(user?.email || '');
+  const [nif, setNif] = useState(user?.nif || '');
+  const [phone, setPhone] = useState(user?.phone || '');
+  const [businessName, setBusinessName] = useState(user?.business_name || '');
   const [product, setProduct] = useState(user?.product || '');
   const [pinColor, setPinColor] = useState(user?.pin_color || '#7B61FF');
   const [paymentMethods, setPaymentMethods] = useState(
@@ -17,6 +20,7 @@ export default function ProfileScreen({ auth, onClose, onUserUpdate }) {
   const [photoPreview, setPhotoPreview] = useState(null);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState('');
+  const [info, setInfo] = useState('');
   const fileInputRef = useRef(null);
 
   const handlePhotoChange = (e) => {
@@ -38,10 +42,14 @@ export default function ProfileScreen({ auth, onClose, onUserUpdate }) {
     e.preventDefault();
     setSaving(true);
     setError('');
+    setInfo('');
     try {
       const data = new FormData();
       if (name !== user.name) data.append('name', name);
       if (email !== user.email) data.append('email', email);
+      if (nif !== (user.nif || '')) data.append('nif', nif);
+      if (phone !== (user.phone || '')) data.append('phone', phone);
+      if (businessName !== (user.business_name || '')) data.append('business_name', businessName);
       if (product !== user.product) data.append('product', product);
       if (pinColor !== (user.pin_color || '#7B61FF')) data.append('pin_color', pinColor);
       const newMethods = paymentMethods.join(',');
@@ -56,6 +64,12 @@ export default function ProfileScreen({ auth, onClose, onUserUpdate }) {
       const body = await res.json();
       if (!res.ok) throw new Error(body.detail || 'Erro ao atualizar perfil.');
       onUserUpdate(body);
+      // O email só muda depois de confirmado no link enviado para o novo endereço
+      if (body.pending_email) {
+        setEmail(body.email || '');
+        setInfo(`Confirma o novo email (${body.pending_email}) na mensagem que enviámos para concluir a alteração.`);
+        return;
+      }
       onClose();
     } catch (err) {
       setError(err.message);
@@ -102,6 +116,7 @@ export default function ProfileScreen({ auth, onClose, onUserUpdate }) {
           </div>
 
           {error && <div className="error-msg">{error}</div>}
+          {info && <div className="info-msg">{info}</div>}
 
           <div className="input-group">
             <label>Nome</label>
@@ -110,6 +125,25 @@ export default function ProfileScreen({ auth, onClose, onUserUpdate }) {
           <div className="input-group">
             <label>Email</label>
             <input type="email" value={email} onChange={(e) => setEmail(e.target.value)} required />
+            <span className="input-hint">Alterar o email exige confirmação no novo endereço.</span>
+          </div>
+          <div className="input-group">
+            <label>NIF</label>
+            <input
+              type="text"
+              inputMode="numeric"
+              maxLength={9}
+              value={nif}
+              onChange={(e) => setNif(e.target.value.replace(/\D/g, ''))}
+            />
+          </div>
+          <div className="input-group">
+            <label>Telemóvel</label>
+            <input type="tel" value={phone} onChange={(e) => setPhone(e.target.value)} />
+          </div>
+          <div className="input-group">
+            <label>Nome da Atividade / Firma</label>
+            <input type="text" value={businessName} onChange={(e) => setBusinessName(e.target.value)} />
           </div>
           <div className="input-group">
             <label>Produto</label>

--- a/sunny_sales_web/src/pages/ManageAccount.css
+++ b/sunny_sales_web/src/pages/ManageAccount.css
@@ -192,6 +192,14 @@
   flex-shrink: 0;
 }
 
+.ma-field-hint {
+  display: block;
+  font-size: 0.78rem;
+  color: var(--text-muted);
+  margin-top: 6px;
+  line-height: 1.4;
+}
+
 .ma-card-body {
   display: flex;
   flex-direction: column;

--- a/sunny_sales_web/src/pages/ManageAccount.jsx
+++ b/sunny_sales_web/src/pages/ManageAccount.jsx
@@ -6,7 +6,7 @@ import BackHomeButton from '../components/BackHomeButton';
 import {
   FiUser, FiLock, FiPackage, FiCamera, FiCheck,
   FiDollarSign, FiSmartphone, FiTerminal, FiCreditCard, FiWifi,
-  FiChevronDown, FiChevronUp, FiSave,
+  FiChevronDown, FiChevronUp, FiSave, FiBriefcase,
 } from 'react-icons/fi';
 import './ManageAccount.css';
 
@@ -22,6 +22,9 @@ export default function ManageAccount() {
   const [vendor, setVendor] = useState(null);
   const [name, setName] = useState('');
   const [email, setEmail] = useState('');
+  const [nif, setNif] = useState('');
+  const [phone, setPhone] = useState('');
+  const [businessName, setBusinessName] = useState('');
   const [product, setProduct] = useState('');
   const [pinColor, setPinColor] = useState('#7B61FF');
   const [photo, setPhoto] = useState(null);
@@ -43,6 +46,9 @@ export default function ManageAccount() {
       setVendor(v);
       setName(v.name || '');
       setEmail(v.email || '');
+      setNif(v.nif || '');
+      setPhone(v.phone || '');
+      setBusinessName(v.business_name || '');
       setProduct(v.product || '');
       setPinColor(v.pin_color || '#7B61FF');
       if (v.payment_methods) {
@@ -84,7 +90,11 @@ export default function ManageAccount() {
     try {
       const data = new FormData();
       if (name !== vendor.name) data.append('name', name);
-      if (email !== vendor.email) data.append('email', email);
+      const emailChanged = email !== vendor.email;
+      if (emailChanged) data.append('email', email);
+      if (nif !== (vendor.nif || '')) data.append('nif', nif);
+      if (phone !== (vendor.phone || '')) data.append('phone', phone);
+      if (businessName !== (vendor.business_name || '')) data.append('business_name', businessName);
       if (password) {
         data.append('new_password', password);
         data.append('old_password', oldPassword);
@@ -104,7 +114,15 @@ export default function ManageAccount() {
       );
       localStorage.setItem('user', JSON.stringify(res.data));
       setVendor(res.data);
-      setSuccess('Dados atualizados com sucesso!');
+      // O email só é alterado depois de confirmado pelo link enviado por email
+      if (res.data.pending_email) {
+        setEmail(res.data.email || '');
+        setSuccess(
+          `Dados atualizados! Enviámos um email para ${res.data.pending_email} — confirma esse endereço para concluíres a alteração de email.`
+        );
+      } else {
+        setSuccess('Dados atualizados com sucesso!');
+      }
       setPassword('');
       setOldPassword('');
       setPhoto(null);
@@ -196,6 +214,55 @@ export default function ManageAccount() {
                 placeholder="email@exemplo.com"
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
+              />
+              {vendor.pending_email ? (
+                <span className="ma-field-hint">
+                  Alteração pendente: confirma <strong>{vendor.pending_email}</strong> no email que enviámos.
+                </span>
+              ) : (
+                <span className="ma-field-hint">
+                  Ao alterar o email vais receber um link de confirmação no novo endereço.
+                </span>
+              )}
+            </div>
+            <div className="ma-field">
+              <label className="ma-label">NIF</label>
+              <input
+                className="ma-input"
+                type="text"
+                inputMode="numeric"
+                maxLength={9}
+                placeholder="123456789"
+                value={nif}
+                onChange={(e) => setNif(e.target.value.replace(/\D/g, ''))}
+              />
+            </div>
+            <div className="ma-field">
+              <label className="ma-label">Telemóvel</label>
+              <input
+                className="ma-input"
+                type="tel"
+                placeholder="912345678"
+                value={phone}
+                onChange={(e) => setPhone(e.target.value)}
+              />
+            </div>
+          </div>
+
+          {/* Atividade / Firma */}
+          <div className="ma-card">
+            <div className="ma-card-header">
+              <FiBriefcase className="ma-card-icon" />
+              <span className="ma-card-title">Atividade</span>
+            </div>
+            <div className="ma-field">
+              <label className="ma-label">Nome da Atividade / Firma</label>
+              <input
+                className="ma-input"
+                type="text"
+                placeholder="Nome comercial (opcional)"
+                value={businessName}
+                onChange={(e) => setBusinessName(e.target.value)}
               />
             </div>
           </div>

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -306,6 +306,108 @@ def test_protected_routes(client):
     assert resp.status_code == 200
 
 
+def test_update_registration_fields(client):
+    """O vendedor pode alterar os dados que introduziu no registo."""
+    resp = register_vendor(client)
+    vendor_id = resp.json()["id"]
+    confirm_latest_email(client)
+    token = get_token(client)
+
+    new_nif = make_nif()
+    resp = client.patch(
+        f"/vendors/{vendor_id}/profile",
+        data={
+            "phone": "961112233",
+            "business_name": "Praia & Sol Lda",
+            "nif": new_nif,
+        },
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["phone"] == "961112233"
+    assert body["business_name"] == "Praia & Sol Lda"
+    assert body["nif"] == new_nif
+
+
+def test_update_profile_rejects_invalid_nif(client):
+    resp = register_vendor(client)
+    vendor_id = resp.json()["id"]
+    confirm_latest_email(client)
+    token = get_token(client)
+
+    resp = client.patch(
+        f"/vendors/{vendor_id}/profile",
+        data={"nif": "123456788"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == "NIF inválido"
+
+
+def test_email_change_requires_confirmation(client):
+    """Alterar o email não é imediato: exige confirmação por email."""
+    resp = register_vendor(client)
+    vendor_id = resp.json()["id"]
+    confirm_latest_email(client)
+    token = get_token(client)
+
+    resp = client.patch(
+        f"/vendors/{vendor_id}/profile",
+        data={"email": "novo@example.com"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    # o email ainda não mudou; fica pendente até confirmação
+    assert body["email"] == "vendor@example.com"
+    assert body["pending_email"] == "novo@example.com"
+
+    # foi enviado um email de confirmação para o novo endereço
+    last = client.sent_emails[-1]
+    assert last["to"] == "novo@example.com"
+    assert "/confirm-email-change/" in last["body"]
+
+    # login com o email antigo continua a funcionar
+    assert client.post(
+        "/token", json={"email": "vendor@example.com", "password": "Secret123", "force": True}
+    ).status_code == 200
+    # ainda não é possível autenticar com o novo email
+    assert client.post(
+        "/token", json={"email": "novo@example.com", "password": "Secret123", "force": True}
+    ).status_code != 200
+
+    # confirmar a alteração através do link
+    change_token = last["body"].split("/confirm-email-change/")[1].split()[0].strip()
+    confirm = client.get(f"/confirm-email-change/{change_token}")
+    assert confirm.status_code == 200
+
+    # agora o login passa a ser feito com o novo email
+    assert client.post(
+        "/token", json={"email": "novo@example.com", "password": "Secret123", "force": True}
+    ).status_code == 200
+    # e o email antigo deixa de ser válido
+    assert client.post(
+        "/token", json={"email": "vendor@example.com", "password": "Secret123", "force": True}
+    ).status_code != 200
+
+
+def test_email_change_rejects_duplicate(client):
+    register_vendor(client, email="a@example.com")
+    second = register_vendor(client, email="b@example.com")
+    vendor_id = second.json()["id"]
+    confirm_latest_email(client)
+    token = get_token(client, email="b@example.com")
+
+    resp = client.patch(
+        f"/vendors/{vendor_id}/profile",
+        data={"email": "a@example.com"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == "Email already in use"
+
+
 def test_location_update_fields(client):
     resp = register_vendor(client)
     vendor_id = resp.json()["id"]


### PR DESCRIPTION
- Adiciona edição de NIF, telemóvel e nome da atividade no perfil
  (web ManageAccount e app móvel ProfileScreen), validando o NIF e a
  unicidade tal como no registo.
- Alteração de email passa a exigir confirmação: o novo endereço fica
  pendente (pending_email) e só é aplicado depois de o vendedor clicar
  no link enviado para o novo email (/confirm-email-change/{token}).
- Backend: novos campos no modelo Vendor + migração, schemas atualizados,
  endpoint PATCH de perfil alargado e endpoint de confirmação de email.
- Testes para edição dos campos de registo e para o fluxo de confirmação
  de alteração de email.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01A7RV31m6Vfryo748jVkGBD