### PR TITLE
Security hardening and test infrastructure improvements

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,41 @@
+# Exemplo de variáveis de ambiente do backend Sunny Sales.
+# Copia para `.env` e preenche com valores reais. NUNCA commitar o `.env`.
+
+# --- Base de dados ---
+# PostgreSQL em produção; se vazio, cai para SQLite local (./app.db).
+DATABASE_URL=postgresql+psycopg2://user:password@host:5432/dbname
+
+# --- Segurança ---
+# Chave para assinar tokens JWT. OBRIGATÓRIA em produção.
+# Gera uma com: python -c "import secrets; print(secrets.token_hex(32))"
+SECRET_KEY=
+# Token para os endpoints de administração (/admin/*, ativação manual).
+ADMIN_TOKEN=
+
+# --- CORS / Hosts ---
+# Lista separada por vírgulas das origens autorizadas do frontend.
+ALLOWED_ORIGINS=https://o-teu-dominio.com
+# Hosts adicionais autorizados (TrustedHostMiddleware), separados por vírgulas.
+ALLOWED_HOSTS=o-teu-dominio.com
+
+# --- URLs da aplicação ---
+BASE_APP_URL=https://o-teu-dominio.com
+
+# --- Email (Resend) ---
+RESEND_API_KEY=
+RESEND_FROM=Sunny Sales <onboarding@resend.dev>
+CONTACT_EMAIL_TO=sunnysales.geral@gmail.com
+
+# --- Stripe ---
+STRIPE_API_KEY=
+STRIPE_WEBHOOK_SECRET=
+SUCCESS_URL=https://o-teu-dominio.com/success
+CANCEL_URL=https://o-teu-dominio.com/cancel
+STRIPE_PRICE_ID_SEMANAL=
+STRIPE_PRICE_ID_QUINZENAL=
+STRIPE_PRICE_ID_MENSAL=
+
+# --- Supabase (armazenamento de ficheiros, opcional) ---
+# Se não definido, os ficheiros são guardados localmente.
+SUPABASE_URL=
+SUPABASE_SERVICE_ROLE_KEY=

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -1,0 +1,28 @@
+name: Backend Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run tests
+        run: pytest -q

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -377,12 +377,17 @@ manager = ConnectionManager()
 SECRET_KEY = os.getenv("SECRET_KEY", "")
 if not SECRET_KEY:
     import warnings
+    import secrets as _secrets
     warnings.warn(
-        "SECRET_KEY não está definida. Usar um valor aleatório em produção.",
+        "SECRET_KEY não está definida — a gerar uma chave aleatória temporária. "
+        "Define SECRET_KEY em produção para manter as sessões válidas entre reinícios.",
         RuntimeWarning,
         stacklevel=1,
     )
-    SECRET_KEY = "dev-insecure-secret-change-in-production"
+    # Nunca usar um valor fixo/conhecido como fallback: permitiria forjar tokens
+    # JWT. Gerar uma chave aleatória por arranque é seguro (no máximo invalida
+    # sessões existentes ao reiniciar quando SECRET_KEY não está configurada).
+    SECRET_KEY = _secrets.token_hex(32)
 bearer_scheme = HTTPBearer(auto_error=False)
 
 def _b64(data: dict | bytes) -> str:
@@ -1578,7 +1583,9 @@ def create_checkout_session(
         )
         return {"checkout_url": session.url}
     except Exception as exc:
-        raise HTTPException(status_code=500, detail=str(exc))
+        # Não expor a mensagem de erro interna do Stripe ao cliente.
+        security_logger.error(f"Stripe checkout error for vendor {vendor_id}: {exc}")
+        raise HTTPException(status_code=502, detail="Erro ao criar sessão de pagamento")
 
 # --------------------------
 # WebSocket para localização em tempo real
@@ -1980,9 +1987,14 @@ if WEB_DIST.is_dir():
 
     @app.get("/{path_name:path}", response_class=HTMLResponse, include_in_schema=False)
     async def serve_spa(path_name: str):
-        file_path = WEB_DIST / path_name
-        if file_path.is_file():
-            return FileResponse(file_path)
-        return FileResponse(WEB_DIST / "index.html")
+        # Resolver o caminho pedido e garantir que continua dentro da pasta de
+        # build. Sem esta verificação, um pedido com `..` (ex.: enviado por um
+        # cliente HTTP que não normaliza o caminho) poderia escapar de WEB_DIST
+        # e servir ficheiros arbitrários do servidor (path traversal).
+        web_dist_root = WEB_DIST.resolve()
+        candidate = (web_dist_root / path_name).resolve()
+        if candidate.is_file() and candidate.is_relative_to(web_dist_root):
+            return FileResponse(candidate)
+        return FileResponse(web_dist_root / "index.html")
 # Force redeploy at Tue Jun 23 10:55:15 UTC 2026
 # Endpoint status: Contact form working - POST /api/contact

--- a/conftest.py
+++ b/conftest.py
@@ -5,3 +5,8 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parent
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
+
+# O TestClient usa o host "testserver"; sem o autorizar, o TrustedHostMiddleware
+# rejeita todos os pedidos com 400 "Invalid host header".
+import os
+os.environ.setdefault("ALLOWED_HOSTS", "testserver")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -196,7 +196,7 @@ def test_session_management(client):
 def test_login_requires_confirmation(client):
     register_vendor(client, email="new@example.com")
     resp = client.post("/login", json={"email": "new@example.com", "password": "Secret123"})
-    assert resp.status_code == 400
+    assert resp.status_code == 403
     assert "Email not confirmed" in resp.json()["detail"]
 
     confirm_latest_email(client)
@@ -443,7 +443,7 @@ def test_websocket_location_broadcast(client):
         f"/vendors/{vendor_id}/routes/start",
         headers={"Authorization": f"Bearer {token}"},
     )
-    with client.websocket_connect("/ws/locations") as websocket:
+    with client.websocket_connect(f"/ws/locations?token={token}") as websocket:
         resp = client.put(
             f"/vendors/{vendor_id}/location",
             json={"lat": 5.5, "lng": -7.1},
@@ -539,7 +539,9 @@ def test_paid_weeks_listing(client):
             }
         },
     }
-    resp = client.post("/stripe/webhook", json=event)
+    resp = client.post(
+        "/stripe/webhook", json=event, headers={"stripe-signature": "test-sig"}
+    )
     assert resp.status_code == 200
 
     token = get_token(client)
@@ -579,7 +581,9 @@ def test_stripe_webhook_applies_plan_duration(client):
             },
         }
         before_payment = main.utcnow()
-        resp = client.post("/stripe/webhook", json=event)
+        resp = client.post(
+            "/stripe/webhook", json=event, headers={"stripe-signature": "test-sig"}
+        )
         after_payment = main.utcnow()
         assert resp.status_code == 200
 


### PR DESCRIPTION
## Summary
This PR enhances security posture and establishes testing infrastructure for the Sunny Sales backend. It addresses several security vulnerabilities, improves error handling, and adds CI/CD automation with comprehensive test configuration.

## Key Changes

**Security Improvements:**
- **SECRET_KEY handling**: Replace hardcoded fallback with cryptographically secure random generation (`secrets.token_hex(32)`). This prevents token forgery attacks while maintaining dev/test usability by invalidating sessions only on restart when SECRET_KEY is unconfigured.
- **Path traversal prevention**: Add path normalization and boundary checking in SPA file serving to prevent `..` attacks from accessing files outside the web distribution directory.
- **Error message sanitization**: Hide internal Stripe error details from clients in checkout endpoint, logging them securely server-side instead. Changed status code from 500 to 502 for clarity.

**Testing & CI/CD:**
- Add `.env.example` with comprehensive documentation of all required environment variables (database, security, CORS, email, Stripe, Supabase).
- Add GitHub Actions workflow (`backend-tests.yml`) for automated testing on push to main and pull requests.
- Fix test suite issues:
  - Update login confirmation test to expect 403 (Forbidden) instead of 400 (Bad Request) for unconfirmed emails.
  - Add authentication token to WebSocket connection test.
  - Add required `stripe-signature` header to webhook tests.
  - Configure `ALLOWED_HOSTS` in test environment to prevent TrustedHostMiddleware rejections.

## Implementation Details
- The random SECRET_KEY generation uses Python's `secrets` module (cryptographically secure) rather than `random`, ensuring production-grade entropy.
- Path traversal fix uses `resolve()` and `is_relative_to()` to safely validate file paths against the web distribution root.
- Test configuration uses `os.environ.setdefault()` to allow override while providing sensible defaults for the test environment.

https://claude.ai/code/session_01UqnKwAAoATZ8byKMbme3ND