### PR TITLE
Replace paySubscription() with navigation to plans page

### DIFF
--- a/sunny_sales_web/src/pages/VendorDashboard.jsx
+++ b/sunny_sales_web/src/pages/VendorDashboard.jsx
@@ -576,7 +576,7 @@ export default function VendorDashboard() {
             <span className="vd-quick-label">Produtos</span>
             <span className="vd-quick-desc">Adicionar e gerir produtos</span>
           </button>
-          <button className="vd-quick-card" onClick={() => paySubscription()}>
+          <button className="vd-quick-card" onClick={() => navigate('/planos')}>
             <span className="vd-quick-icon"><FiCheckSquare /></span>
             <span className="vd-quick-label">Ativar Subscrição</span>
             <span className="vd-quick-desc">Ativar ou renovar o plano</span>


### PR DESCRIPTION
## Summary
Updated the subscription activation button in the Vendor Dashboard to navigate to the plans page instead of calling the `paySubscription()` function.

## Changes
- Modified the "Ativar Subscrição" (Activate Subscription) button click handler to use `navigate('/planos')` instead of `paySubscription()`
- This change redirects users to the plans page where they can view and select subscription options

## Implementation Details
- The button now uses React Router's `navigate` function to route to the `/planos` route
- This provides a more direct user flow for subscription management compared to the previous function call

https://claude.ai/code/session_01Bpe3abBSoimn7Gh2HnaCqo