### PR TITLE
Fix npm install network errors in GitHub Actions

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -26,7 +26,11 @@ jobs:
 
       - name: Install dependencies
         working-directory: mobile
-        run: npm install
+        run: |
+          npm config set fetch-timeout 60000
+          npm config set fetch-retry-mintimeout 20000
+          npm config set fetch-retry-maxtimeout 120000
+          npm ci --prefer-offline --no-audit
 
       - name: Build React
         working-directory: mobile


### PR DESCRIPTION
Replace 'npm install' with 'npm ci' for more reliable CI builds and add npm configuration to handle network timeouts:
- Set fetch-timeout to 60 seconds (default is 30s)
- Set fetch-retry timeouts with min 20s and max 120s
- Use --prefer-offline to use cache when possible
- Use --no-audit to skip security audit (can add to separate step if needed)

This resolves ECONNRESET errors that occur during package installation in CI environments.

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Vu6dZ4FiBySTag6aHJfNUR