### PR TITLE
Add cache bust comment to ModernMapLayout

### DIFF
--- a/sunny_sales_web/src/pages/ModernMapLayout.jsx
+++ b/sunny_sales_web/src/pages/ModernMapLayout.jsx
@@ -799,3 +799,4 @@ export default function ModernMapLayout() {
     </div>
   );
 }
+# Cache bust - 1782927153


### PR DESCRIPTION
## Summary
Added a cache busting comment to the ModernMapLayout component to invalidate cached versions and force a fresh load.

## Key Changes
- Added cache bust comment with timestamp (1782927153) at the end of ModernMapLayout.jsx

## Implementation Details
This change appends a comment with a unique timestamp to the module, which serves as a cache buster. This technique forces browsers and build systems to treat the file as modified, ensuring that any cached versions are invalidated and the latest version is loaded.

https://claude.ai/code/session_01QiFk5PrtbN3MU3iPK9jz3V