### PR TITLE
Update logo filename from logofinal.png to logo.png

### DIFF
--- a/mobile/index.html
+++ b/mobile/index.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     <meta name="theme-color" content="#4BA3C3" />
-    <link rel="icon" type="image/png" href="/logofinal.png" />
-    <link rel="apple-touch-icon" href="/logofinal.png" />
+    <link rel="icon" type="image/png" href="/logo.png" />
+    <link rel="apple-touch-icon" href="/logo.png" />
     <title>Sunny Sales</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/sunny_sales_web/index.html
+++ b/sunny_sales_web/index.html
@@ -2,8 +2,8 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/png" href="/logofinal.png" />
-    <link rel="apple-touch-icon" href="/logofinal.png" />
+    <link rel="icon" type="image/png" href="/logo.png" />
+    <link rel="apple-touch-icon" href="/logo.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Sunny Sales</title>
   </head>

--- a/sunny_sales_web/src/App.jsx
+++ b/sunny_sales_web/src/App.jsx
@@ -116,7 +116,7 @@ function AppLayout() {
     <div className="wrapper">
       <nav className="navbar">
         <Link className="nav-logo" to="/">
-          <img src="/logofinal.png" alt="Sunny Sales" className="nav-logo-img" />
+          <img src="/logo.png" alt="Sunny Sales" className="nav-logo-img" />
           Sunny Sales
         </Link>
 


### PR DESCRIPTION
## Summary
This PR updates all references to the application logo from `logofinal.png` to `logo.png` across the codebase.

## Changes Made
- Updated favicon and apple-touch-icon references in `mobile/index.html`
- Updated favicon and apple-touch-icon references in `sunny_sales_web/index.html`
- Updated logo image source in the navigation bar component (`sunny_sales_web/src/App.jsx`)

## Details
All four instances of the logo filename have been renamed to use the simpler `logo.png` filename instead of `logofinal.png`. This change affects:
- Browser favicon references (2 files)
- Apple touch icon references (2 files)
- Navigation bar logo display (1 component)

The change assumes that the logo asset has been renamed or moved to the new filename in the public assets directory.

https://claude.ai/code/session_01JQcYZofmZ28EPEbsFQrLeY