### PR TITLE
Replace anchor tag with React Router Link in VendorRegister

### DIFF
--- a/sunny_sales_web/src/pages/VendorRegister.jsx
+++ b/sunny_sales_web/src/pages/VendorRegister.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { Link } from 'react-router-dom';
 import axios from 'axios';
 import { BASE_URL } from '../config';
 import ImageCropper from '../components/ImageCropper';
@@ -286,7 +287,7 @@ export default function VendorRegister() {
           </button>
         )}
         {error && <p className="vr-error">{error}</p>}
-        <a href="/vendor-login" className="vr-login-link">Ir para o login</a>
+        <Link to="/vendor-login" className="vr-login-link">Ir para o login</Link>
       </div>
     );
   }


### PR DESCRIPTION
## Summary
Updated the VendorRegister component to use React Router's `Link` component instead of a standard HTML anchor tag for internal navigation.

## Key Changes
- Added import for `Link` from `react-router-dom`
- Replaced `<a href="/vendor-login">` with `<Link to="/vendor-login">` for the login navigation link
- Maintained the same CSS class and link text for consistent styling and UX

## Implementation Details
This change improves the application's routing consistency by using React Router's client-side navigation instead of full page reloads. The `Link` component provides better performance and maintains application state during navigation between the vendor registration and login pages.

https://claude.ai/code/session_01FzViyaF5anWN9BeNTrJxk9