### PR TITLE
Update logo asset filename from logo.png to logosite.png

### DIFF
--- a/mobile/index.html
+++ b/mobile/index.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     <meta name="theme-color" content="#4BA3C3" />
-    <link rel="icon" type="image/png" href="/logo.png" />
-    <link rel="apple-touch-icon" href="/logo.png" />
+    <link rel="icon" type="image/png" href="/logosite.png" />
+    <link rel="apple-touch-icon" href="/logosite.png" />
     <title>Sunny Sales</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/sunny_sales_web/index.html
+++ b/sunny_sales_web/index.html
@@ -2,8 +2,8 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/png" href="/logo.png" />
-    <link rel="apple-touch-icon" href="/logo.png" />
+    <link rel="icon" type="image/png" href="/logosite.png" />
+    <link rel="apple-touch-icon" href="/logosite.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Sunny Sales</title>
   </head>

--- a/sunny_sales_web/src/App.jsx
+++ b/sunny_sales_web/src/App.jsx
@@ -116,7 +116,7 @@ function AppLayout() {
     <div className="wrapper">
       <nav className="navbar">
         <Link className="nav-logo" to="/">
-          <img src="/logo.png" alt="Sunny Sales" className="nav-logo-img" />
+          <img src="/logosite.png" alt="Sunny Sales" className="nav-logo-img" />
           Sunny Sales
         </Link>
 


### PR DESCRIPTION
## Summary
Updated all references to the application logo asset from `logo.png` to `logosite.png` across the codebase.

## Changes Made
- Updated favicon and apple-touch-icon references in `mobile/index.html`
- Updated favicon and apple-touch-icon references in `sunny_sales_web/index.html`
- Updated logo image source in the navigation bar component (`sunny_sales_web/src/App.jsx`)

## Details
This change ensures consistent branding by using the renamed logo asset `logosite.png` instead of the previous `logo.png` filename. The updates cover:
- HTML metadata (favicon and iOS home screen icon)
- Navigation bar logo display in the React application

All three locations that reference the logo asset have been updated to maintain consistency across the mobile and web versions of the application.

https://claude.ai/code/session_0142vvFU6gg5JkMPmnGZuSF1