### PR TITLE
Standardize hover states to use outline instead of background

### DIFF
--- a/sunny_sales_web/src/components/LocateHint.css
+++ b/sunny_sales_web/src/components/LocateHint.css
@@ -50,7 +50,6 @@
 }
 .locate-hint__close:hover {
   color: var(--text);
-  background: var(--surface-alt);
-  transform: none;
-  box-shadow: none;
+  outline: 2px solid var(--primary);
+  outline-offset: 2px;
 }

--- a/sunny_sales_web/src/index.css
+++ b/sunny_sales_web/src/index.css
@@ -138,7 +138,8 @@ body {
 }
 .nav-link:hover {
   color: #ffffff;
-  border-color: rgba(255, 255, 255, 0.3);
+  outline: 2px solid rgba(255, 255, 255, 0.6);
+  outline-offset: 2px;
 }
 .nav-link.active {
   color: #ffffff;
@@ -173,7 +174,8 @@ body {
 }
 .profile-icon:hover {
   color: rgba(255, 255, 255, 0.72);
-  border-color: rgba(0, 0, 0, 0.4);
+  outline: 2px solid rgba(255, 255, 255, 0.6);
+  outline-offset: 2px;
 }
 
 .menu-toggle {
@@ -194,7 +196,8 @@ body {
 }
 .menu-toggle:hover {
   color: #ffffff;
-  background: rgba(0, 0, 0, 0.12);
+  outline: 2px solid rgba(255, 255, 255, 0.6);
+  outline-offset: 2px;
 }
 
 /* Mobile nav overlay */
@@ -257,9 +260,8 @@ button {
 }
 
 button:hover:not(:disabled) {
-  background: var(--primary-hover);
-  box-shadow: var(--shadow-warm);
-  transform: translateY(-1px);
+  outline: 2px solid var(--primary);
+  outline-offset: 2px;
 }
 
 button:active:not(:disabled) {
@@ -417,9 +419,8 @@ button:disabled {
 
 .form .submit:hover:not(:disabled),
 .form-btn:hover:not(:disabled) {
-  background: var(--primary-hover);
-  box-shadow: var(--shadow-warm-lg);
-  transform: translateY(-1px);
+  outline: 2px solid var(--primary);
+  outline-offset: 2px;
 }
 
 .form .submit:disabled {
@@ -485,9 +486,8 @@ button:disabled {
   box-shadow: var(--shadow-warm);
 }
 .apple-login-button:hover {
-  background: var(--primary-hover);
-  box-shadow: var(--shadow-warm-lg);
-  transform: translateY(-1px);
+  outline: 2px solid var(--primary);
+  outline-offset: 2px;
 }
 
 .google-login-button {
@@ -497,9 +497,8 @@ button:disabled {
   box-shadow: var(--shadow-xs);
 }
 .google-login-button:hover {
-  border-color: var(--primary);
-  box-shadow: 0 0 0 3px var(--primary-light);
-  transform: translateY(-1px);
+  outline: 2px solid var(--primary);
+  outline-offset: 2px;
 }
 
 .apple-icon { color: var(--primary); font-size: 18px; }
@@ -573,8 +572,8 @@ h2 {
   transition: background var(--transition), box-shadow var(--transition);
 }
 .btn-top:hover {
-  background: var(--primary-hover);
-  box-shadow: var(--shadow-warm);
+  outline: 2px solid var(--primary);
+  outline-offset: 2px;
 }
 
 @keyframes gradientAnimation {
@@ -637,7 +636,8 @@ h2 {
 
   .nav-link:hover {
     color: #ffffff;
-    background: rgba(0, 0, 0, 0.12);
+    outline: 2px solid rgba(255, 255, 255, 0.6);
+    outline-offset: 2px;
   }
 
   .nav-link.active {
@@ -733,9 +733,8 @@ h2 {
 }
 .back-btn:hover {
   color: var(--primary);
-  background: var(--primary-light);
-  transform: none;
-  box-shadow: none;
+  outline: 2px solid var(--primary);
+  outline-offset: 2px;
 }
 
 /* ── Secondary page layout ───────────────────────────── */
@@ -841,8 +840,8 @@ h2 {
   flex-shrink: 0;
 }
 .page-link-btn:hover {
-  background: var(--primary);
-  color: #fff;
+  outline: 2px solid var(--primary);
+  outline-offset: 2px;
 }
 
 .page-danger-btn {
@@ -861,9 +860,8 @@ h2 {
   transition: background var(--transition);
 }
 .page-danger-btn:hover {
-  background: rgba(239, 68, 68, 0.14);
-  transform: none;
-  box-shadow: none;
+  outline: 2px solid #ef5350;
+  outline-offset: 2px;
 }
 
 .page-chevron {


### PR DESCRIPTION
## Summary
This PR standardizes the hover state styling across the application by replacing inconsistent background color changes, box shadows, and transforms with a consistent outline-based approach.

## Key Changes
- **Navigation and UI elements**: Replaced `border-color` and `background` hover effects with `outline: 2px solid` and `outline-offset: 2px` for nav links, profile icons, and menu toggles
- **Buttons**: Standardized all button hover states (primary buttons, form buttons, login buttons) to use outline instead of background color changes and shadow effects
- **Secondary buttons**: Updated back button, page link button, and danger button hover states to use the outline approach
- **Close buttons**: Changed the locate hint close button hover state to match the new outline pattern
- **Removed effects**: Eliminated `transform: translateY(-1px)`, `box-shadow` changes, and `background` color transitions in favor of the outline approach

## Implementation Details
- All hover outlines use `2px solid` with `outline-offset: 2px` for consistent spacing
- Color values remain semantically appropriate (e.g., `var(--primary)` for primary buttons, `#ef5350` for danger buttons)
- The outline approach provides better accessibility and visual feedback while maintaining a cleaner, more consistent design language
- Changes applied consistently across desktop and mobile responsive styles

https://claude.ai/code/session_018xvek1BELzPgq6agfqBR5T