### PR TITLE
Fix: não terminar sessão do vendedor em refresh por erro de rede/cold start

### DIFF
--- a/sunny_sales_web/src/App.jsx
+++ b/sunny_sales_web/src/App.jsx
@@ -63,6 +63,7 @@ function AppLayout() {
       setIsLoggedIn(false);
       return;
     }
+    setIsLoggedIn(true);
     axios
       .get(`${BASE_URL}/vendors/me`, {
         headers: { Authorization: `Bearer ${token}` },
@@ -71,12 +72,18 @@ function AppLayout() {
         localStorage.setItem('user', JSON.stringify(res.data));
         setIsLoggedIn(true);
       })
-      .catch(() => {
-        localStorage.removeItem('token');
-        localStorage.removeItem('user');
-        setIsLoggedIn(false);
+      .catch((err) => {
+        // Só termina a sessão se o servidor recusar explicitamente o token
+        // (401/403). Erros de rede, timeouts ou indisponibilidade temporária
+        // do backend (ex.: "cold start") não devem deslogar o vendedor.
+        const status = err.response?.status;
+        if (status === 401 || status === 403) {
+          localStorage.removeItem('token');
+          localStorage.removeItem('user');
+          setIsLoggedIn(false);
+        }
       });
-  }, [location]);
+  }, []);
 
   // Close mobile menu on route change
   useEffect(() => {


### PR DESCRIPTION
A validação de sessão em App.jsx tratava qualquer falha no GET /vendors/me
(timeout, erro de rede, indisponibilidade temporária do backend) como token
inválido e limpava o localStorage, deslogando o vendedor sempre que a página
era recarregada. Agora só se faz logout em resposta explícita 401/403, e a
validação corre apenas uma vez no mount em vez de em cada mudança de rota.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01YVHSJvFfxioyCwEvUFj1L1