### PR TITLE
Refactor ALLOWED_HOSTS configuration for TrustedHostMiddleware

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -184,15 +184,19 @@ app.add_middleware(
 )
 
 # Middleware de host confiável
+_allowed_hosts = [
+    "localhost",
+    "localhost:8000",
+    "127.0.0.1",
+    "ss-tester.onrender.com",
+]
+_env_hosts = os.getenv("ALLOWED_HOSTS", "")
+if _env_hosts:
+    _allowed_hosts.extend([h.strip() for h in _env_hosts.split(",") if h.strip()])
+
 app.add_middleware(
     TrustedHostMiddleware,
-    allowed_hosts=[
-        "localhost",
-        "localhost:8000",
-        "127.0.0.1",
-        "ss-tester.onrender.com",
-        os.getenv("ALLOWED_HOSTS", "ss-tester.onrender.com").split(","),
-    ]
+    allowed_hosts=_allowed_hosts
 )
 
 # Middleware de Security Headers


### PR DESCRIPTION
## Summary
Improved the handling of allowed hosts configuration for the TrustedHostMiddleware by extracting the logic into a separate variable and fixing a bug in environment variable parsing.

## Key Changes
- Extracted allowed hosts list into a `_allowed_hosts` variable for better readability and maintainability
- Fixed environment variable parsing: the previous implementation incorrectly passed a list as a single element instead of extending the allowed hosts properly
- Added proper string trimming when parsing comma-separated hosts from the `ALLOWED_HOSTS` environment variable
- Simplified the middleware initialization by passing the pre-processed `_allowed_hosts` list

## Implementation Details
The refactoring addresses a bug where `os.getenv("ALLOWED_HOSTS", "ss-tester.onrender.com").split(",")` would be added as a list object to the `allowed_hosts` parameter, rather than extending it with individual host strings. The new implementation:
1. Starts with a base list of default hosts (localhost, 127.0.0.1, ss-tester.onrender.com)
2. Checks if the `ALLOWED_HOSTS` environment variable is set
3. If present, parses it as comma-separated values and extends the list with trimmed host strings
4. Passes the complete list to the middleware configuration

https://claude.ai/code/session_01YGPKPUbtMm8mgk2JhQ62ox