### PR TITLE
Refactor filter sheet layout for better scrolling behavior

### DIFF
--- a/sunny_sales_web/src/pages/ModernMapLayout.css
+++ b/sunny_sales_web/src/pages/ModernMapLayout.css
@@ -195,11 +195,19 @@ body {
 .filter-sheet {
   width: 100%;
   max-width: 480px;
+  max-height: 85vh;
   margin: 0 auto;
   background: var(--surface);
   border-radius: var(--radius-xl) var(--radius-xl) 0 0;
+  display: flex;
+  flex-direction: column;
   overflow: hidden;
   animation: sheetSlideUp 0.28s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.filter-sheet-body {
+  overflow-y: auto;
+  flex: 1;
 }
 
 @keyframes sheetSlideUp {
@@ -221,6 +229,7 @@ body {
   align-items: center;
   justify-content: space-between;
   padding: 12px 20px 8px;
+  flex-shrink: 0;
 }
 
 .filter-sheet-label {
@@ -249,32 +258,6 @@ body {
 
 .filter-back-btn:hover {
   background: var(--surface-alt);
-  color: var(--primary);
-  transform: none;
-  box-shadow: none;
-}
-
-.filter-close-btn {
-  width: 28px;
-  height: 28px;
-  min-height: auto;
-  min-width: auto;
-  padding: 0;
-  background: var(--surface-alt);
-  border: none;
-  border-radius: var(--radius-full);
-  font-size: 1.15rem;
-  color: var(--text-secondary);
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  transition: background var(--transition), color var(--transition);
-  line-height: 1;
-}
-
-.filter-close-btn:hover {
-  background: var(--primary-light);
   color: var(--primary);
   transform: none;
   box-shadow: none;
@@ -425,6 +408,7 @@ body {
   gap: 12px;
   padding: 14px 20px max(16px, env(safe-area-inset-bottom, 16px));
   border-top: 1px solid var(--border);
+  flex-shrink: 0;
 }
 
 .filter-reset-all-btn {

--- a/sunny_sales_web/src/pages/ModernMapLayout.jsx
+++ b/sunny_sales_web/src/pages/ModernMapLayout.jsx
@@ -650,62 +650,57 @@ export default function ModernMapLayout() {
                     <span>Voltar</span>
                   </button>
                   <span className="filter-sheet-label">Filtrar por:</span>
-                  <button
-                    className="filter-close-btn"
-                    onClick={() => setFilterOpen(false)}
-                    aria-label="Fechar"
-                  >
-                    ×
-                  </button>
                 </div>
 
-                {/* Products section */}
-                <div className="filter-section">
-                  <div className="filter-section-row">
-                    <span className="filter-section-title">Vendedores</span>
+                <div className="filter-sheet-body">
+                  {/* Products section */}
+                  <div className="filter-section">
+                    <div className="filter-section-row">
+                      <span className="filter-section-title">Vendedores</span>
+                    </div>
+                    {PRODUCTS.map((p) => {
+                      const active = pendingProducts.includes(p);
+                      return (
+                        <button
+                          key={p}
+                          className={`filter-option${active ? ' active' : ''}`}
+                          onClick={() => togglePendingProduct(p)}
+                        >
+                          <span>{p}</span>
+                          {active && <FiCheck size={14} className="filter-check" />}
+                        </button>
+                      );
+                    })}
                   </div>
-                  {PRODUCTS.map((p) => {
-                    const active = pendingProducts.includes(p);
-                    return (
-                      <button
-                        key={p}
-                        className={`filter-option${active ? ' active' : ''}`}
-                        onClick={() => togglePendingProduct(p)}
-                      >
-                        <span>{p}</span>
-                        {active && <FiCheck size={14} className="filter-check" />}
-                      </button>
-                    );
-                  })}
-                </div>
 
-                <div className="filter-divider" />
+                  <div className="filter-divider" />
 
-                {/* Distance section */}
-                <div className="filter-section">
-                  <div className="filter-section-row">
-                    <span className="filter-section-title">
-                      <FiMapPin size={14} style={{ marginRight: 6 }} />
-                      Distância
-                    </span>
+                  {/* Distance section */}
+                  <div className="filter-section">
+                    <div className="filter-section-row">
+                      <span className="filter-section-title">
+                        <FiMapPin size={14} style={{ marginRight: 6 }} />
+                        Distância
+                      </span>
+                    </div>
+                    <div className="filter-distance-row">
+                      {DISTANCE_OPTIONS.map((opt) => (
+                        <button
+                          key={opt.label}
+                          className={`filter-distance-opt${pendingDistance === opt.value ? ' active' : ''}`}
+                          onClick={() => setPendingDistance(opt.value)}
+                        >
+                          {pendingDistance === opt.value && <FiCheck size={12} />}
+                          {opt.label}
+                        </button>
+                      ))}
+                    </div>
+                    {pendingDistance !== null && !clientPos && (
+                      <p className="filter-distance-hint">
+                        Ative a localização para filtrar por distância
+                      </p>
+                    )}
                   </div>
-                  <div className="filter-distance-row">
-                    {DISTANCE_OPTIONS.map((opt) => (
-                      <button
-                        key={opt.label}
-                        className={`filter-distance-opt${pendingDistance === opt.value ? ' active' : ''}`}
-                        onClick={() => setPendingDistance(opt.value)}
-                      >
-                        {pendingDistance === opt.value && <FiCheck size={12} />}
-                        {opt.label}
-                      </button>
-                    ))}
-                  </div>
-                  {pendingDistance !== null && !clientPos && (
-                    <p className="filter-distance-hint">
-                      Ative a localização para filtrar por distância
-                    </p>
-                  )}
                 </div>
 
                 {/* Footer */}


### PR DESCRIPTION
## Summary
Restructured the filter sheet component to implement proper scrolling behavior by separating the layout into fixed header/footer sections with a scrollable body area.

## Key Changes
- **Layout restructuring**: Wrapped filter sections in a new `.filter-sheet-body` container to enable independent scrolling of content while keeping header and footer fixed
- **CSS flexbox improvements**: 
  - Added `display: flex` and `flex-direction: column` to `.filter-sheet`
  - Set `max-height: 85vh` to constrain sheet height on viewport
  - Applied `flex-shrink: 0` to header and footer to prevent them from shrinking
  - Made `.filter-sheet-body` scrollable with `overflow-y: auto` and `flex: 1`
- **Removed close button**: Deleted the `.filter-close-btn` element and its associated styles (28px circular button with × icon) from the header, simplifying the UI

## Implementation Details
- The filter sheet now properly handles content overflow by scrolling only the middle section (products and distance filters) while keeping the header ("Voltar" button and "Filtrar por:" label) and footer (action buttons) always visible
- All filter content is now indented within the scrollable body area, improving visual hierarchy
- The changes maintain the existing animation and styling while improving UX for mobile devices with limited viewport height

https://claude.ai/code/session_01TNBej6yT4U9r9f9rD1C7DY