### PR TITLE
Melhorar tracking de localização em background

### DIFF
--- a/mobile/android/app/src/main/java/com/sunnysales/vendor/LocationForegroundService.java
+++ b/mobile/android/app/src/main/java/com/sunnysales/vendor/LocationForegroundService.java
@@ -8,6 +8,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.location.Location;
 import android.os.Build;
+import android.os.Handler;
 import android.os.IBinder;
 import android.os.Looper;
 import android.os.PowerManager;
@@ -37,6 +38,8 @@ public class LocationForegroundService extends Service {
     private LocationCallback locationCallback;
     private PowerManager.WakeLock wakeLock;
     private Location lastAcceptedLocation;
+    private Handler handler;
+    private static final long WAKELOCK_RENEW_INTERVAL = 55 * 60 * 1000L;
 
     public interface LocationListener {
         void onLocationUpdate(double lat, double lng);
@@ -53,6 +56,7 @@ public class LocationForegroundService extends Service {
         super.onCreate();
         createNotificationChannel();
         fusedClient = LocationServices.getFusedLocationProviderClient(this);
+        handler = new Handler(Looper.getMainLooper());
     }
 
     @Override
@@ -71,6 +75,7 @@ public class LocationForegroundService extends Service {
         }
 
         acquireWakeLock();
+        scheduleWakeLockRenewal();
         startLocationUpdates();
         return START_STICKY;
     }
@@ -84,13 +89,26 @@ public class LocationForegroundService extends Service {
                 PowerManager.PARTIAL_WAKE_LOCK,
                 "SunnySales:LocationWakeLock"
         );
-        wakeLock.acquire(10 * 60 * 60 * 1000L);
+        wakeLock.acquire(1 * 60 * 60 * 1000L);
+    }
+
+    private void scheduleWakeLockRenewal() {
+        handler.postDelayed(this::renewWakeLock, WAKELOCK_RENEW_INTERVAL);
+    }
+
+    private void renewWakeLock() {
+        if (wakeLock != null && wakeLock.isHeld()) {
+            wakeLock.release();
+        }
+        acquireWakeLock();
+        scheduleWakeLockRenewal();
     }
 
     private void startLocationUpdates() {
-        LocationRequest request = new LocationRequest.Builder(1000)
+        LocationRequest request = new LocationRequest.Builder(5000)
                 .setPriority(Priority.PRIORITY_HIGH_ACCURACY)
-                .setMinUpdateIntervalMillis(1000)
+                .setMinUpdateIntervalMillis(2000)
+                .setMaxUpdateDelayMillis(30000)
                 .setMinUpdateDistanceMeters(MIN_UPDATE_DISTANCE_METERS)
                 .build();
 
@@ -159,6 +177,9 @@ public class LocationForegroundService extends Service {
     @Override
     public void onDestroy() {
         super.onDestroy();
+        if (handler != null) {
+            handler.removeCallbacksAndMessages(null);
+        }
         if (fusedClient != null && locationCallback != null) {
             fusedClient.removeLocationUpdates(locationCallback);
         }

--- a/mobile/android/app/src/main/java/com/sunnysales/vendor/LocationPlugin.java
+++ b/mobile/android/app/src/main/java/com/sunnysales/vendor/LocationPlugin.java
@@ -9,11 +9,34 @@ import com.getcapacitor.PluginCall;
 import com.getcapacitor.PluginMethod;
 import com.getcapacitor.annotation.CapacitorPlugin;
 
-@CapacitorPlugin(name = "LocationTracker")
+@CapacitorPlugin(name = "LocationTracker", permissions = {
+        android.Manifest.permission.ACCESS_FINE_LOCATION,
+        android.Manifest.permission.ACCESS_COARSE_LOCATION,
+        android.Manifest.permission.ACCESS_BACKGROUND_LOCATION
+})
 public class LocationPlugin extends Plugin {
 
     @PluginMethod
     public void startTracking(PluginCall call) {
+        requestPermissions(call);
+    }
+
+    @Override
+    protected void handleRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
+        super.handleRequestPermissionsResult(requestCode, permissions, grantResults);
+        PluginCall savedCall = getSavedCall();
+        if (savedCall == null) {
+            return;
+        }
+
+        if (getPermissionState("ACCESS_FINE_LOCATION") == PermissionState.GRANTED) {
+            startLocationTracking(savedCall);
+        } else {
+            savedCall.reject("Permissão de localização negada");
+        }
+    }
+
+    private void startLocationTracking(PluginCall call) {
         LocationForegroundService.setLocationListener((lat, lng) -> {
             JSObject data = new JSObject();
             data.put("lat", lat);


### PR DESCRIPTION
- Aumentar intervalo de atualização de localização (1s → 5s)
- Adicionar maxUpdateDelayMillis (30s) para garantir updates regulares em background
- Implementar renovação periódica do WakeLock para manter o serviço ativo
- Adicionar pedido explícito de permissão de background location
- Reduzir tempo máximo do WakeLock de 10h para 1h com renovação automática

Isto resolve o problema de a app deixar de atualizar a localização do vendedor quando minimizada.

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PYt2hh3EhZ8iUHM14hCvdy