### PR TITLE
Fix font loading and Leaflet CSS import issues

### DIFF
--- a/sunny_sales_web/src/pages/ModernMapLayout.css
+++ b/sunny_sales_web/src/pages/ModernMapLayout.css
@@ -1,4 +1,7 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap');
+/* (em português) As fontes já são carregadas globalmente em index.css; um
+   @import aqui iria parar ao chunk CSS lazy desta página e, se a request
+   externa falhar ou demorar, o preload do Vite nunca resolve e a página
+   fica presa no loader. */
 
 body {
   margin: 0;

--- a/sunny_sales_web/src/pages/ModernMapLayout.jsx
+++ b/sunny_sales_web/src/pages/ModernMapLayout.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { MapContainer, TileLayer, Marker, Popup, useMap } from 'react-leaflet';
 import L from 'leaflet';
+import 'leaflet/dist/leaflet.css';
 import 'leaflet-rotate';
 import axios from 'axios';
 import { BASE_URL, mediaUrl } from '../config';


### PR DESCRIPTION
## Summary
This PR fixes two CSS loading issues that could cause page rendering problems and missing map styles.

## Key Changes
- **Removed duplicate font import from ModernMapLayout.css**: The Inter font was being imported in the page-specific CSS file, which would be lazy-loaded as a separate chunk. If the external font request failed or was delayed, Vite's preload mechanism could hang indefinitely, leaving the page stuck on the loader. Since fonts are already loaded globally in index.css, this duplicate import has been removed with an explanatory comment.

- **Added explicit Leaflet CSS import in ModernMapLayout.jsx**: The Leaflet library's stylesheet is now explicitly imported in the component file to ensure map styles are properly loaded. This prevents missing styles for map elements.

## Implementation Details
- The font import removal includes a Portuguese comment explaining why the import was problematic and why it's safe to remove
- The Leaflet CSS import follows the standard pattern for react-leaflet usage and is placed after the library import for clarity

https://claude.ai/code/session_0124fgtB9t9YtjpvLLx4yUUv