### PR TITLE
Add GPS anomaly detection to filter impossible location jumps

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -336,6 +336,12 @@ def haversine(lat1, lon1, lat2, lon2):
 # valores mais baixos deixavam passar oscilações dentro do raio de erro do GPS.
 MIN_GPS_DISTANCE_M = 15.0
 
+# Distância máxima (metros) aceite entre leituras consecutivas. Acima deste
+# valor, é considerado erro de GPS (satélite perdido, salto para outro
+# fornecedor de localização, etc.) e a leitura é descartada. Para um vendedor
+# numa praia, valores > 2 km em 1 segundo são fisicamente impossíveis.
+MAX_GPS_DISTANCE_M = 2000.0
+
 # Gerenciador de WebSockets
 class ConnectionManager:
     def __init__(self):
@@ -1062,14 +1068,15 @@ async def update_vendor_location(
     points = json.loads(active_route.points or "[]")
     last_point = points[-1] if points else None
 
-    # Ignora leituras de GPS demasiado próximas da última posição gravada:
-    # ruído de GPS (poucos metros) não deve ser contabilizado como movimento
-    # nem propagado ao mapa, para não dar a impressão de o vendedor estar
-    # sempre a deslocar-se enquanto está parado.
+    # Ignora leituras de GPS demasiado próximas ou demasiado afastadas:
+    # - Próximas (< 15m): ruído de GPS não deve ser contabilizado como movimento
+    # - Afastadas (> 2km): saltos impossíveis de GPS (erro de satélite, etc.)
     if last_point is not None:
         moved = haversine(last_point["lat"], last_point["lng"], lat, lng)
         if moved < MIN_GPS_DISTANCE_M:
             return {"message": "Localização ignorada (ruído de GPS)"}
+        if moved > MAX_GPS_DISTANCE_M:
+            return {"message": "Localização ignorada (salto de GPS anómalo)"}
 
     vendor.current_lat = lat
     vendor.current_lng = lng


### PR DESCRIPTION
## Summary
Added validation to detect and filter out anomalous GPS readings that represent physically impossible location jumps, improving the reliability of vendor location tracking.

## Key Changes
- Introduced `MAX_GPS_DISTANCE_M` constant (2000m) to define the maximum acceptable distance between consecutive GPS readings
- Enhanced the GPS reading validation logic in `update_vendor_location()` to reject readings that exceed the maximum distance threshold
- Updated comments to clarify that both minimum (noise filtering) and maximum (anomaly detection) distance checks are now performed
- Added error response message for anomalous GPS jumps: "Localização ignorada (salto de GPS anómalo)"

## Implementation Details
The change adds a second validation check after the existing minimum distance check. When a GPS reading indicates movement greater than 2km in a single update (physically impossible for a street vendor), the reading is discarded rather than being recorded. This prevents GPS errors such as satellite loss or location provider switching from corrupting the vendor's route history and map display.

The validation maintains the existing behavior for small movements (< 15m) while adding protection against large erratic jumps that indicate GPS malfunction rather than actual vendor movement.

https://claude.ai/code/session_01NibA28HSRfHKFYQ4JB7pMh