### PR TITLE
Mostrar aviso claro quando a sessão do vendedor é terminada

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -927,7 +927,7 @@ def list_vendors(
 # --------------------------
 # Detalhe público de um vendedor
 # --------------------------
-@app.get("/vendors/{vendor_id}", response_model=schemas.VendorPublicOut)
+@app.get("/vendors/{vendor_id:int}", response_model=schemas.VendorPublicOut)
 def get_vendor(vendor_id: int, db: Session = Depends(get_db)):
     vendor = db.query(models.Vendor).filter(models.Vendor.id == vendor_id).first()
     if not vendor:

--- a/sunny_sales_web/src/main.jsx
+++ b/sunny_sales_web/src/main.jsx
@@ -1,6 +1,7 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
+import './sessionAuth.js'
 import App from './App.jsx'
 import ErrorBoundary from './components/ErrorBoundary.jsx'
 

--- a/sunny_sales_web/src/pages/VendorDashboard.jsx
+++ b/sunny_sales_web/src/pages/VendorDashboard.jsx
@@ -505,7 +505,7 @@ export default function VendorDashboard() {
             <span className="vd-quick-label">Produtos</span>
             <span className="vd-quick-desc">Adicionar e gerir produtos</span>
           </button>
-          <button className="vd-quick-card" onClick={paySubscription}>
+          <button className="vd-quick-card" onClick={() => paySubscription()}>
             <span className="vd-quick-icon"><FiCheckSquare /></span>
             <span className="vd-quick-label">Ativar Subscrição</span>
             <span className="vd-quick-desc">Ativar ou renovar o plano</span>

--- a/sunny_sales_web/src/pages/VendorLogin.jsx
+++ b/sunny_sales_web/src/pages/VendorLogin.jsx
@@ -1,9 +1,10 @@
 // (em português) Página Web para login de vendedores
 import './VendorLogin.css';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import axios from 'axios';
 import { BASE_URL } from '../config';
+import { SESSION_ENDED_MESSAGE_KEY } from '../sessionAuth';
 import LoadingDots from '../components/LoadingDots';
 
 // Componente de login dedicado aos vendedores
@@ -13,6 +14,16 @@ export default function VendorLogin() {
   const [error, setError] = useState(null);
   const [loading, setLoading] = useState(false);
   const navigate = useNavigate();
+
+  // Mostra, uma única vez, o aviso deixado pelo interceptor de sessão
+  // (ex: sessão terminada por login noutro dispositivo ou token expirado).
+  useEffect(() => {
+    const sessionMessage = sessionStorage.getItem(SESSION_ENDED_MESSAGE_KEY);
+    if (sessionMessage) {
+      setError(sessionMessage);
+      sessionStorage.removeItem(SESSION_ENDED_MESSAGE_KEY);
+    }
+  }, []);
 
   // (em português) Decodifica o token JWT para extrair o ID do vendedor
   const getVendorIdFromToken = (token) => {

--- a/sunny_sales_web/src/sessionAuth.js
+++ b/sunny_sales_web/src/sessionAuth.js
@@ -1,0 +1,37 @@
+// (em português) Interceptor global de axios: deteta quando o backend rejeita
+// o token de sessão do vendedor (token inválido/expirado, ou sessão terminada
+// por login noutro dispositivo) e substitui a mensagem técnica por uma
+// mensagem percetível, limpando a sessão local e redirecionando para o login.
+import axios from 'axios';
+
+const SESSION_ERROR_MESSAGES = {
+  'Session invalidated': 'A tua sessão foi terminada porque iniciaste sessão noutro dispositivo.',
+  'Invalid token': 'A tua sessão expirou. Por favor inicia sessão novamente.',
+  'Invalid token signature': 'A tua sessão expirou. Por favor inicia sessão novamente.',
+  'Token expired': 'A tua sessão expirou. Por favor inicia sessão novamente.',
+  'Vendor not found': 'A tua sessão expirou. Por favor inicia sessão novamente.',
+  'Not authenticated': 'A tua sessão expirou. Por favor inicia sessão novamente.',
+};
+
+export const SESSION_ENDED_MESSAGE_KEY = 'sessionEndedMessage';
+
+axios.interceptors.response.use(
+  (res) => res,
+  (err) => {
+    const status = err.response?.status;
+    const detail = err.response?.data?.detail;
+    const hadAuthHeader = !!err.config?.headers?.Authorization;
+    const friendlyMessage = SESSION_ERROR_MESSAGES[detail];
+
+    if ((status === 401 || status === 403) && hadAuthHeader && friendlyMessage) {
+      localStorage.removeItem('token');
+      localStorage.removeItem('user');
+      sessionStorage.setItem(SESSION_ENDED_MESSAGE_KEY, friendlyMessage);
+      err.response.data.detail = friendlyMessage;
+      if (!window.location.hash.startsWith('#/vendor-login')) {
+        window.location.hash = '#/vendor-login';
+      }
+    }
+    return Promise.reject(err);
+  }
+);


### PR DESCRIPTION
Quando o token deixa de ser válido (sessão substituída por login noutro
dispositivo, token expirado, etc.) o backend devolvia mensagens técnicas
como "Invalid token" que apareciam diretamente na interface (ex. ao criar
um produto). Um interceptor global de axios agora limpa a sessão local,
substitui essas mensagens por um aviso percetível e redireciona para o
login, onde o aviso é mostrado uma única vez.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KYJrPqWJQPrtmNYeCth7Nk