### PR TITLE
Update primary color scheme from teal to red

### DIFF
--- a/mobile/src/index.css
+++ b/mobile/src/index.css
@@ -817,7 +817,7 @@ body {
 
 .profile-input:focus {
   border-color: var(--primary);
-  box-shadow: 0 0 0 3px rgba(10, 147, 150, 0.12);
+  box-shadow: 0 0 0 3px rgba(239, 80, 80, 0.12);
   background: var(--surface);
 }
 

--- a/mobile/src/styles/PlansScreen.css
+++ b/mobile/src/styles/PlansScreen.css
@@ -375,7 +375,7 @@
   align-items: center;
   gap: 8px;
   background: var(--primary-light);
-  border: 1px solid rgba(10, 147, 150, 0.25);
+  border: 1px solid rgba(239, 80, 80, 0.25);
   border-radius: var(--radius-sm);
   padding: 12px 14px;
   font-size: 13px;
@@ -421,7 +421,7 @@
 }
 
 .plans-faq-item[open] {
-  border-color: rgba(10, 147, 150, 0.3);
+  border-color: rgba(239, 80, 80, 0.3);
   background: var(--white);
 }
 

--- a/sunny_sales_web/src/index.css
+++ b/sunny_sales_web/src/index.css
@@ -1,11 +1,11 @@
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Roboto:wght@400;700&display=swap');
 
 :root {
-  --primary: #4BA3C3;
-  --primary-hover: #097b7e;
-  --primary-dark: #2E7A9A;
-  --primary-light: rgba(10, 147, 150, 0.12);
-  --primary-light-solid: #e0f5f5;
+  --primary: #ef5050;
+  --primary-hover: #d93d3d;
+  --primary-dark: #9e2d2d;
+  --primary-light: rgba(239, 80, 80, 0.12);
+  --primary-light-solid: #ffe0e0;
 
   --secondary: #EE9B00;
   --secondary-hover: #d48900;
@@ -31,8 +31,8 @@
   --shadow-sm: 0 2px 8px rgba(0,0,0,0.07), 0 1px 2px rgba(0,0,0,0.04);
   --shadow-md: 0 4px 16px rgba(0,0,0,0.10), 0 2px 4px rgba(0,0,0,0.06);
   --shadow-lg: 0 8px 32px rgba(0,0,0,0.12), 0 4px 8px rgba(0,0,0,0.06);
-  --shadow-warm: 0 4px 24px rgba(10, 147, 150, 0.22);
-  --shadow-warm-lg: 0 8px 40px rgba(10, 147, 150, 0.28);
+  --shadow-warm: 0 4px 24px rgba(239, 80, 80, 0.22);
+  --shadow-warm-lg: 0 8px 40px rgba(239, 80, 80, 0.28);
 
   --radius-xs: 6px;
   --radius-sm: 10px;

--- a/sunny_sales_web/src/pages/Contacto.css
+++ b/sunny_sales_web/src/pages/Contacto.css
@@ -56,7 +56,7 @@
 
 .contacto-input:focus {
   border-color: var(--primary);
-  box-shadow: 0 0 0 3px rgba(10, 147, 150, 0.12);
+  box-shadow: 0 0 0 3px rgba(239, 80, 80, 0.12);
 }
 
 .contacto-select {
@@ -110,14 +110,14 @@
   border-radius: var(--radius-full);
   cursor: pointer;
   transition: background 0.18s, transform 0.15s, box-shadow 0.18s;
-  box-shadow: 0 4px 16px rgba(10, 147, 150, 0.3);
+  box-shadow: 0 4px 16px rgba(239, 80, 80, 0.3);
   align-self: flex-start;
 }
 
 .contacto-btn:hover:not(:disabled) {
   background: var(--primary-dark);
   transform: translateY(-2px);
-  box-shadow: 0 6px 20px rgba(10, 147, 150, 0.4);
+  box-shadow: 0 6px 20px rgba(239, 80, 80, 0.4);
 }
 
 .contacto-btn:disabled {

--- a/sunny_sales_web/src/pages/FAQ.css
+++ b/sunny_sales_web/src/pages/FAQ.css
@@ -43,7 +43,7 @@
 }
 
 .faq-item[open] {
-  border-color: rgba(10, 147, 150, 0.3);
+  border-color: rgba(239, 80, 80, 0.3);
 }
 
 .faq-q {

--- a/sunny_sales_web/src/pages/InfoPage.css
+++ b/sunny_sales_web/src/pages/InfoPage.css
@@ -212,7 +212,7 @@
 /* Accent card */
 .info-card.accent {
   background: var(--primary-light-solid);
-  border-color: rgba(10, 147, 150, 0.25);
+  border-color: rgba(239, 80, 80, 0.25);
   border-top-color: transparent;
 }
 
@@ -300,7 +300,7 @@
   top: 44px;
   bottom: 20px;
   width: 2px;
-  background: linear-gradient(to bottom, var(--primary), rgba(10, 147, 150, 0.08));
+  background: linear-gradient(to bottom, var(--primary), rgba(239, 80, 80, 0.08));
   z-index: 0;
 }
 
@@ -324,7 +324,7 @@
   font-weight: 800;
   font-size: 0.95rem;
   z-index: 1;
-  box-shadow: 0 2px 10px rgba(10, 147, 150, 0.35);
+  box-shadow: 0 2px 10px rgba(239, 80, 80, 0.35);
   flex-shrink: 0;
 }
 

--- a/sunny_sales_web/src/pages/ManageAccount.css
+++ b/sunny_sales_web/src/pages/ManageAccount.css
@@ -255,7 +255,7 @@
 
 .ma-input:focus {
   border-color: var(--primary);
-  box-shadow: 0 0 0 3px rgba(10, 147, 150, 0.12);
+  box-shadow: 0 0 0 3px rgba(239, 80, 80, 0.12);
   background: var(--surface);
 }
 

--- a/sunny_sales_web/src/pages/PaidWeeksScreen.css
+++ b/sunny_sales_web/src/pages/PaidWeeksScreen.css
@@ -241,7 +241,7 @@
   font-size: 1rem;
   flex-shrink: 0;
   text-decoration: none;
-  border: 1.5px solid rgba(10, 147, 150, 0.2);
+  border: 1.5px solid rgba(239, 80, 80, 0.2);
   transition: background var(--transition), box-shadow var(--transition);
 }
 

--- a/sunny_sales_web/src/pages/PlanosVendedores.css
+++ b/sunny_sales_web/src/pages/PlanosVendedores.css
@@ -345,7 +345,7 @@
   align-items: center;
   gap: 10px;
   background: var(--primary-light-solid);
-  border: 1px solid rgba(10, 147, 150, 0.25);
+  border: 1px solid rgba(239, 80, 80, 0.25);
   border-radius: var(--radius-lg);
   padding: 14px 20px;
   font-size: 0.88rem;
@@ -387,7 +387,7 @@
   box-shadow: var(--shadow-xs);
 }
 .pv-faq-item[open] {
-  border-color: rgba(10, 147, 150, 0.3);
+  border-color: rgba(239, 80, 80, 0.3);
 }
 
 .pv-faq-q {

--- a/sunny_sales_web/src/pages/RouteDetail.css
+++ b/sunny_sales_web/src/pages/RouteDetail.css
@@ -83,7 +83,7 @@
 
 .rd-stat-card--accent {
   background: var(--primary-light-solid);
-  border-color: rgba(10, 147, 150, 0.2);
+  border-color: rgba(239, 80, 80, 0.2);
 }
 
 .rd-stat-card--accent .rd-stat-icon {

--- a/sunny_sales_web/src/pages/VendorDashboard.css
+++ b/sunny_sales_web/src/pages/VendorDashboard.css
@@ -320,7 +320,7 @@
   padding: 3px 9px 3px 6px;
   font-size: 0.72rem;
   font-weight: 700;
-  border: 1px solid rgba(10, 147, 150, 0.18);
+  border: 1px solid rgba(239, 80, 80, 0.18);
 }
 
 .vd-payment-badge-icon {
@@ -579,7 +579,7 @@
 }
 
 .vd-quick-card:hover .vd-quick-icon {
-  background: rgba(10, 147, 150, 0.22);
+  background: rgba(239, 80, 80, 0.22);
 }
 
 .vd-quick-label {
@@ -770,7 +770,7 @@
 
 .vd-modal-photo-btn:hover {
   background: var(--primary-light);
-  border-color: rgba(10, 147, 150, 0.3);
+  border-color: rgba(239, 80, 80, 0.3);
   color: var(--primary-dark);
 }
 
@@ -805,7 +805,7 @@
 .vd-modal-input:focus {
   outline: none;
   border-color: var(--primary);
-  box-shadow: 0 0 0 3px rgba(10, 147, 150, 0.12);
+  box-shadow: 0 0 0 3px rgba(239, 80, 80, 0.12);
 }
 
 .vd-modal-pin-row {

--- a/sunny_sales_web/src/pages/VendorPage.css
+++ b/sunny_sales_web/src/pages/VendorPage.css
@@ -225,7 +225,7 @@
 .vendor-textarea:focus {
   outline: none;
   border-color: var(--primary);
-  box-shadow: 0 0 0 3px rgba(10, 147, 150, 0.12);
+  box-shadow: 0 0 0 3px rgba(239, 80, 80, 0.12);
 }
 
 /* ── Status Badges ─────────────────────────────────– */


### PR DESCRIPTION
## Summary
This PR updates the application's primary color scheme from teal (#4BA3C3) to red (#ef5050) across all stylesheets in both the web and mobile applications.

## Key Changes
- **Primary color palette**: Changed from teal to red
  - `--primary`: #4BA3C3 → #ef5050
  - `--primary-hover`: #097b7e → #d93d3d
  - `--primary-dark`: #2E7A9A → #9e2d2d
  - `--primary-light`: rgba(10, 147, 150, 0.12) → rgba(239, 80, 80, 0.12)
  - `--primary-light-solid`: #e0f5f5 → #ffe0e0

- **Shadow colors**: Updated warm shadow colors to use the new red primary color
  - `--shadow-warm` and `--shadow-warm-lg` now use rgba(239, 80, 80, ...) instead of rgba(10, 147, 150, ...)

- **Component-specific updates**: Updated all hardcoded color references in component stylesheets to use the new red color scheme:
  - VendorDashboard.css
  - Contacto.css
  - InfoPage.css
  - PlansScreen.css (mobile)
  - PlanosVendedores.css
  - FAQ.css
  - ManageAccount.css
  - PaidWeeksScreen.css
  - RouteDetail.css
  - VendorPage.css

## Implementation Details
All color changes maintain the same opacity levels and color relationships as the original teal scheme, ensuring consistent visual hierarchy and accessibility throughout the application. The update is comprehensive, covering both CSS custom properties and hardcoded color values in focus states, hover effects, borders, and shadows.

https://claude.ai/code/session_01WFJpmCQR8WEzTLwoAS1cbv