### PR TITLE
Increase nav logo height from 38px to 56px

### DIFF
--- a/sunny_sales_web/src/index.css
+++ b/sunny_sales_web/src/index.css
@@ -106,7 +106,7 @@ body {
 }
 
 .nav-logo-img {
-  height: 38px;
+  height: 56px;
   width: auto;
   flex-shrink: 0;
 }


### PR DESCRIPTION
## Summary
Updated the navigation logo image height to improve visibility and visual prominence in the header.

## Changes
- Increased `.nav-logo-img` height from 38px to 56px
- Width remains set to `auto` to maintain aspect ratio

## Details
This change makes the logo more prominent in the navigation bar while preserving its aspect ratio through the `auto` width setting. The `flex-shrink: 0` property ensures the logo maintains its new size without being compressed by flex layout.

https://claude.ai/code/session_01XerTs2ctgL6VhnyNNGHgAM