### PR TITLE
Reorganize vendor profile form and improve UI styling

### DIFF
--- a/sunny_sales_web/src/pages/VendorDashboard.css
+++ b/sunny_sales_web/src/pages/VendorDashboard.css
@@ -752,9 +752,9 @@
 }
 
 .vd-modal-payment-chip.active {
-  background: var(--primary-light);
+  background: var(--primary);
   border-color: var(--primary);
-  color: var(--primary-dark);
+  color: #fff;
 }
 
 .vd-modal-payment-chip:hover {
@@ -863,8 +863,8 @@
 }
 
 .vd-modal-tab.active {
-  background: var(--surface);
-  color: var(--primary-dark);
+  background: var(--primary);
+  color: #fff;
   box-shadow: 0 1px 6px rgba(0, 0, 0, 0.10);
 }
 

--- a/sunny_sales_web/src/pages/VendorDashboard.jsx
+++ b/sunny_sales_web/src/pages/VendorDashboard.jsx
@@ -262,6 +262,9 @@ export default function VendorDashboard() {
         const file = new File([editPhoto], 'profile.jpg', { type: 'image/jpeg' });
         data.append('profile_photo', file);
       }
+      if (editProduct !== vendor.product) data.append('product', editProduct);
+      const newPaymentMethods = editPaymentMethods.join(',');
+      if (newPaymentMethods !== (vendor.payment_methods || '')) data.append('payment_methods', newPaymentMethods);
       const res = await axios.patch(
         `${BASE_URL}/vendors/${vendor.id}/profile`,
         data,
@@ -297,10 +300,6 @@ export default function VendorDashboard() {
       if (editEmail !== vendor.email) data.append('email', editEmail);
       if (editNif !== (vendor.nif || '')) data.append('nif', editNif);
       if (editPhone !== (vendor.phone || '')) data.append('phone', editPhone);
-      if (editBusinessName !== (vendor.business_name || '')) data.append('business_name', editBusinessName);
-      if (editProduct !== vendor.product) data.append('product', editProduct);
-      const newPaymentMethods = editPaymentMethods.join(',');
-      if (newPaymentMethods !== (vendor.payment_methods || '')) data.append('payment_methods', newPaymentMethods);
       const res = await axios.patch(
         `${BASE_URL}/vendors/${vendor.id}/profile`,
         data,
@@ -594,6 +593,36 @@ export default function VendorDashboard() {
                   </div>
                 </div>
 
+                <div className="vd-modal-field">
+                  <label className="vd-modal-label">Produto</label>
+                  <select
+                    className="vd-modal-input"
+                    value={editProduct}
+                    onChange={e => setEditProduct(e.target.value)}
+                  >
+                    <option value="Bolas de Berlim">Bolas de Berlim</option>
+                    <option value="Gelados">Gelados</option>
+                    <option value="Acessórios de Praia">Acessórios de Praia</option>
+                  </select>
+                </div>
+
+                <div className="vd-modal-field">
+                  <label className="vd-modal-label">Métodos de pagamento aceites</label>
+                  <div className="vd-modal-payments-grid">
+                    {Object.keys(PAYMENT_ICONS).map((method) => (
+                      <button
+                        type="button"
+                        key={method}
+                        className={`vd-modal-payment-chip${editPaymentMethods.includes(method) ? ' active' : ''}`}
+                        onClick={() => togglePaymentMethod(method)}
+                      >
+                        <span className="vd-modal-payment-chip-icon">{PAYMENT_ICONS[method]}</span>
+                        {method}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+
                 {editError && <p className="vd-modal-error">{editError}</p>}
                 {editSuccess && (
                   <p className="vd-modal-success">
@@ -655,44 +684,6 @@ export default function VendorDashboard() {
                     value={editPhone}
                     onChange={e => setEditPhone(e.target.value)}
                   />
-                </div>
-                <div className="vd-modal-field">
-                  <label className="vd-modal-label">Nome da Atividade / Firma</label>
-                  <input
-                    className="vd-modal-input"
-                    type="text"
-                    placeholder="Nome comercial (opcional)"
-                    value={editBusinessName}
-                    onChange={e => setEditBusinessName(e.target.value)}
-                  />
-                </div>
-                <div className="vd-modal-field">
-                  <label className="vd-modal-label">Produto</label>
-                  <select
-                    className="vd-modal-input"
-                    value={editProduct}
-                    onChange={e => setEditProduct(e.target.value)}
-                  >
-                    <option value="Bolas de Berlim">Bolas de Berlim</option>
-                    <option value="Gelados">Gelados</option>
-                    <option value="Acessórios de Praia">Acessórios de Praia</option>
-                  </select>
-                </div>
-                <div className="vd-modal-field">
-                  <label className="vd-modal-label">Métodos de pagamento aceites</label>
-                  <div className="vd-modal-payments-grid">
-                    {Object.keys(PAYMENT_ICONS).map((method) => (
-                      <button
-                        type="button"
-                        key={method}
-                        className={`vd-modal-payment-chip${editPaymentMethods.includes(method) ? ' active' : ''}`}
-                        onClick={() => togglePaymentMethod(method)}
-                      >
-                        <span className="vd-modal-payment-chip-icon">{PAYMENT_ICONS[method]}</span>
-                        {method}
-                      </button>
-                    ))}
-                  </div>
                 </div>
 
                 {personalError && <p className="vd-modal-error">{personalError}</p>}


### PR DESCRIPTION
## Summary
This PR reorganizes the vendor profile edit form by moving product and payment method fields to an earlier section, removes the business name field, and improves the visual styling of active states for payment method chips and modal tabs.

## Key Changes
- **Form reorganization**: Moved "Produto" (Product) and "Métodos de pagamento aceites" (Accepted Payment Methods) fields from the bottom section to appear earlier in the form, right after the profile photo section
- **Removed field**: Deleted the "Nome da Atividade / Firma" (Business Name) field from the form
- **API payload adjustment**: Moved product and payment methods data append logic to the first profile update request (before email, NIF, and phone fields)
- **UI styling improvements**:
  - Active payment method chips now use primary color background with white text instead of light primary background with dark text
  - Active modal tabs now use primary color background with white text instead of surface background with dark text
  - Enhanced visual contrast for better accessibility and UX

## Implementation Details
- The form fields are now logically grouped with basic profile information (photo, product, payment methods) appearing before personal details (email, NIF, phone)
- Payment method and product data are now sent in the same API request as the profile photo, improving data consistency
- CSS color scheme updates maintain consistency across interactive elements while improving visual hierarchy

https://claude.ai/code/session_01PSAKo7cEKcVWASA9kSKBDs