### PR TITLE
Fix LocationPlugin annotation errors

### DIFF
--- a/mobile/android/app/src/main/java/com/sunnysales/vendor/LocationPlugin.java
+++ b/mobile/android/app/src/main/java/com/sunnysales/vendor/LocationPlugin.java
@@ -4,15 +4,17 @@ import android.content.Intent;
 import android.os.Build;
 
 import com.getcapacitor.JSObject;
+import com.getcapacitor.PermissionState;
 import com.getcapacitor.Plugin;
 import com.getcapacitor.PluginCall;
 import com.getcapacitor.PluginMethod;
 import com.getcapacitor.annotation.CapacitorPlugin;
+import com.getcapacitor.annotation.Permission;
 
 @CapacitorPlugin(name = "LocationTracker", permissions = {
-        android.Manifest.permission.ACCESS_FINE_LOCATION,
-        android.Manifest.permission.ACCESS_COARSE_LOCATION,
-        android.Manifest.permission.ACCESS_BACKGROUND_LOCATION
+        @Permission(alias = "ACCESS_FINE_LOCATION", strings = { android.Manifest.permission.ACCESS_FINE_LOCATION }),
+        @Permission(alias = "ACCESS_COARSE_LOCATION", strings = { android.Manifest.permission.ACCESS_COARSE_LOCATION }),
+        @Permission(alias = "ACCESS_BACKGROUND_LOCATION", strings = { android.Manifest.permission.ACCESS_BACKGROUND_LOCATION })
 })
 public class LocationPlugin extends Plugin {
 


### PR DESCRIPTION
- Add missing PermissionState import from Capacitor
- Add Permission annotation import
- Convert permission strings to proper @Permission annotation syntax
- Each permission now uses @Permission with alias and strings array

This fixes the "annotation value must be an annotation" compilation errors
and the "cannot find symbol PermissionState" error.

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015KxceDHompGuUKX57kHgqt