### PR TITLE
Update deployment URLs from Render to Railway

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -171,7 +171,7 @@ else:
     origins = [
         "http://localhost:3000",
         "http://localhost:5173",
-        "https://ss-tester.onrender.com",
+        "https://laudable-learning-production-a293.up.railway.app",
     ]
 
 app.add_middleware(
@@ -188,7 +188,7 @@ _allowed_hosts = [
     "localhost",
     "localhost:8000",
     "127.0.0.1",
-    "ss-tester.onrender.com",
+    "sstester-production.up.railway.app",
 ]
 _env_hosts = os.getenv("ALLOWED_HOSTS", "")
 if _env_hosts:
@@ -261,7 +261,7 @@ _init_db()
 # Contexto para hash de password
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
-BASE_APP_URL = os.getenv("BASE_APP_URL", "https://ss-tester.onrender.com")
+BASE_APP_URL = os.getenv("BASE_APP_URL", "https://laudable-learning-production-a293.up.railway.app")
 
 RESEND_API_KEY = os.getenv("RESEND_API_KEY", "")
 RESEND_FROM = os.getenv("RESEND_FROM", "Sunny Sales <onboarding@resend.dev>")

--- a/start.sh
+++ b/start.sh
@@ -6,6 +6,9 @@ if [ -d "sunny_sales_web" ]; then
   echo "A compilar o frontend..."
   cd sunny_sales_web
   npm install --prefer-offline --no-audit --no-fund
+  # Usar VITE_BASE_URL para configurar a URL do backend em produção
+  # Em Railway, o backend está em https://sstester-production.up.railway.app
+  export VITE_BASE_URL="${VITE_BASE_URL:-https://sstester-production.up.railway.app}"
   npm run build
   cd ..
   echo "Frontend compilado com sucesso."


### PR DESCRIPTION
## Summary
This PR updates the application's deployment infrastructure URLs from Render to Railway, ensuring all backend and frontend services point to the correct production endpoints.

## Key Changes
- **CORS Origins**: Updated allowed origin from `https://ss-tester.onrender.com` to `https://laudable-learning-production-a293.up.railway.app`
- **Allowed Hosts**: Updated allowed host from `ss-tester.onrender.com` to `sstester-production.up.railway.app`
- **Base App URL**: Updated default `BASE_APP_URL` environment variable from Render to Railway production URL
- **Frontend Build Configuration**: Added `VITE_BASE_URL` environment variable export in build script to configure frontend backend URL to point to the new Railway backend endpoint

## Implementation Details
- All three URL references (CORS, allowed hosts, and base app URL) have been consistently updated to use the new Railway deployment
- The build script now explicitly sets the frontend's backend URL during the build process, ensuring the frontend communicates with the correct backend in production
- Environment variables can still override these defaults if needed

https://claude.ai/code/session_014uouL9QccJWi8zPRQXEbhM