### PR TITLE
Consolidate favicon and logo assets to single logofinal.png

### DIFF
--- a/mobile/index.html
+++ b/mobile/index.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     <meta name="theme-color" content="#4BA3C3" />
-    <link rel="icon" type="image/x-icon" href="/favicon.ico" />
-    <link rel="apple-touch-icon" href="/logo-icon.png" />
+    <link rel="icon" type="image/png" href="/logofinal.png" />
+    <link rel="apple-touch-icon" href="/logofinal.png" />
     <title>Sunny Sales</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/sunny_sales_web/index.html
+++ b/sunny_sales_web/index.html
@@ -2,8 +2,8 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/x-icon" href="/favicon.ico" />
-    <link rel="apple-touch-icon" href="/logo-icon.png" />
+    <link rel="icon" type="image/png" href="/logofinal.png" />
+    <link rel="apple-touch-icon" href="/logofinal.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Sunny Sales</title>
   </head>

--- a/sunny_sales_web/src/App.jsx
+++ b/sunny_sales_web/src/App.jsx
@@ -116,7 +116,7 @@ function AppLayout() {
     <div className="wrapper">
       <nav className="navbar">
         <Link className="nav-logo" to="/">
-          <img src="/logo-header.png" alt="Sunny Sales" className="nav-logo-img" />
+          <img src="/logofinal.png" alt="Sunny Sales" className="nav-logo-img" />
           Sunny Sales
         </Link>
 


### PR DESCRIPTION
## Summary
This PR consolidates the application's favicon and logo assets by replacing multiple image files with a single unified `logofinal.png` file across both the mobile and web versions of the application.

## Key Changes
- Updated favicon references from `/favicon.ico` to `/logofinal.png` with image type changed from `image/x-icon` to `image/png` in both `mobile/index.html` and `sunny_sales_web/index.html`
- Unified apple-touch-icon references to use `/logofinal.png` instead of `/logo-icon.png` in both HTML files
- Updated the navigation logo image source in `sunny_sales_web/src/App.jsx` from `/logo-header.png` to `/logofinal.png`

## Implementation Details
- All three previously used image assets (`favicon.ico`, `logo-icon.png`, and `logo-header.png`) are now replaced with a single `logofinal.png` file
- This change applies consistently across both mobile and web applications
- The favicon type attribute was updated to reflect the PNG format

https://claude.ai/code/session_01Nm4j1o6o24AQeUYgJjt4Bs