### PR TITLE
Increase PinColorPicker grid columns from 4 to 8

### DIFF
--- a/mobile/src/components/PinColorPicker.css
+++ b/mobile/src/components/PinColorPicker.css
@@ -79,7 +79,7 @@
 
 .pcp-colors-grid {
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
+  grid-template-columns: repeat(8, 1fr);
   gap: 8px;
 }
 

--- a/sunny_sales_web/src/components/PinColorPicker.css
+++ b/sunny_sales_web/src/components/PinColorPicker.css
@@ -79,7 +79,7 @@
 
 .pcp-colors-grid {
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
+  grid-template-columns: repeat(8, 1fr);
   gap: 8px;
 }
 


### PR DESCRIPTION
## Summary
Updated the PinColorPicker color grid layout to display 8 columns instead of 4, allowing for a wider color palette display across both mobile and web applications.

## Changes
- Modified `.pcp-colors-grid` CSS grid layout in `mobile/src/components/PinColorPicker.css`
  - Changed `grid-template-columns` from `repeat(4, 1fr)` to `repeat(8, 1fr)`
- Applied the same layout change to `sunny_sales_web/src/components/PinColorPicker.css`

## Details
This change doubles the number of columns in the color picker grid, enabling a more compact horizontal layout that displays twice as many color options per row. The 8px gap between items remains unchanged, maintaining consistent spacing throughout the grid.

https://claude.ai/code/session_017GooWW5Zv7zg1PpMWpWQHq