### PR TITLE
Fix map page visibility issue: position WeatherCard over map instead of breaking flex layout

### DIFF
--- a/sunny_sales_web/src/pages/ModernMapLayout.css
+++ b/sunny_sales_web/src/pages/ModernMapLayout.css
@@ -1144,6 +1144,17 @@ body {
   100% { transform: scale(1.4); opacity: 0; }
 }
 
+/* ── Weather overlay ──────────────────────────────────── */
+
+.weather-overlay {
+  position: absolute;
+  bottom: 20px;
+  left: 20px;
+  max-width: 340px;
+  z-index: 400;
+  pointer-events: auto;
+}
+
 /* ── Responsive ───────────────────────────────────────── */
 
 @media (max-width: 1024px) {

--- a/sunny_sales_web/src/pages/ModernMapLayout.jsx
+++ b/sunny_sales_web/src/pages/ModernMapLayout.jsx
@@ -651,6 +651,11 @@ export default function ModernMapLayout() {
             </div>
           )}
 
+          {/* Weather card positioned over map */}
+          <div className="weather-overlay">
+            <WeatherCard />
+          </div>
+
         </main>
       </div>
 
@@ -717,7 +722,6 @@ export default function ModernMapLayout() {
         </div>
       </div>}
 
-      <WeatherCard />
       {showWelcome && <WelcomeCard onClose={dismissWelcome} />}
     </div>
   );


### PR DESCRIPTION
The WeatherCard was being rendered as a direct child of .modern-layout,
causing it to take up space in the flex layout and covering the map.
Now positioned absolutely within .map-area so the map is visible and
WeatherCard appears as an overlay in the bottom-left corner.

Fixes issue where meteorologia card was occupying entire map area.

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DSCg9aBkt5jkyuh5TWqfUv