### PR TITLE
Redesenha o dashboard do vendedor em formato de perfil com menus em lista

### DIFF
--- a/mobile/src/index.css
+++ b/mobile/src/index.css
@@ -962,58 +962,51 @@ body {
   overflow-y: auto;
 }
 
-.dashboard-hero {
+/* Foto em cima (cartão de perfil) */
+.dash-profile-head {
   display: flex;
-  flex-direction: column;
-  gap: 8px;
-  padding: 24px 0;
-}
-
-.dashboard-hero-title {
-  font-size: 28px;
-  font-weight: 700;
-  color: var(--text);
-  letter-spacing: -0.5px;
-}
-
-.dashboard-hero-subtitle {
-  font-size: 14px;
-  color: var(--text-secondary);
-  line-height: 1.5;
-}
-
-.dashboard-greeting {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  padding: 0;
-}
-
-.dashboard-greeting-time {
-  font-size: 14px;
-  color: var(--text-secondary);
-  font-weight: 600;
-}
-
-.dashboard-greeting-name {
-  font-size: 24px;
-  font-weight: 700;
-  color: var(--text);
-}
-
-/* Profile card */
-.dashboard-profile-card {
+  align-items: center;
+  gap: 14px;
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: var(--radius);
-  padding: 20px;
+  padding: 18px 16px;
   box-shadow: var(--shadow-sm);
+  cursor: pointer;
+  text-align: left;
+  width: 100%;
+  color: var(--text);
+  transition: all var(--transition);
 }
 
-.dashboard-profile-top {
+.dash-profile-head:active {
+  border-color: var(--primary);
+  transform: scale(0.99);
+}
+
+.dash-profile-head-meta {
   display: flex;
-  gap: 16px;
-  align-items: flex-start;
+  flex-direction: column;
+  gap: 3px;
+  min-width: 0;
+  flex: 1;
+}
+
+.dash-profile-head-name {
+  font-size: 16px;
+  font-weight: 700;
+  color: var(--text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.dash-profile-head-email {
+  font-size: 13px;
+  color: var(--text-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .dashboard-avatar {
@@ -1031,24 +1024,6 @@ body {
   justify-content: center;
   font-size: 24px;
   font-weight: 700;
-}
-
-.dashboard-profile-meta {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  flex: 1;
-}
-
-.dashboard-profile-name {
-  font-size: 16px;
-  font-weight: 700;
-  color: var(--text);
-}
-
-.dashboard-profile-product {
-  font-size: 14px;
-  color: var(--text-secondary);
 }
 
 .dashboard-sub-badge {
@@ -1079,93 +1054,6 @@ body {
 
 .dashboard-sub-date {
   display: block;
-}
-
-.dashboard-profile-divider {
-  height: 1px;
-  background: var(--border);
-  margin: 12px 0;
-}
-
-.dashboard-profile-details {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-}
-
-.dashboard-detail-row {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  font-size: 13px;
-}
-
-.dashboard-detail-row-icon {
-  color: var(--primary);
-  font-size: 1rem;
-  flex-shrink: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 24px;
-}
-
-.dashboard-detail-row-label {
-  font-weight: 600;
-  color: var(--text-secondary);
-  min-width: 80px;
-}
-
-.dashboard-detail-row-value {
-  color: var(--text);
-  font-weight: 500;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  flex: 1;
-}
-
-.dashboard-pin-dot {
-  width: 12px;
-  height: 12px;
-  border-radius: 50%;
-  display: inline-block;
-}
-
-.dashboard-detail-row-payments {
-  flex-direction: column;
-  gap: 8px;
-  align-items: flex-start;
-}
-
-.dashboard-payments-row {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-  width: 100%;
-}
-
-.dashboard-payment-badge {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: 6px 10px;
-  background: var(--primary-light);
-  border-radius: 6px;
-  font-size: 12px;
-  font-weight: 500;
-  color: var(--primary-dark);
-}
-
-.dashboard-payment-badge-icon {
-  font-size: 0.9rem;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.dashboard-payment-badge-label {
-  white-space: nowrap;
 }
 
 /* CTA Card */
@@ -1216,74 +1104,108 @@ body {
   opacity: 0.9;
 }
 
-/* Quick grid */
-.dashboard-quick-grid {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 12px;
-}
-
-.dashboard-quick-card {
-  background: var(--surface);
-  border: 1.5px solid var(--border);
-  border-radius: var(--radius-lg);
-  padding: 16px;
+/* Menus em baixo (formato lista agrupada) */
+.dash-menu-section {
   display: flex;
   flex-direction: column;
   gap: 8px;
-  align-items: flex-start;
-  cursor: pointer;
-  transition: all var(--transition);
-  text-align: left;
 }
 
-.dashboard-quick-card:active {
-  border-color: var(--primary);
-  background: var(--primary-light);
-  transform: scale(0.98);
+.dash-menu-section-label {
+  font-size: 13px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-muted, var(--text-secondary));
+  padding: 0 4px;
 }
 
-.dashboard-quick-icon {
-  font-size: 1.5rem;
-  color: var(--primary);
+.dash-menu-group {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-sm);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.dash-menu-row {
   display: flex;
   align-items: center;
-  justify-content: center;
-}
-
-.dashboard-quick-label {
-  font-size: 14px;
-  font-weight: 700;
-  color: var(--text);
-}
-
-.dashboard-quick-desc {
-  font-size: 12px;
-  color: var(--text-secondary);
-  line-height: 1.3;
-}
-
-/* Logout button */
-.dashboard-logout-btn {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 8px;
-  padding: 14px 20px;
-  border: 1.5px solid var(--danger);
-  background: white;
-  color: var(--danger);
-  border-radius: var(--radius-sm);
-  font-size: 15px;
-  font-weight: 700;
-  cursor: pointer;
-  transition: all var(--transition);
+  gap: 12px;
   width: 100%;
+  padding: 15px 16px;
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid var(--border);
+  color: var(--text);
+  font-size: 15px;
+  font-weight: 600;
+  text-align: left;
+  cursor: pointer;
+  border-radius: 0;
+  transition: background var(--transition);
 }
 
-.dashboard-logout-btn:active {
+.dash-menu-row:last-child {
+  border-bottom: none;
+}
+
+.dash-menu-row:active {
+  background: var(--primary-light);
+}
+
+.dash-menu-row-icon {
+  width: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-secondary);
+  font-size: 1.1rem;
+  flex-shrink: 0;
+}
+
+.dash-menu-row-label {
+  flex: 1;
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.dash-menu-row-value {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  flex-shrink: 0;
+}
+
+.dash-menu-row-value.on {
+  color: #16a34a;
+}
+
+.dash-menu-row-value.off {
+  color: var(--danger);
+}
+
+.dash-menu-row-chevron {
+  color: var(--text-secondary);
+  font-size: 1rem;
+  flex-shrink: 0;
+  opacity: 0.55;
+}
+
+.dash-menu-row.danger {
+  color: var(--danger);
+}
+
+.dash-menu-row.danger .dash-menu-row-icon {
+  color: var(--danger);
+}
+
+.dash-menu-row.danger:active {
   background: #fee2e2;
-  transform: scale(0.98);
 }
 
 /* ── Home Page ─────────────────────────────────── */

--- a/mobile/src/pages/DashboardScreen.jsx
+++ b/mobile/src/pages/DashboardScreen.jsx
@@ -1,8 +1,8 @@
 import React, { useState } from 'react';
 import {
-  FiUser, FiMapPin, FiDollarSign, FiSmartphone, FiTerminal,
-  FiCreditCard, FiWifi, FiSend, FiCheckSquare, FiCalendar,
-  FiFileText, FiMail, FiLogOut, FiMap, FiShoppingBag, FiExternalLink
+  FiUser, FiSend, FiCheckSquare, FiCalendar,
+  FiFileText, FiMail, FiLogOut, FiShoppingBag,
+  FiChevronRight, FiExternalLink, FiMap
 } from 'react-icons/fi';
 import { BASE_URL, WEB_URL, mediaUrl } from '../config.js';
 import ProfileScreen from './ProfileScreen.jsx';
@@ -11,24 +11,8 @@ import RoutesScreen from './RoutesScreen.jsx';
 import ProductsScreen from './ProductsScreen.jsx';
 import InvoicesScreen from './InvoicesScreen.jsx';
 
-const PAYMENT_ICONS = {
-  'Numerário': <FiDollarSign />,
-  'MB Way': <FiSmartphone />,
-  'Multibanco': <FiTerminal />,
-  'Cartão': <FiCreditCard />,
-  'NFC': <FiWifi />,
-};
-
-function getGreeting() {
-  const h = new Date().getHours();
-  if (h < 12) return 'Bom dia';
-  if (h < 19) return 'Boa tarde';
-  return 'Boa noite';
-}
-
 export default function DashboardScreen({ auth, onChangePage, onLogout, onUserUpdate }) {
   const { user } = auth;
-  const [activeTab, setActiveTab] = useState('dashboard');
   const [showProfile, setShowProfile] = useState(false);
   const [showPlans, setShowPlans] = useState(false);
   const [showRoutes, setShowRoutes] = useState(false);
@@ -42,7 +26,6 @@ export default function DashboardScreen({ auth, onChangePage, onLogout, onUserUp
 
   const handleLogout = async () => {
     const token = localStorage.getItem('token');
-    const vendorId = localStorage.getItem('vendorId');
     try {
       await fetch(`${BASE_URL}/logout`, {
         method: 'POST',
@@ -56,94 +39,83 @@ export default function DashboardScreen({ auth, onChangePage, onLogout, onUserUp
     window.open(`${WEB_URL}/#${path}`, '_system');
   };
 
+  // Menus agrupados (foto em cima, menus em baixo)
+  const menuGroups = [
+    {
+      label: 'Conta',
+      items: [
+        { icon: <FiUser />, label: 'Perfil', desc: 'Ver e editar informações', onClick: () => setShowProfile(true) },
+      ],
+    },
+    {
+      label: 'Atividade',
+      items: [
+        { icon: <FiMap />, label: 'Mapa', desc: 'Voltar ao mapa', onClick: () => onChangePage('map') },
+        { icon: <FiSend />, label: 'Trajetos', desc: 'Consultar histórico de rotas', onClick: () => setShowRoutes(true) },
+      ],
+    },
+    {
+      label: 'Negócio',
+      items: [
+        { icon: <FiShoppingBag />, label: 'Produtos', desc: 'Adicionar e gerir produtos', onClick: () => setShowProducts(true) },
+        {
+          icon: <FiCheckSquare />,
+          label: 'Subscrição',
+          value: subscriptionActive ? 'Ativa' : 'Inativa',
+          valueClass: subscriptionActive ? 'on' : 'off',
+          onClick: () => setShowPlans(true),
+        },
+        { icon: <FiCalendar />, label: 'Semanas pagas', external: true, onClick: () => openWebsite('/paid-weeks') },
+        { icon: <FiFileText />, label: 'Faturas', desc: 'Consultar faturas e recibos', onClick: () => setShowInvoices(true) },
+      ],
+    },
+    {
+      label: 'Suporte',
+      items: [
+        { icon: <FiMail />, label: 'Contactar suporte', external: true, onClick: () => openWebsite('/contacto') },
+      ],
+    },
+  ];
+
   return (
     <div className="dashboard-screen">
-      {/* Hero Section */}
+      {/* Foto em cima (cartão de perfil) */}
       {user && (
-        <div className="dashboard-hero">
-          <h1 className="dashboard-hero-title">Bem-vindo de volta!</h1>
-          <p className="dashboard-hero-subtitle">
-            Gerencie sua presença no mapa e mantenha seus clientes sempre informados.
-          </p>
-        </div>
-      )}
-
-      {/* Greeting */}
-      {user && (
-        <div className="dashboard-greeting">
-          <span className="dashboard-greeting-time">{getGreeting()},</span>
-          <h2 className="dashboard-greeting-name">{user.name.split(' ')[0]}</h2>
-        </div>
-      )}
-
-      {/* Profile card */}
-      {user && (
-        <div className="dashboard-profile-card">
-          <div className="dashboard-profile-top">
-            {user.profile_photo ? (
-              <img
-                src={mediaUrl(user.profile_photo)}
-                alt="Foto de perfil"
-                className="dashboard-avatar"
-                style={{ borderColor: user.pin_color || '#7B61FF' }}
-              />
-            ) : (
-              <div
-                className="dashboard-avatar dashboard-avatar-placeholder"
-                style={{
-                  borderColor: user.pin_color || '#7B61FF',
-                  background: `${user.pin_color || '#7B61FF'}22`,
-                  color: user.pin_color || '#7B61FF'
-                }}
-              >
-                {user.name?.charAt(0)?.toUpperCase() || '?'}
-              </div>
-            )}
-            <div className="dashboard-profile-meta">
-              <span className="dashboard-profile-name">{user.name}</span>
-              <span className="dashboard-profile-product">{user.product}</span>
-              <span className={`dashboard-sub-badge${subscriptionActive ? ' active' : ' inactive'}`}>
-                <span className="dashboard-sub-dot" />
-                {subscriptionActive
-                  ? <>Ativa{subscriptionDate && <span className="dashboard-sub-date"> · {subscriptionDate}</span>}</>
-                  : 'Inativa'}
-              </span>
+        <button className="dash-profile-head" onClick={() => setShowProfile(true)}>
+          {user.profile_photo ? (
+            <img
+              src={mediaUrl(user.profile_photo)}
+              alt="Foto de perfil"
+              className="dashboard-avatar"
+              style={{ borderColor: user.pin_color || '#7B61FF' }}
+            />
+          ) : (
+            <div
+              className="dashboard-avatar dashboard-avatar-placeholder"
+              style={{
+                borderColor: user.pin_color || '#7B61FF',
+                background: `${user.pin_color || '#7B61FF'}22`,
+                color: user.pin_color || '#7B61FF'
+              }}
+            >
+              {user.name?.charAt(0)?.toUpperCase() || '?'}
             </div>
+          )}
+          <div className="dash-profile-head-meta">
+            <span className="dash-profile-head-name">{user.name}</span>
+            <span className="dash-profile-head-email">{user.email}</span>
+            <span className={`dashboard-sub-badge${subscriptionActive ? ' active' : ' inactive'}`}>
+              <span className="dashboard-sub-dot" />
+              {subscriptionActive
+                ? <>Subscrição ativa{subscriptionDate && <span className="dashboard-sub-date"> · {subscriptionDate}</span>}</>
+                : 'Subscrição inativa'}
+            </span>
           </div>
-
-          <div className="dashboard-profile-divider" />
-
-          <div className="dashboard-profile-details">
-            <div className="dashboard-detail-row">
-              <span className="dashboard-detail-row-icon"><FiMail /></span>
-              <span className="dashboard-detail-row-label">EMAIL</span>
-              <span className="dashboard-detail-row-value">{user.email}</span>
-            </div>
-            <div className="dashboard-detail-row">
-              <span className="dashboard-detail-row-icon">
-                <span className="dashboard-pin-dot" style={{ backgroundColor: user.pin_color || '#7B61FF' }} />
-              </span>
-              <span className="dashboard-detail-row-label">COR DO PIN</span>
-            </div>
-            {user.payment_methods && (
-              <div className="dashboard-detail-row dashboard-detail-row-payments">
-                <span className="dashboard-detail-row-icon"><FiCreditCard /></span>
-                <span className="dashboard-detail-row-label">PAGAMENTOS</span>
-                <div className="dashboard-payments-row">
-                  {user.payment_methods.split(',').filter(Boolean).map(m => (
-                    <span key={m} className="dashboard-payment-badge" title={m}>
-                      <span className="dashboard-payment-badge-icon">{PAYMENT_ICONS[m] || <FiCreditCard />}</span>
-                      <span className="dashboard-payment-badge-label">{m}</span>
-                    </span>
-                  ))}
-                </div>
-              </div>
-            )}
-          </div>
-        </div>
+          <FiChevronRight className="dash-menu-row-chevron" />
+        </button>
       )}
 
-      {/* Subscription CTA if inactive */}
+      {/* CTA de subscrição inativa */}
       {user && !subscriptionActive && (
         <div className="dashboard-cta-card">
           <div className="dashboard-cta-text">
@@ -156,49 +128,35 @@ export default function DashboardScreen({ auth, onChangePage, onLogout, onUserUp
         </div>
       )}
 
-      {/* Quick actions grid */}
-      <div className="dashboard-quick-grid">
-        <button className="dashboard-quick-card" onClick={() => setShowProfile(true)}>
-          <span className="dashboard-quick-icon"><FiUser /></span>
-          <span className="dashboard-quick-label">Perfil</span>
-          <span className="dashboard-quick-desc">Ver e editar informações</span>
-        </button>
-        <button className="dashboard-quick-card" onClick={() => setShowRoutes(true)}>
-          <span className="dashboard-quick-icon"><FiSend /></span>
-          <span className="dashboard-quick-label">Trajetos</span>
-          <span className="dashboard-quick-desc">Consultar histórico de rotas</span>
-        </button>
-        <button className="dashboard-quick-card" onClick={() => setShowProducts(true)}>
-          <span className="dashboard-quick-icon"><FiShoppingBag /></span>
-          <span className="dashboard-quick-label">Produtos</span>
-          <span className="dashboard-quick-desc">Adicionar e gerir produtos</span>
-        </button>
-        <button className="dashboard-quick-card" onClick={() => setShowPlans(true)}>
-          <span className="dashboard-quick-icon"><FiCheckSquare /></span>
-          <span className="dashboard-quick-label">Ativar Subscrição</span>
-          <span className="dashboard-quick-desc">Ativar ou renovar o plano</span>
-        </button>
-        <button className="dashboard-quick-card" onClick={() => openWebsite('/paid-weeks')}>
-          <span className="dashboard-quick-icon"><FiCalendar /></span>
-          <span className="dashboard-quick-label">Subscrições</span>
-          <span className="dashboard-quick-desc">Gerir planos e semanas pagas</span>
-        </button>
-        <button className="dashboard-quick-card" onClick={() => setShowInvoices(true)}>
-          <span className="dashboard-quick-icon"><FiFileText /></span>
-          <span className="dashboard-quick-label">Faturas</span>
-          <span className="dashboard-quick-desc">Consultar faturas e recibos</span>
-        </button>
-        <button className="dashboard-quick-card" onClick={() => openWebsite('/contacto')}>
-          <span className="dashboard-quick-icon"><FiMail /></span>
-          <span className="dashboard-quick-label">Contactar Suporte</span>
-          <span className="dashboard-quick-desc">Enviar mensagem à equipa</span>
-        </button>
-      </div>
+      {/* Menus em baixo (formato lista agrupada) */}
+      {menuGroups.map((group) => (
+        <div className="dash-menu-section" key={group.label}>
+          <span className="dash-menu-section-label">{group.label}</span>
+          <div className="dash-menu-group">
+            {group.items.map((item) => (
+              <button key={item.label} className="dash-menu-row" onClick={item.onClick}>
+                <span className="dash-menu-row-icon">{item.icon}</span>
+                <span className="dash-menu-row-label">{item.label}</span>
+                {item.value && (
+                  <span className={`dash-menu-row-value ${item.valueClass || ''}`}>{item.value}</span>
+                )}
+                {item.external
+                  ? <FiExternalLink className="dash-menu-row-chevron" />
+                  : <FiChevronRight className="dash-menu-row-chevron" />}
+              </button>
+            ))}
+          </div>
+        </div>
+      ))}
 
-      <button className="dashboard-logout-btn" onClick={handleLogout}>
-        <FiLogOut size={15} />
-        Terminar Sessão
-      </button>
+      <div className="dash-menu-section">
+        <div className="dash-menu-group">
+          <button className="dash-menu-row danger" onClick={handleLogout}>
+            <span className="dash-menu-row-icon"><FiLogOut /></span>
+            <span className="dash-menu-row-label">Terminar Sessão</span>
+          </button>
+        </div>
+      </div>
 
       {showProfile && (
         <ProfileScreen auth={auth} onClose={() => setShowProfile(false)} onUserUpdate={onUserUpdate} />

--- a/sunny_sales_web/src/pages/VendorDashboard.css
+++ b/sunny_sales_web/src/pages/VendorDashboard.css
@@ -1,30 +1,350 @@
-/* ── Wrapper ─────────────────────────────────────────── */
+/* ── Página ──────────────────────────────────────────── */
 
-.vd-wrapper {
-  position: relative;
+.vd-page {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 0 1rem 3rem;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  color: var(--text);
+  font-family: 'Inter', 'Roboto', sans-serif;
   min-height: 60vh;
 }
 
-/* ── Main content ────────────────────────────────────── */
+/* ── Layout (telemóvel: 1 coluna; PC: menu à esquerda +
+     conteúdo ao centro) ─────────────────────────────── */
 
-.vd-container {
-  margin-left: 240px;
-  margin-top: 0;
-  padding: 0 2rem 3rem;
-  display: flex;
-  flex-direction: column;
+.vd-layout {
+  display: grid;
+  grid-template-columns: 1fr;
   gap: 24px;
-  color: var(--text);
-  font-family: 'Inter', 'Roboto', sans-serif;
-  min-height: 100vh;
+  align-items: start;
 }
 
-/* ── Hero Section (matching info-hero) ────────────────── */
+/* ── Menu (foto em cima, menus em baixo) ─────────────── */
+
+.vd-menu {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  min-width: 0;
+}
+
+.vd-profile-head {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-xl);
+  padding: 18px 16px;
+  box-shadow: var(--shadow-sm);
+  cursor: pointer;
+  text-align: left;
+  width: 100%;
+  min-height: auto;
+  color: var(--text);
+  transition: box-shadow var(--transition), border-color var(--transition);
+  animation: fadeIn 0.35s ease;
+}
+
+.vd-profile-head:hover {
+  box-shadow: var(--shadow-warm);
+  border-color: var(--primary-light-solid);
+}
+
+.vd-avatar {
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  object-fit: cover;
+  border: 3px solid var(--primary-light-solid);
+  box-shadow: var(--shadow-warm);
+  flex-shrink: 0;
+}
+
+.vd-avatar-placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--primary-light-solid);
+  color: var(--primary-dark);
+  font-size: 1.6rem;
+  font-weight: 800;
+  border: 3px solid var(--primary-light-solid);
+}
+
+.vd-profile-head-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  min-width: 0;
+  flex: 1;
+}
+
+.vd-profile-head-name {
+  font-size: 1.02rem;
+  font-weight: 800;
+  color: var(--text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.vd-profile-head-email {
+  font-size: 0.82rem;
+  color: var(--text-muted);
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.vd-sub-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 0.72rem;
+  font-weight: 700;
+  width: fit-content;
+  margin-top: 2px;
+}
+
+.vd-sub-badge.active {
+  color: #2e7d32;
+}
+
+.vd-sub-badge.inactive {
+  color: #c62828;
+}
+
+.vd-sub-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  background: currentColor;
+}
+
+.vd-sub-date {
+  font-weight: 500;
+  opacity: 0.8;
+}
+
+/* ── Grupos de menu (formato lista, como no ecrã Profile) */
+
+.vd-menu-section {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.vd-menu-section-label {
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-muted);
+  padding: 0 4px;
+}
+
+.vd-menu-group {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow-xs);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.vd-menu-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  padding: 14px 16px;
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid var(--border);
+  color: var(--text);
+  font-size: 0.9rem;
+  font-weight: 600;
+  text-align: left;
+  cursor: pointer;
+  min-height: auto;
+  border-radius: 0;
+  transition: background var(--transition);
+}
+
+.vd-menu-row:last-child {
+  border-bottom: none;
+}
+
+.vd-menu-row:hover {
+  background: var(--surface-alt);
+}
+
+.vd-menu-row.active {
+  background: var(--primary-light);
+}
+
+.vd-menu-row.active .vd-menu-row-icon {
+  color: var(--primary-dark);
+}
+
+.vd-menu-row-static {
+  cursor: default;
+}
+
+.vd-menu-row-static:hover {
+  background: transparent;
+}
+
+.vd-menu-row-icon {
+  width: 22px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-secondary);
+  font-size: 1.05rem;
+  flex-shrink: 0;
+}
+
+.vd-menu-row-label {
+  flex: 1;
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.vd-menu-row-value {
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  flex-shrink: 0;
+}
+
+.vd-menu-row-value.on {
+  color: #2e7d32;
+}
+
+.vd-menu-row-value.off {
+  color: #c62828;
+}
+
+.vd-menu-row-chevron {
+  color: var(--text-muted);
+  font-size: 1rem;
+  flex-shrink: 0;
+  opacity: 0.55;
+}
+
+.vd-menu-row.danger {
+  color: #c62828;
+}
+
+.vd-menu-row.danger .vd-menu-row-icon {
+  color: #c62828;
+}
+
+.vd-menu-row.danger:hover {
+  background: rgba(239, 68, 68, 0.06);
+}
+
+/* ── Painel de conteúdo ──────────────────────────────── */
+
+.vd-panel {
+  min-width: 0;
+  display: none;
+}
+
+.vd-panel-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.vd-panel-back {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: var(--surface);
+  border: 1.5px solid var(--border);
+  border-radius: var(--radius-full);
+  padding: 7px 14px;
+  font-size: 0.82rem;
+  font-weight: 700;
+  color: var(--text-secondary);
+  cursor: pointer;
+  min-height: auto;
+  transition: background var(--transition), border-color var(--transition), color var(--transition);
+}
+
+.vd-panel-back:hover {
+  background: var(--primary-light);
+  border-color: rgba(10, 147, 150, 0.3);
+  color: var(--primary-dark);
+}
+
+.vd-panel-title {
+  font-size: 1.15rem;
+  font-weight: 800;
+  color: var(--text);
+  margin: 0;
+}
+
+.vd-panel-body {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  animation: fadeIn 0.25s ease;
+}
+
+/* No telemóvel a secção abre por cima do menu (padrão lista → detalhe) */
+.vd-layout.panel-open .vd-menu {
+  display: none;
+}
+
+.vd-layout.panel-open .vd-panel {
+  display: block;
+}
+
+/* No PC ambos ficam visíveis: menu à esquerda, conteúdo ao centro */
+@media (min-width: 920px) {
+  .vd-page {
+    padding: 0 2rem 3rem;
+  }
+
+  .vd-layout {
+    grid-template-columns: 340px minmax(0, 1fr);
+  }
+
+  .vd-layout.panel-open .vd-menu,
+  .vd-menu {
+    display: flex;
+    position: sticky;
+    top: 90px;
+  }
+
+  .vd-panel {
+    display: block;
+  }
+
+  .vd-panel-back {
+    display: none;
+  }
+}
+
+/* ── Hero (saudação na Visão geral) ──────────────────── */
 
 .vd-hero {
   background: linear-gradient(135deg, var(--primary) 0%, var(--primary-dark) 100%);
   border-radius: var(--radius-xl);
-  padding: 32px 28px 28px;
+  padding: 28px 24px 24px;
   color: white;
   text-align: left;
   position: relative;
@@ -73,7 +393,7 @@
 }
 
 .vd-hero-title {
-  font-size: clamp(1.55rem, 5vw, 2.1rem);
+  font-size: clamp(1.45rem, 4vw, 1.9rem);
   font-weight: 800;
   margin: 0 0 8px;
   color: white;
@@ -83,7 +403,7 @@
 }
 
 .vd-hero-subtitle {
-  font-size: 0.95rem;
+  font-size: 0.92rem;
   opacity: 0.9;
   max-width: 530px;
   margin: 0;
@@ -179,238 +499,6 @@
 
 .vd-notice-close:hover {
   opacity: 1;
-}
-
-/* ── Profile card (matching info-card) ───────────────── */
-
-.vd-profile-card {
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-top: 3px solid transparent;
-  border-radius: var(--radius-xl);
-  padding: 24px 20px;
-  box-shadow: var(--shadow-sm);
-  display: flex;
-  flex-direction: column;
-  gap: 0;
-  animation: fadeIn 0.35s ease;
-  transition: box-shadow var(--transition), transform var(--transition), border-top-color var(--transition);
-}
-
-.vd-profile-card:hover {
-  box-shadow: var(--shadow-warm);
-  transform: translateY(-3px);
-  border-top-color: var(--primary);
-}
-
-.vd-profile-top {
-  display: flex;
-  align-items: center;
-  gap: 16px;
-}
-
-.vd-avatar {
-  width: 72px;
-  height: 72px;
-  border-radius: 50%;
-  object-fit: cover;
-  border: 3px solid var(--primary-light-solid);
-  box-shadow: var(--shadow-warm);
-  flex-shrink: 0;
-}
-
-.vd-avatar-placeholder {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: var(--primary-light-solid);
-  color: var(--primary-dark);
-  font-size: 1.75rem;
-  font-weight: 800;
-  border: 3px solid var(--primary-light-solid);
-}
-
-.vd-profile-meta {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  min-width: 0;
-  flex: 1;
-}
-
-.vd-profile-name {
-  font-size: 1.05rem;
-  font-weight: 700;
-  color: var(--text);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.vd-profile-product {
-  font-size: 0.82rem;
-  color: var(--text-secondary);
-  font-weight: 500;
-}
-
-.vd-sub-badge {
-  display: inline-flex;
-  align-items: center;
-  gap: 5px;
-  padding: 3px 10px 3px 6px;
-  border-radius: var(--radius-full);
-  font-size: 0.78rem;
-  font-weight: 700;
-  width: fit-content;
-  margin-top: 2px;
-}
-
-.vd-sub-badge.active {
-  background: rgba(76, 175, 80, 0.12);
-  color: #2e7d32;
-}
-
-.vd-sub-badge.inactive {
-  background: rgba(239, 68, 68, 0.10);
-  color: #c62828;
-}
-
-.vd-sub-dot {
-  width: 7px;
-  height: 7px;
-  border-radius: 50%;
-  flex-shrink: 0;
-}
-
-.vd-sub-badge.active .vd-sub-dot {
-  background: #4caf50;
-}
-
-.vd-sub-badge.inactive .vd-sub-dot {
-  background: #ef5350;
-}
-
-.vd-sub-date {
-  font-weight: 400;
-  opacity: 0.8;
-}
-
-.vd-profile-divider {
-  height: 1px;
-  background: var(--border);
-  margin: 16px 0 14px;
-}
-
-/* ── Profile detail rows (icon + label + value + chevron) */
-
-.vd-profile-details {
-  display: flex;
-  flex-direction: column;
-  gap: 0;
-}
-
-.vd-detail-row {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  padding: 12px 4px;
-  border-bottom: 1px solid var(--border);
-  cursor: default;
-}
-
-.vd-detail-row:last-child {
-  border-bottom: none;
-}
-
-.vd-detail-row-icon {
-  width: 20px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: var(--text-muted);
-  font-size: 1rem;
-  flex-shrink: 0;
-}
-
-.vd-detail-row-label {
-  font-size: 0.72rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  color: var(--text-muted);
-  min-width: 70px;
-  flex-shrink: 0;
-}
-
-.vd-detail-row-value {
-  flex: 1;
-  font-size: 0.875rem;
-  font-weight: 500;
-  color: var(--text);
-  word-break: break-all;
-  min-width: 0;
-}
-
-.vd-detail-row-chevron {
-  color: var(--text-muted);
-  font-size: 0.9rem;
-  flex-shrink: 0;
-  opacity: 0.5;
-}
-
-.vd-detail-row-payments {
-  flex-wrap: wrap;
-  align-items: flex-start;
-  gap: 10px;
-  padding-bottom: 14px;
-}
-
-.vd-detail-row-payments .vd-detail-row-icon {
-  margin-top: 2px;
-}
-
-.vd-detail-row-payments .vd-detail-row-label {
-  margin-top: 2px;
-}
-
-.vd-pin-dot {
-  display: inline-block;
-  width: 14px;
-  height: 14px;
-  border-radius: 50%;
-  border: 2px solid rgba(0, 0, 0, 0.08);
-  flex-shrink: 0;
-  transition: background-color 0.25s ease;
-}
-
-.vd-payments-row {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 5px;
-  flex: 1;
-}
-
-.vd-payment-badge {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  background: var(--primary-light);
-  color: var(--primary-dark);
-  border-radius: var(--radius-full);
-  padding: 3px 9px 3px 6px;
-  font-size: 0.72rem;
-  font-weight: 700;
-  border: 1px solid rgba(10, 147, 150, 0.18);
-}
-
-.vd-payment-badge-icon {
-  font-size: 0.8rem;
-  display: flex;
-  align-items: center;
-}
-
-.vd-payment-badge-label {
-  line-height: 1;
 }
 
 /* ── Subscription CTA ────────────────────────────────── */
@@ -588,14 +676,17 @@
 
 /* ── Statistics grid ─────────────────────────────────── */
 
-.vd-stats-section {
-  margin-top: 8px;
-}
-
 .vd-stats-grid {
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  gap: 16px;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 12px;
+}
+
+@media (min-width: 640px) {
+  .vd-stats-grid {
+    grid-template-columns: repeat(4, 1fr);
+    gap: 16px;
+  }
 }
 
 .vd-stat-card {
@@ -641,21 +732,6 @@
   color: var(--text-secondary);
   text-transform: uppercase;
   letter-spacing: 0.01em;
-}
-
-/* ── Bottom section (perfil + atividade) ─────────────── */
-
-.vd-bottom-section {
-  display: grid;
-  grid-template-columns: 1.15fr 1fr;
-  gap: 16px;
-  align-items: start;
-}
-
-/* Permite que os cartões encolham dentro da grelha (min-width:auto por
-   omissão) para não forçarem overflow horizontal em ecrãs estreitos. */
-.vd-bottom-section > * {
-  min-width: 0;
 }
 
 /* ── Recent Activity ─────────────────────────────────── */
@@ -847,149 +923,6 @@
   opacity: 0.9;
 }
 
-/* ── Quick actions grid ──────────────────────────────── */
-
-.vd-quick-grid {
-  display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  gap: 12px;
-}
-
-.vd-quick-card {
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-lg);
-  padding: 20px 12px 16px;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 8px;
-  cursor: pointer;
-  box-shadow: var(--shadow-xs);
-  transition: box-shadow var(--transition), transform var(--transition), border-color var(--transition), background var(--transition);
-  color: var(--text);
-  text-align: center;
-}
-
-.vd-quick-card:hover {
-  box-shadow: var(--shadow-md);
-  transform: translateY(-2px);
-  border-color: var(--primary-light-solid);
-  background: var(--surface-warm);
-}
-
-.vd-quick-card:active {
-  transform: translateY(0);
-  box-shadow: var(--shadow-sm);
-}
-
-.vd-quick-icon {
-  width: 44px;
-  height: 44px;
-  border-radius: var(--radius-md);
-  background: var(--primary-light);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 1.2rem;
-  color: var(--primary-dark);
-  flex-shrink: 0;
-  transition: background var(--transition);
-}
-
-.vd-quick-card:hover .vd-quick-icon {
-  background: rgba(10, 147, 150, 0.22);
-}
-
-.vd-quick-label {
-  font-size: 0.82rem;
-  font-weight: 700;
-  color: var(--text);
-  letter-spacing: 0.01em;
-  line-height: 1.2;
-}
-
-.vd-quick-desc {
-  font-size: 0.65rem;
-  font-weight: 500;
-  color: var(--text-muted);
-  line-height: 1.3;
-  padding: 0 4px;
-}
-
-/* ── Account actions (definições + terminar sessão) ──── */
-
-.vd-account-actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 12px;
-}
-
-.vd-account-btn {
-  flex: 1;
-  min-width: 180px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 8px;
-  padding: 13px 20px;
-  border-radius: var(--radius-full);
-  background: var(--surface);
-  border: 1.5px solid var(--border-strong);
-  color: var(--text-secondary);
-  font-size: 0.9rem;
-  font-weight: 700;
-  cursor: pointer;
-  min-height: auto;
-  transition: background var(--transition), border-color var(--transition),
-    color var(--transition), transform var(--transition);
-}
-
-.vd-account-btn:hover {
-  background: var(--surface-alt);
-  border-color: var(--primary-light-solid);
-  color: var(--primary-dark);
-  transform: translateY(-1px);
-}
-
-.vd-account-btn-danger {
-  background: rgba(239, 68, 68, 0.06);
-  border-color: rgba(239, 68, 68, 0.28);
-  color: #c62828;
-}
-
-.vd-account-btn-danger:hover {
-  background: rgba(239, 68, 68, 0.12);
-  border-color: #ef5350;
-  color: #c62828;
-}
-
-/* ── Edit profile button ─────────────────────────────── */
-
-.vd-edit-btn {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  align-self: flex-start;
-  background: var(--surface-alt);
-  border: 1.5px solid var(--border);
-  border-radius: var(--radius-full);
-  padding: 7px 14px;
-  font-size: 0.8rem;
-  font-weight: 700;
-  color: var(--text-secondary);
-  cursor: pointer;
-  flex-shrink: 0;
-  min-height: auto;
-  transition: background var(--transition), border-color var(--transition), color var(--transition);
-}
-
-.vd-edit-btn:hover {
-  background: var(--primary-light);
-  border-color: rgba(10, 147, 150, 0.3);
-  color: var(--primary-dark);
-}
-
 /* ── Location toggle switch ──────────────────────────── */
 
 .vendor-switch {
@@ -1042,64 +975,26 @@
   transform: translateX(24px);
 }
 
-/* ── Profile modal ───────────────────────────────────── */
+/* ── Formulários (aparência / dados pessoais / segurança) */
 
-.vd-modal-overlay {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.45);
-  backdrop-filter: blur(3px);
-  z-index: 1000;
-  display: flex;
-  align-items: flex-end;
-  justify-content: center;
-  animation: fadeIn 0.2s ease;
-}
-
-.vd-modal {
+.vd-form {
   background: var(--surface);
-  border-radius: var(--radius-xl) var(--radius-xl) 0 0;
-  padding: 24px 20px 36px;
-  width: 100%;
-  max-width: 520px;
-  max-height: 90vh;
-  overflow-y: auto;
-  box-shadow: 0 -4px 32px rgba(0, 0, 0, 0.18);
-  animation: slideUp 0.25s ease;
-}
-
-@keyframes slideUp {
-  from { transform: translateY(40px); opacity: 0; }
-  to   { transform: translateY(0);    opacity: 1; }
-}
-
-.vd-modal-header {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  margin-bottom: 20px;
-}
-
-.vd-modal-title {
-  font-size: 1.1rem;
-  font-weight: 800;
-  color: var(--text);
-}
-
-.vd-modal-form {
-  display: flex;
-  flex-direction: column;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-xl);
+  padding: 24px 20px;
+  box-shadow: var(--shadow-sm);
   gap: 16px;
+  max-width: 560px;
 }
 
-.vd-modal-photo-section {
+.vd-form-photo-section {
   display: flex;
   align-items: center;
   gap: 16px;
   margin-bottom: 4px;
 }
 
-.vd-modal-avatar {
+.vd-form-avatar {
   width: 72px;
   height: 72px;
   border-radius: 50%;
@@ -1109,7 +1004,7 @@
   flex-shrink: 0;
 }
 
-.vd-modal-avatar-placeholder {
+.vd-form-avatar-placeholder {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -1117,7 +1012,7 @@
   font-weight: 800;
 }
 
-.vd-modal-photo-btn {
+.vd-form-photo-btn {
   display: inline-block;
   background: var(--surface-alt);
   border: 1.5px solid var(--border);
@@ -1130,19 +1025,19 @@
   transition: background var(--transition), border-color var(--transition), color var(--transition);
 }
 
-.vd-modal-photo-btn:hover {
+.vd-form-photo-btn:hover {
   background: var(--primary-light);
   border-color: rgba(10, 147, 150, 0.3);
   color: var(--primary-dark);
 }
 
-.vd-modal-field {
+.vd-form-field {
   display: flex;
   flex-direction: column;
   gap: 6px;
 }
 
-.vd-modal-label {
+.vd-form-label {
   font-size: 0.75rem;
   font-weight: 700;
   text-transform: uppercase;
@@ -1150,7 +1045,7 @@
   color: var(--text-muted);
 }
 
-.vd-modal-input {
+.vd-form-input {
   width: 100%;
   padding: 10px 14px;
   border: 1.5px solid var(--border);
@@ -1164,53 +1059,19 @@
   appearance: auto;
 }
 
-.vd-modal-input:focus {
+.vd-form-input:focus {
   outline: none;
   border-color: var(--primary);
   box-shadow: 0 0 0 3px rgba(10, 147, 150, 0.12);
 }
 
-.vd-modal-pin-row {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-}
-
-.vd-modal-pin-swatch {
-  position: relative;
-  width: 44px;
-  height: 44px;
-  border-radius: var(--radius-md);
-  border: 2px solid rgba(0, 0, 0, 0.1);
-  cursor: pointer;
-  display: block;
-  overflow: hidden;
-  flex-shrink: 0;
-  transition: box-shadow var(--transition);
-}
-
-.vd-modal-pin-swatch:hover {
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
-}
-
-.vd-modal-pin-input {
-  position: absolute;
-  inset: 0;
-  width: 100%;
-  height: 100%;
-  opacity: 0;
-  cursor: pointer;
-  border: none;
-  padding: 0;
-}
-
-.vd-modal-payments-grid {
+.vd-form-payments-grid {
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
 }
 
-.vd-modal-payment-chip {
+.vd-form-payment-chip {
   display: inline-flex;
   align-items: center;
   gap: 6px;
@@ -1226,57 +1087,47 @@
   transition: background var(--transition), border-color var(--transition), color var(--transition);
 }
 
-.vd-modal-payment-chip-icon {
+.vd-form-payment-chip-icon {
   display: flex;
   align-items: center;
   font-size: 0.9rem;
 }
 
-.vd-modal-payment-chip.active {
+.vd-form-payment-chip.active {
   background: var(--primary);
   border-color: var(--primary);
   color: #fff;
 }
 
-.vd-modal-payment-chip:hover {
+.vd-form-payment-chip:hover {
   border-color: var(--primary-light-solid);
 }
 
-.vd-modal-error {
+.vd-form-error {
   color: #c62828;
   font-size: 0.82rem;
   font-weight: 600;
   margin: 0;
 }
 
-.vd-modal-actions {
+.vd-form-success {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: #1b8a4e;
+  font-size: 0.82rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.vd-form-actions {
   display: flex;
   gap: 10px;
   margin-top: 4px;
 }
 
-.vd-modal-cancel {
+.vd-form-save {
   flex: 1;
-  background: transparent;
-  border: 1.5px solid var(--border-strong);
-  border-radius: var(--radius-full);
-  padding: 11px 20px;
-  font-size: 0.875rem;
-  font-weight: 600;
-  color: var(--text-secondary);
-  cursor: pointer;
-  min-height: auto;
-  transition: background var(--transition), border-color var(--transition), color var(--transition);
-}
-
-.vd-modal-cancel:hover {
-  background: rgba(239, 68, 68, 0.06);
-  border-color: #ef5350;
-  color: #c62828;
-}
-
-.vd-modal-save {
-  flex: 2;
   background: var(--primary);
   border: none;
   border-radius: var(--radius-full);
@@ -1290,73 +1141,20 @@
   transition: background var(--transition), box-shadow var(--transition), transform var(--transition);
 }
 
-.vd-modal-save:hover:not(:disabled) {
+.vd-form-save:hover:not(:disabled) {
   background: var(--primary-hover);
   box-shadow: var(--shadow-warm-lg);
   transform: translateY(-1px);
 }
 
-.vd-modal-save:disabled {
+.vd-form-save:disabled {
   opacity: 0.7;
   cursor: not-allowed;
 }
 
-@media (min-width: 480px) {
-  .vd-modal-overlay {
-    align-items: center;
-  }
+/* ── Segurança ───────────────────────────────────────── */
 
-  .vd-modal {
-    border-radius: var(--radius-xl);
-    padding: 28px 28px 36px;
-    max-height: 85vh;
-  }
-}
-
-/* ── Modal tabs ──────────────────────────────────────── */
-
-.vd-modal-tabs {
-  display: flex;
-  gap: 4px;
-  background: var(--surface-alt);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-full);
-  padding: 4px;
-  margin-bottom: 20px;
-}
-
-.vd-modal-tab {
-  flex: 1;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 6px;
-  background: transparent;
-  border: 1.5px solid transparent;
-  border-radius: var(--radius-full);
-  padding: 8px 12px;
-  font-size: 0.82rem;
-  font-weight: 700;
-  color: var(--text-muted);
-  cursor: pointer;
-  min-height: auto;
-  transition: border-color var(--transition), color var(--transition);
-}
-
-.vd-modal-tab.active {
-  background: transparent;
-  border-color: var(--text);
-  color: var(--text);
-}
-
-.vd-modal-tab:not(.active):hover {
-  border-color: var(--text-secondary);
-  color: var(--text-secondary);
-}
-
-/* ── Security tab ────────────────────────────────────── */
-
-.vd-modal-security-header {
+.vd-form-security-header {
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -1365,95 +1163,14 @@
   padding: 8px 0 4px;
 }
 
-.vd-modal-security-icon {
+.vd-form-security-icon {
   color: var(--primary);
   opacity: 0.85;
 }
 
-.vd-modal-security-desc {
+.vd-form-security-desc {
   font-size: 0.85rem;
   color: var(--text-muted);
   margin: 0;
   max-width: 260px;
-}
-
-.vd-modal-success {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  color: #1b8a4e;
-  font-size: 0.82rem;
-  font-weight: 600;
-  margin: 0;
-}
-
-/* ── Responsive ──────────────────────────────────────── */
-
-@media (max-width: 768px) {
-  .vd-container {
-    margin-left: 200px;
-    padding: 0 1.5rem 3rem;
-  }
-}
-
-@media (max-width: 480px) {
-  .vd-container {
-    margin-left: 70px;
-    padding: 0 0.75rem 2rem;
-  }
-
-  .vd-hero {
-    padding: 26px 20px 22px;
-  }
-
-  .vd-avatar {
-    width: 62px;
-    height: 62px;
-  }
-
-  .vd-quick-card {
-    padding: 16px 8px 12px;
-  }
-
-  .vd-quick-icon {
-    width: 38px;
-    height: 38px;
-    font-size: 1.05rem;
-  }
-
-  .vd-quick-label {
-    font-size: 0.78rem;
-  }
-
-  .vd-quick-desc {
-    font-size: 0.65rem;
-  }
-
-  .vd-stats-grid {
-    grid-template-columns: repeat(2, 1fr);
-  }
-
-  .vd-bottom-section {
-    grid-template-columns: 1fr;
-  }
-}
-
-@media (max-width: 768px) {
-  .vd-quick-grid {
-    grid-template-columns: 1fr 1fr;
-  }
-
-  .vd-stats-grid {
-    grid-template-columns: repeat(2, 1fr);
-  }
-
-  .vd-bottom-section {
-    grid-template-columns: 1fr;
-  }
-}
-
-@media (max-width: 1080px) {
-  .vd-bottom-section {
-    grid-template-columns: 1fr;
-  }
 }

--- a/sunny_sales_web/src/pages/VendorDashboard.jsx
+++ b/sunny_sales_web/src/pages/VendorDashboard.jsx
@@ -10,10 +10,10 @@ import {
   FiShoppingBag, FiNavigation, FiBarChart2,
   FiEdit2, FiAlertCircle, FiX,
   FiClock, FiTrendingUp, FiLogOut, FiSettings,
+  FiHome, FiHelpCircle, FiChevronRight, FiArrowLeft,
 } from 'react-icons/fi';
 import ImageCropper from '../components/ImageCropper';
 import PinColorPicker from '../components/PinColorPicker';
-import VendorSidebar from '../components/VendorSidebar';
 import './VendorDashboard.css';
 
 // Distância mínima (m) entre leituras de GPS para serem aceites como
@@ -83,6 +83,13 @@ function relativeTime(dateStr) {
   return new Date(dateStr).toLocaleDateString('pt-PT');
 }
 
+const SECTION_TITLES = {
+  inicio: 'Visão geral',
+  dados: 'Dados pessoais',
+  aparencia: 'Aparência',
+  seguranca: 'Segurança',
+};
+
 export default function VendorDashboard() {
   const [vendor, setVendor] = useState(null);
   const [sharing, setSharing] = useState(false);
@@ -92,9 +99,11 @@ export default function VendorDashboard() {
   const [notice, setNotice] = useState(null);
   const navigate = useNavigate();
 
-  // Profile modal state
-  const [profileOpen, setProfileOpen] = useState(false);
-  const [profileTab, setProfileTab] = useState('aparencia');
+  // Secção ativa (painel central no PC; no telemóvel abre por cima do menu)
+  const [activeSection, setActiveSection] = useState('inicio');
+  const [mobilePanelOpen, setMobilePanelOpen] = useState(false);
+
+  // Formulários de perfil (aparência / dados pessoais / segurança)
   const [editName, setEditName] = useState('');
   const [editEmail, setEditEmail] = useState('');
   const [editNif, setEditNif] = useState('');
@@ -235,6 +244,18 @@ export default function VendorDashboard() {
     checkPermission();
   }, []);
 
+  // Preenche os formulários de perfil com os dados atuais do vendedor
+  useEffect(() => {
+    if (!vendor) return;
+    setEditName(vendor.name || '');
+    setEditEmail(vendor.email || '');
+    setEditNif(vendor.nif || '');
+    setEditPhone(vendor.phone || '');
+    setEditProduct(vendor.product || '');
+    setEditPinColor(vendor.pin_color || '#7B61FF');
+    setEditPaymentMethods(vendor.payment_methods ? vendor.payment_methods.split(',').filter(Boolean) : []);
+  }, [vendor]);
+
   // Carrega os trajetos para calcular o resumo do dia e a atividade recente
   useEffect(() => {
     if (!vendor?.id) return;
@@ -317,39 +338,28 @@ export default function VendorDashboard() {
       .slice(0, 4);
   }, [routes]);
 
-  // ── Profile modal ─────────────────────────────────────
+  // ── Navegação entre secções ───────────────────────────
 
-  const openProfileModal = () => {
-    if (!vendor) return;
-    setProfileTab('aparencia');
-    setEditName(vendor.name || '');
-    setEditEmail(vendor.email || '');
-    setEditNif(vendor.nif || '');
-    setEditPhone(vendor.phone || '');
-    setEditProduct(vendor.product || '');
-    setEditPhoto(null);
-    setEditPhotoPreview(null);
-    setEditCropSrc(null);
-    setEditPinColor(vendor.pin_color || '#7B61FF');
-    setEditPaymentMethods(vendor.payment_methods ? vendor.payment_methods.split(',').filter(Boolean) : []);
+  const openSection = (id) => {
+    setActiveSection(id);
+    setMobilePanelOpen(true);
+    // Limpa mensagens de gravações anteriores ao entrar numa secção
     setEditError('');
     setEditSuccess('');
     setPersonalError('');
     setPersonalSuccess('');
-    setSecOldPassword('');
-    setSecNewPassword('');
     setSecError('');
     setSecSuccess('');
-    setProfileOpen(true);
+    if (id === 'seguranca') {
+      setSecOldPassword('');
+      setSecNewPassword('');
+    }
+    window.scrollTo({ top: 0 });
   };
 
-  const closeProfileModal = () => {
-    if (editPhotoPreview) URL.revokeObjectURL(editPhotoPreview);
-    if (editCropSrc) URL.revokeObjectURL(editCropSrc);
-    setProfileOpen(false);
-    setEditPhoto(null);
-    setEditPhotoPreview(null);
-    setEditCropSrc(null);
+  const closePanel = () => {
+    setMobilePanelOpen(false);
+    window.scrollTo({ top: 0 });
   };
 
   const handleEditPhoto = (e) => {
@@ -493,7 +503,7 @@ export default function VendorDashboard() {
     ? new Date(vendor.subscription_valid_until).toLocaleDateString('pt-PT')
     : null;
 
-  const modalAvatarSrc = editPhotoPreview
+  const formAvatarSrc = editPhotoPreview
     || (vendor?.profile_photo ? mediaUrl(vendor.profile_photo) : null);
 
   const todayLabel = new Date().toLocaleDateString('pt-PT', {
@@ -502,96 +512,57 @@ export default function VendorDashboard() {
     month: 'long',
   });
 
-  const quickActions = [
-    { path: '/routes', icon: <FiNavigation />, label: 'Trajetos', desc: 'Histórico de sessões' },
-    { path: '/stats', icon: <FiBarChart2 />, label: 'Estatísticas', desc: 'Km percorridos por dia' },
-    { path: '/products', icon: <FiShoppingBag />, label: 'Produtos', desc: 'Gerir o teu catálogo' },
-    { path: '/paid-weeks', icon: <FiCreditCard />, label: 'Subscrição', desc: 'Pagamentos e recibos' },
+  // ── Estrutura do menu (foto em cima, menus em baixo) ──
+
+  const menuGroups = [
+    {
+      label: 'Atividade',
+      items: [
+        { id: 'inicio', type: 'section', icon: <FiHome />, label: 'Visão geral' },
+        { id: 'location', type: 'toggle', icon: <FiMapPin />, label: 'Partilha de localização' },
+        { type: 'route', path: '/routes', icon: <FiNavigation />, label: 'Trajetos' },
+        { type: 'route', path: '/stats', icon: <FiBarChart2 />, label: 'Estatísticas' },
+      ],
+    },
+    {
+      label: 'Conta',
+      items: [
+        { id: 'dados', type: 'section', icon: <FiUser />, label: 'Dados pessoais' },
+        { id: 'aparencia', type: 'section', icon: <FiEdit2 />, label: 'Aparência' },
+        { id: 'seguranca', type: 'section', icon: <FiLock />, label: 'Segurança' },
+        { type: 'route', path: '/settings', icon: <FiSettings />, label: 'Definições' },
+      ],
+    },
+    {
+      label: 'Negócio',
+      items: [
+        { type: 'route', path: '/products', icon: <FiShoppingBag />, label: 'Produtos' },
+        {
+          type: 'route',
+          path: '/paid-weeks',
+          icon: <FiCreditCard />,
+          label: 'Subscrição',
+          value: subscriptionActive ? 'Ativa' : 'Inativa',
+          valueClass: subscriptionActive ? 'on' : 'off',
+        },
+        { type: 'route', path: '/invoices', icon: <FiFileText />, label: 'Faturas' },
+      ],
+    },
+    {
+      label: 'Suporte',
+      items: [
+        { type: 'route', path: '/faqs', icon: <FiHelpCircle />, label: 'Perguntas frequentes' },
+        { type: 'route', path: '/contacto', icon: <FiMail />, label: 'Contactar suporte' },
+      ],
+    },
   ];
 
-  return (
-    <div className="vd-wrapper">
-      <VendorSidebar onLogout={logout} />
-      <div className="vd-container">
-
-        {/* Cabeçalho */}
-        {vendor && (
-          <div className="vd-hero">
-            <span className="vd-hero-date">{todayLabel}</span>
-            <h1 className="vd-hero-title">
-              {getGreeting()}, {vendor.name.split(' ')[0]}
-            </h1>
-            <p className="vd-hero-subtitle">
-              Gere a tua presença no mapa e acompanha a tua atividade do dia.
-            </p>
-            <div className="vd-hero-chips">
-              <span className={`vd-hero-chip${subscriptionActive ? ' on' : ' off'}`}>
-                <span className="vd-hero-chip-dot" />
-                {subscriptionActive ? 'Subscrição ativa' : 'Subscrição inativa'}
-              </span>
-              <span className={`vd-hero-chip${sharing ? ' on' : ' off'}`}>
-                <span className="vd-hero-chip-dot" />
-                {sharing ? 'Visível no mapa' : 'Localização desligada'}
-              </span>
-            </div>
-          </div>
-        )}
-
-        {/* Aviso contextual (substitui os alert()) */}
-        {notice && (
-          <div className={`vd-notice vd-notice-${notice.type}`} role="alert">
-            <FiAlertCircle className="vd-notice-icon" />
-            <span className="vd-notice-text">{notice.text}</span>
-            <button
-              type="button"
-              className="vd-notice-close"
-              aria-label="Fechar aviso"
-              onClick={() => setNotice(null)}
-            >
-              <FiX />
-            </button>
-          </div>
-        )}
-
-        {/* Permissão de localização negada */}
-        {locationPermission === 'denied' && (
-          <div className="vd-cta-card warning">
-            <div className="vd-cta-text">
-              <span className="vd-cta-title">Permissão de localização negada</span>
-              <span className="vd-cta-desc">Ativa-a nas definições do browser para poderes partilhar a tua localização</span>
-            </div>
-          </div>
-        )}
-
-        {/* CTA de subscrição inativa */}
-        {vendor && !subscriptionActive && (
-          <div className="vd-cta-card">
-            <div className="vd-cta-text">
-              <span className="vd-cta-title">Subscrição inativa</span>
-              <span className="vd-cta-desc">Ativa a subscrição para apareceres no mapa e receberes clientes</span>
-            </div>
-            <button className="vd-cta-btn" onClick={() => navigate('/planos')}>
-              Ativar
-            </button>
-          </div>
-        )}
-
-        {/* Partilha de localização */}
-        <div className={`vd-location-card${sharing ? ' active' : ''}`}>
-          <div className="vd-location-icon-wrap">
-            <FiMapPin className="vd-location-icon" />
-            {sharing && <span className="vd-location-pulse" />}
-          </div>
-          <div className="vd-location-text">
-            <span className="vd-location-title">Partilha de localização</span>
-            <span className="vd-location-status">
-              {sharing
-                ? 'Ativa — estás visível no mapa'
-                : subscriptionActive
-                  ? 'Desligada — não apareces no mapa'
-                  : 'Requer subscrição ativa'}
-            </span>
-          </div>
+  const renderMenuItem = (item) => {
+    if (item.type === 'toggle') {
+      return (
+        <div key={item.id} className="vd-menu-row vd-menu-row-static">
+          <span className="vd-menu-row-icon">{item.icon}</span>
+          <span className="vd-menu-row-label">{item.label}</span>
           <label className="vendor-switch" aria-label="Ativar/desativar localização">
             <input
               type="checkbox"
@@ -601,465 +572,502 @@ export default function VendorDashboard() {
             <span className="slider" />
           </label>
         </div>
+      );
+    }
+    if (item.type === 'section') {
+      const active = activeSection === item.id;
+      return (
+        <button
+          key={item.id}
+          type="button"
+          className={`vd-menu-row${active ? ' active' : ''}`}
+          onClick={() => openSection(item.id)}
+        >
+          <span className="vd-menu-row-icon">{item.icon}</span>
+          <span className="vd-menu-row-label">{item.label}</span>
+          <FiChevronRight className="vd-menu-row-chevron" />
+        </button>
+      );
+    }
+    return (
+      <button
+        key={item.path}
+        type="button"
+        className="vd-menu-row"
+        onClick={() => navigate(item.path)}
+      >
+        <span className="vd-menu-row-icon">{item.icon}</span>
+        <span className="vd-menu-row-label">{item.label}</span>
+        {item.value && (
+          <span className={`vd-menu-row-value ${item.valueClass || ''}`}>{item.value}</span>
+        )}
+        <FiChevronRight className="vd-menu-row-chevron" />
+      </button>
+    );
+  };
 
-        <div className="vd-info-card">
-          💡 <strong>Dica:</strong> a app web partilha a localização enquanto o separador estiver
-          ativo. Para partilha contínua em segundo plano, usa a <strong>app móvel</strong>.
+  return (
+    <div className="vd-page">
+
+      {/* Aviso contextual (substitui os alert()) */}
+      {notice && (
+        <div className={`vd-notice vd-notice-${notice.type}`} role="alert">
+          <FiAlertCircle className="vd-notice-icon" />
+          <span className="vd-notice-text">{notice.text}</span>
+          <button
+            type="button"
+            className="vd-notice-close"
+            aria-label="Fechar aviso"
+            onClick={() => setNotice(null)}
+          >
+            <FiX />
+          </button>
         </div>
+      )}
 
-        {/* Resumo de hoje (dados reais dos trajetos) */}
-        {vendor && (
-          <div className="vd-stats-section">
-            <h3 className="vd-section-title">Resumo de hoje</h3>
-            <div className="vd-stats-grid">
-              <div className="vd-stat-card">
-                <div className="vd-stat-icon"><FiNavigation /></div>
-                <div className="vd-stat-value">
-                  {stats ? formatDistance(stats.distToday) : '—'}
+      <div className={`vd-layout${mobilePanelOpen ? ' panel-open' : ''}`}>
+
+        {/* ── Menu (telemóvel: foto em cima e menus em baixo;
+               PC: coluna fixa à esquerda) ─────────────────── */}
+        <aside className="vd-menu">
+          {vendor && (
+            <button type="button" className="vd-profile-head" onClick={() => openSection('dados')}>
+              {vendor.profile_photo ? (
+                <img
+                  src={mediaUrl(vendor.profile_photo)}
+                  alt="Foto de perfil"
+                  className="vd-avatar"
+                  style={{ borderColor: pinColor }}
+                />
+              ) : (
+                <div
+                  className="vd-avatar vd-avatar-placeholder"
+                  style={{ borderColor: pinColor, background: `${pinColor}22`, color: pinColor }}
+                >
+                  {vendor.name?.charAt(0)?.toUpperCase() || '?'}
                 </div>
-                <div className="vd-stat-label">Distância percorrida</div>
+              )}
+              <div className="vd-profile-head-meta">
+                <span className="vd-profile-head-name">{vendor.name}</span>
+                <span className="vd-profile-head-email">{vendor.email}</span>
+                <span className={`vd-sub-badge${subscriptionActive ? ' active' : ' inactive'}`}>
+                  <span className="vd-sub-dot" />
+                  {subscriptionActive
+                    ? <>Subscrição ativa{subscriptionDate && <span className="vd-sub-date"> · até {subscriptionDate}</span>}</>
+                    : 'Subscrição inativa'}
+                </span>
               </div>
-              <div className="vd-stat-card">
-                <div className="vd-stat-icon"><FiClock /></div>
-                <div className="vd-stat-value">
-                  {stats ? formatDuration(stats.msToday) : '—'}
-                </div>
-                <div className="vd-stat-label">Tempo online</div>
-              </div>
-              <div className="vd-stat-card">
-                <div className="vd-stat-icon"><FiMapPin /></div>
-                <div className="vd-stat-value">
-                  {stats ? stats.sessionsToday : '—'}
-                </div>
-                <div className="vd-stat-label">Sessões de partilha</div>
-              </div>
-              <div className="vd-stat-card">
-                <div className="vd-stat-icon"><FiTrendingUp /></div>
-                <div className="vd-stat-value">
-                  {stats ? formatDistance(stats.distWeek) : '—'}
-                </div>
-                <div className="vd-stat-label">Últimos 7 dias</div>
+              <FiChevronRight className="vd-menu-row-chevron" />
+            </button>
+          )}
+
+          {menuGroups.map((group) => (
+            <div className="vd-menu-section" key={group.label}>
+              <span className="vd-menu-section-label">{group.label}</span>
+              <div className="vd-menu-group">
+                {group.items.map(renderMenuItem)}
               </div>
             </div>
-          </div>
-        )}
+          ))}
 
-        {/* Ações rápidas */}
-        <div className="vd-quick-section">
-          <h3 className="vd-section-title">Ações rápidas</h3>
-          <div className="vd-quick-grid">
-            {quickActions.map((action) => (
-              <button
-                key={action.path}
-                type="button"
-                className="vd-quick-card"
-                onClick={() => navigate(action.path)}
-              >
-                <span className="vd-quick-icon">{action.icon}</span>
-                <span className="vd-quick-label">{action.label}</span>
-                <span className="vd-quick-desc">{action.desc}</span>
+          <div className="vd-menu-section">
+            <div className="vd-menu-group">
+              <button type="button" className="vd-menu-row danger" onClick={logout}>
+                <span className="vd-menu-row-icon"><FiLogOut /></span>
+                <span className="vd-menu-row-label">Terminar sessão</span>
               </button>
-            ))}
+            </div>
           </div>
-        </div>
+        </aside>
 
-        {/* Perfil + atividade recente */}
-        <div className="vd-bottom-section">
-          {vendor && (
-            <div className="vd-profile-card">
-              <div className="vd-profile-top">
-                {vendor.profile_photo ? (
-                  <img
-                    src={mediaUrl(vendor.profile_photo)}
-                    alt="Foto de perfil"
-                    className="vd-avatar"
-                    style={{ borderColor: pinColor }}
-                  />
-                ) : (
-                  <div
-                    className="vd-avatar vd-avatar-placeholder"
-                    style={{ borderColor: pinColor, background: `${pinColor}22`, color: pinColor }}
-                  >
-                    {vendor.name?.charAt(0)?.toUpperCase() || '?'}
+        {/* ── Painel central (PC) / vista de detalhe (telemóvel) ── */}
+        <section className="vd-panel">
+          <header className="vd-panel-header">
+            <button type="button" className="vd-panel-back" onClick={closePanel}>
+              <FiArrowLeft /> Voltar
+            </button>
+            <h2 className="vd-panel-title">{SECTION_TITLES[activeSection]}</h2>
+          </header>
+
+          {activeSection === 'inicio' && (
+            <div className="vd-panel-body">
+
+              {vendor && (
+                <div className="vd-hero">
+                  <span className="vd-hero-date">{todayLabel}</span>
+                  <h1 className="vd-hero-title">
+                    {getGreeting()}, {vendor.name.split(' ')[0]}
+                  </h1>
+                  <p className="vd-hero-subtitle">
+                    Gere a tua presença no mapa e acompanha a tua atividade do dia.
+                  </p>
+                  <div className="vd-hero-chips">
+                    <span className={`vd-hero-chip${subscriptionActive ? ' on' : ' off'}`}>
+                      <span className="vd-hero-chip-dot" />
+                      {subscriptionActive ? 'Subscrição ativa' : 'Subscrição inativa'}
+                    </span>
+                    <span className={`vd-hero-chip${sharing ? ' on' : ' off'}`}>
+                      <span className="vd-hero-chip-dot" />
+                      {sharing ? 'Visível no mapa' : 'Localização desligada'}
+                    </span>
                   </div>
-                )}
-                <div className="vd-profile-meta">
-                  <span className="vd-profile-name">{vendor.name}</span>
-                  <span className="vd-profile-product">{vendor.product}</span>
-                  <span className={`vd-sub-badge${subscriptionActive ? ' active' : ' inactive'}`}>
-                    <span className="vd-sub-dot" />
-                    {subscriptionActive
-                      ? <>Ativa{subscriptionDate && <span className="vd-sub-date"> · até {subscriptionDate}</span>}</>
-                      : 'Inativa'}
+                </div>
+              )}
+
+              {/* Permissão de localização negada */}
+              {locationPermission === 'denied' && (
+                <div className="vd-cta-card warning">
+                  <div className="vd-cta-text">
+                    <span className="vd-cta-title">Permissão de localização negada</span>
+                    <span className="vd-cta-desc">Ativa-a nas definições do browser para poderes partilhar a tua localização</span>
+                  </div>
+                </div>
+              )}
+
+              {/* CTA de subscrição inativa */}
+              {vendor && !subscriptionActive && (
+                <div className="vd-cta-card">
+                  <div className="vd-cta-text">
+                    <span className="vd-cta-title">Subscrição inativa</span>
+                    <span className="vd-cta-desc">Ativa a subscrição para apareceres no mapa e receberes clientes</span>
+                  </div>
+                  <button className="vd-cta-btn" onClick={() => navigate('/planos')}>
+                    Ativar
+                  </button>
+                </div>
+              )}
+
+              {/* Partilha de localização */}
+              <div className={`vd-location-card${sharing ? ' active' : ''}`}>
+                <div className="vd-location-icon-wrap">
+                  <FiMapPin className="vd-location-icon" />
+                  {sharing && <span className="vd-location-pulse" />}
+                </div>
+                <div className="vd-location-text">
+                  <span className="vd-location-title">Partilha de localização</span>
+                  <span className="vd-location-status">
+                    {sharing
+                      ? 'Ativa — estás visível no mapa'
+                      : subscriptionActive
+                        ? 'Desligada — não apareces no mapa'
+                        : 'Requer subscrição ativa'}
                   </span>
                 </div>
-                <button type="button" className="vd-edit-btn" onClick={openProfileModal}>
-                  <FiEdit2 size={13} /> Editar
-                </button>
+                <label className="vendor-switch" aria-label="Ativar/desativar localização">
+                  <input
+                    type="checkbox"
+                    checked={sharing}
+                    onChange={sharing ? stopSharing : startSharing}
+                  />
+                  <span className="slider" />
+                </label>
               </div>
 
-              <div className="vd-profile-divider" />
+              <div className="vd-info-card">
+                💡 <strong>Dica:</strong> a app web partilha a localização enquanto o separador estiver
+                ativo. Para partilha contínua em segundo plano, usa a <strong>app móvel</strong>.
+              </div>
 
-              <div className="vd-profile-details">
-                <div className="vd-detail-row">
-                  <span className="vd-detail-row-icon"><FiMail /></span>
-                  <span className="vd-detail-row-label">Email</span>
-                  <span className="vd-detail-row-value">{vendor.email}</span>
-                </div>
-                <div className="vd-detail-row">
-                  <span className="vd-detail-row-icon">
-                    <span className="vd-pin-dot" style={{ backgroundColor: pinColor }} />
-                  </span>
-                  <span className="vd-detail-row-label">Cor do pin</span>
-                  <span className="vd-detail-row-value" />
-                </div>
-                {vendor.payment_methods && (
-                  <div className="vd-detail-row vd-detail-row-payments">
-                    <span className="vd-detail-row-icon"><FiCreditCard /></span>
-                    <span className="vd-detail-row-label">Pagamentos</span>
-                    <div className="vd-payments-row">
-                      {vendor.payment_methods.split(',').filter(Boolean).map(m => (
-                        <span key={m} className="vd-payment-badge" title={m}>
-                          <span className="vd-payment-badge-icon">{PAYMENT_ICONS[m] || <FiCreditCard />}</span>
-                          <span className="vd-payment-badge-label">{m}</span>
-                        </span>
-                      ))}
+              {/* Resumo de hoje (dados reais dos trajetos) */}
+              {vendor && (
+                <div className="vd-stats-section">
+                  <h3 className="vd-section-title">Resumo de hoje</h3>
+                  <div className="vd-stats-grid">
+                    <div className="vd-stat-card">
+                      <div className="vd-stat-icon"><FiNavigation /></div>
+                      <div className="vd-stat-value">
+                        {stats ? formatDistance(stats.distToday) : '—'}
+                      </div>
+                      <div className="vd-stat-label">Distância percorrida</div>
+                    </div>
+                    <div className="vd-stat-card">
+                      <div className="vd-stat-icon"><FiClock /></div>
+                      <div className="vd-stat-value">
+                        {stats ? formatDuration(stats.msToday) : '—'}
+                      </div>
+                      <div className="vd-stat-label">Tempo online</div>
+                    </div>
+                    <div className="vd-stat-card">
+                      <div className="vd-stat-icon"><FiMapPin /></div>
+                      <div className="vd-stat-value">
+                        {stats ? stats.sessionsToday : '—'}
+                      </div>
+                      <div className="vd-stat-label">Sessões de partilha</div>
+                    </div>
+                    <div className="vd-stat-card">
+                      <div className="vd-stat-icon"><FiTrendingUp /></div>
+                      <div className="vd-stat-value">
+                        {stats ? formatDistance(stats.distWeek) : '—'}
+                      </div>
+                      <div className="vd-stat-label">Últimos 7 dias</div>
                     </div>
                   </div>
+                </div>
+              )}
+
+              {/* Atividade recente */}
+              <div className="vd-activity-card">
+                <div className="vd-activity-card-title">
+                  <span>Atividade recente</span>
+                  {recentRoutes.length > 0 && (
+                    <Link to="/routes" className="vd-activity-view-all">Ver tudo</Link>
+                  )}
+                </div>
+                {routes === null && (
+                  <div className="vd-activity-empty">A carregar atividade…</div>
+                )}
+                {routes !== null && recentRoutes.length === 0 && (
+                  <div className="vd-activity-empty">
+                    Ainda não tens trajetos registados. Ativa a partilha de localização para
+                    começares a registar a tua atividade.
+                  </div>
+                )}
+                {recentRoutes.length > 0 && (
+                  <div className="vd-activity-items">
+                    {recentRoutes.map((r) => {
+                      const ongoing = !r.end_time;
+                      const duration = ongoing
+                        ? Date.now() - new Date(r.start_time).getTime()
+                        : new Date(r.end_time) - new Date(r.start_time);
+                      return (
+                        <Link to="/routes" key={r.id ?? r.start_time} className="vd-activity-item">
+                          <div className="vd-activity-item-icon"><FiNavigation size={14} /></div>
+                          <div className="vd-activity-item-content">
+                            <div className="vd-activity-item-title">
+                              {ongoing
+                                ? 'Sessão em curso'
+                                : `Sessão de ${formatDuration(duration)} · ${formatDistance(r.distance_m || 0)}`}
+                            </div>
+                            <div className="vd-activity-item-time">{relativeTime(r.start_time)}</div>
+                          </div>
+                        </Link>
+                      );
+                    })}
+                  </div>
                 )}
               </div>
+
+              {/* Dicas */}
+              <div className="vd-tips-card">
+                <div className="vd-tips-title">💡 Dicas para vendedores</div>
+                <div className="vd-tips-items">
+                  <div className="vd-tip-item">
+                    <div className="vd-tip-item-icon">✓</div>
+                    <div>Mantém a partilha de localização ativa para apareceres no mapa</div>
+                  </div>
+                  <div className="vd-tip-item">
+                    <div className="vd-tip-item-icon">✓</div>
+                    <div>Atualiza os teus produtos e métodos de pagamento regularmente</div>
+                  </div>
+                  <div className="vd-tip-item">
+                    <div className="vd-tip-item-icon">✓</div>
+                    <div>Uma foto de perfil ajuda os banhistas a reconhecer-te</div>
+                  </div>
+                  <div className="vd-tip-item">
+                    <div className="vd-tip-item-icon">✓</div>
+                    <div>O maior movimento na praia é entre as 15h e as 19h</div>
+                  </div>
+                </div>
+                <div className="vd-tips-footer">
+                  <Link to="/faqs" className="vd-tips-learn-more">Ver perguntas frequentes →</Link>
+                </div>
+              </div>
+
             </div>
           )}
 
-          <div className="vd-activity-card">
-            <div className="vd-activity-card-title">
-              <span>Atividade recente</span>
-              {recentRoutes.length > 0 && (
-                <Link to="/routes" className="vd-activity-view-all">Ver tudo</Link>
+          {activeSection === 'aparencia' && (
+            <form className="vd-panel-body vd-form" onSubmit={saveAppearance}>
+              {/* Avatar + photo upload */}
+              <div className="vd-form-photo-section">
+                {formAvatarSrc ? (
+                  <img
+                    src={formAvatarSrc}
+                    alt="Foto de perfil"
+                    className="vd-form-avatar"
+                    style={{ borderColor: editPinColor }}
+                  />
+                ) : (
+                  <div
+                    className="vd-form-avatar vd-form-avatar-placeholder"
+                    style={{ borderColor: editPinColor, background: `${editPinColor}22`, color: editPinColor }}
+                  >
+                    {vendor?.name?.charAt(0)?.toUpperCase() || '?'}
+                  </div>
+                )}
+                <label className="vd-form-photo-btn">
+                  Alterar foto
+                  <input type="file" accept="image/*" hidden onChange={handleEditPhoto} />
+                </label>
+              </div>
+
+              <div className="vd-form-field">
+                <label className="vd-form-label">Cor do Pin</label>
+                <PinColorPicker value={editPinColor} onChange={setEditPinColor} />
+              </div>
+
+              <div className="vd-form-field">
+                <label className="vd-form-label">Produto</label>
+                <select
+                  className="vd-form-input"
+                  value={editProduct}
+                  onChange={e => setEditProduct(e.target.value)}
+                >
+                  <option value="Bolas de Berlim">Bolas de Berlim</option>
+                  <option value="Gelados">Gelados</option>
+                  <option value="Acessórios de Praia">Acessórios de Praia</option>
+                </select>
+              </div>
+
+              <div className="vd-form-field">
+                <label className="vd-form-label">Métodos de pagamento aceites</label>
+                <div className="vd-form-payments-grid">
+                  {Object.keys(PAYMENT_ICONS).map((method) => (
+                    <button
+                      type="button"
+                      key={method}
+                      className={`vd-form-payment-chip${editPaymentMethods.includes(method) ? ' active' : ''}`}
+                      onClick={() => togglePaymentMethod(method)}
+                    >
+                      <span className="vd-form-payment-chip-icon">{PAYMENT_ICONS[method]}</span>
+                      {method}
+                    </button>
+                  ))}
+                </div>
+              </div>
+
+              {editError && <p className="vd-form-error">{editError}</p>}
+              {editSuccess && (
+                <p className="vd-form-success">
+                  <FiCheck size={14} /> {editSuccess}
+                </p>
               )}
-            </div>
-            {routes === null && (
-              <div className="vd-activity-empty">A carregar atividade…</div>
-            )}
-            {routes !== null && recentRoutes.length === 0 && (
-              <div className="vd-activity-empty">
-                Ainda não tens trajetos registados. Ativa a partilha de localização para
-                começares a registar a tua atividade.
+
+              <div className="vd-form-actions">
+                <button type="submit" className="vd-form-save" disabled={editSaving}>
+                  {editSaving ? 'A guardar…' : 'Guardar'}
+                </button>
               </div>
-            )}
-            {recentRoutes.length > 0 && (
-              <div className="vd-activity-items">
-                {recentRoutes.map((r) => {
-                  const ongoing = !r.end_time;
-                  const duration = ongoing
-                    ? Date.now() - new Date(r.start_time).getTime()
-                    : new Date(r.end_time) - new Date(r.start_time);
-                  return (
-                    <Link to="/routes" key={r.id ?? r.start_time} className="vd-activity-item">
-                      <div className="vd-activity-item-icon"><FiNavigation size={14} /></div>
-                      <div className="vd-activity-item-content">
-                        <div className="vd-activity-item-title">
-                          {ongoing
-                            ? 'Sessão em curso'
-                            : `Sessão de ${formatDuration(duration)} · ${formatDistance(r.distance_m || 0)}`}
-                        </div>
-                        <div className="vd-activity-item-time">{relativeTime(r.start_time)}</div>
-                      </div>
-                    </Link>
-                  );
-                })}
+            </form>
+          )}
+
+          {activeSection === 'dados' && (
+            <form className="vd-panel-body vd-form" onSubmit={savePersonalData}>
+              <div className="vd-form-field">
+                <label className="vd-form-label">Nome</label>
+                <input
+                  className="vd-form-input"
+                  type="text"
+                  value={editName}
+                  onChange={e => setEditName(e.target.value)}
+                  required
+                />
               </div>
-            )}
-          </div>
-        </div>
+              <div className="vd-form-field">
+                <label className="vd-form-label">Email</label>
+                <input
+                  className="vd-form-input"
+                  type="email"
+                  value={editEmail}
+                  onChange={e => setEditEmail(e.target.value)}
+                  required
+                />
+              </div>
+              <div className="vd-form-field">
+                <label className="vd-form-label">NIF</label>
+                <input
+                  className="vd-form-input"
+                  type="text"
+                  inputMode="numeric"
+                  maxLength={9}
+                  placeholder="123456789"
+                  value={editNif}
+                  onChange={e => setEditNif(e.target.value.replace(/\D/g, ''))}
+                />
+              </div>
+              <div className="vd-form-field">
+                <label className="vd-form-label">Telemóvel</label>
+                <input
+                  className="vd-form-input"
+                  type="tel"
+                  placeholder="912345678"
+                  value={editPhone}
+                  onChange={e => setEditPhone(e.target.value)}
+                />
+              </div>
 
-        {/* Dicas */}
-        <div className="vd-tips-card">
-          <div className="vd-tips-title">💡 Dicas para vendedores</div>
-          <div className="vd-tips-items">
-            <div className="vd-tip-item">
-              <div className="vd-tip-item-icon">✓</div>
-              <div>Mantém a partilha de localização ativa para apareceres no mapa</div>
-            </div>
-            <div className="vd-tip-item">
-              <div className="vd-tip-item-icon">✓</div>
-              <div>Atualiza os teus produtos e métodos de pagamento regularmente</div>
-            </div>
-            <div className="vd-tip-item">
-              <div className="vd-tip-item-icon">✓</div>
-              <div>Uma foto de perfil ajuda os banhistas a reconhecer-te</div>
-            </div>
-            <div className="vd-tip-item">
-              <div className="vd-tip-item-icon">✓</div>
-              <div>O maior movimento na praia é entre as 15h e as 19h</div>
-            </div>
-          </div>
-          <div className="vd-tips-footer">
-            <Link to="/faqs" className="vd-tips-learn-more">Ver perguntas frequentes →</Link>
-          </div>
-        </div>
+              {personalError && <p className="vd-form-error">{personalError}</p>}
+              {personalSuccess && (
+                <p className="vd-form-success">
+                  <FiCheck size={14} /> {personalSuccess}
+                </p>
+              )}
 
-        {/* Conta */}
-        <div className="vd-account-section">
-          <h3 className="vd-section-title">Conta</h3>
-          <div className="vd-account-actions">
-            <button
-              type="button"
-              className="vd-account-btn"
-              onClick={() => navigate('/settings')}
-            >
-              <FiSettings /> Definições
-            </button>
-            <button
-              type="button"
-              className="vd-account-btn vd-account-btn-danger"
-              onClick={logout}
-            >
-              <FiLogOut /> Terminar sessão
-            </button>
-          </div>
-        </div>
+              <div className="vd-form-actions">
+                <button type="submit" className="vd-form-save" disabled={personalSaving}>
+                  {personalSaving ? 'A guardar…' : 'Guardar'}
+                </button>
+              </div>
+            </form>
+          )}
 
+          {activeSection === 'seguranca' && (
+            <form className="vd-panel-body vd-form" onSubmit={savePassword}>
+              <div className="vd-form-security-header">
+                <FiLock size={24} className="vd-form-security-icon" />
+                <p className="vd-form-security-desc">
+                  Introduz a tua palavra-passe atual e escolhe uma nova.
+                </p>
+              </div>
+
+              <div className="vd-form-field">
+                <label className="vd-form-label">Palavra-passe atual</label>
+                <input
+                  className="vd-form-input"
+                  type="password"
+                  placeholder="Palavra-passe atual"
+                  value={secOldPassword}
+                  onChange={e => setSecOldPassword(e.target.value)}
+                  autoComplete="current-password"
+                  required
+                />
+              </div>
+              <div className="vd-form-field">
+                <label className="vd-form-label">Nova palavra-passe</label>
+                <input
+                  className="vd-form-input"
+                  type="password"
+                  placeholder="Mínimo 8 caracteres"
+                  value={secNewPassword}
+                  onChange={e => setSecNewPassword(e.target.value)}
+                  autoComplete="new-password"
+                  required
+                />
+              </div>
+
+              {secError && <p className="vd-form-error">{secError}</p>}
+              {secSuccess && (
+                <p className="vd-form-success">
+                  <FiCheck size={14} /> {secSuccess}
+                </p>
+              )}
+
+              <div className="vd-form-actions">
+                <button type="submit" className="vd-form-save" disabled={secSaving}>
+                  {secSaving ? 'A guardar…' : 'Alterar Palavra-passe'}
+                </button>
+              </div>
+            </form>
+          )}
+        </section>
       </div>
 
-      {/* Profile edit modal */}
-      {profileOpen && (
-        <div className="vd-modal-overlay" onClick={closeProfileModal}>
-          <div className="vd-modal" onClick={e => e.stopPropagation()}>
-            <div className="vd-modal-header">
-              <button type="button" className="back-btn" onClick={closeProfileModal}>
-                ← Voltar
-              </button>
-              <span className="vd-modal-title">Perfil</span>
-            </div>
-
-            {/* Tabs */}
-            <div className="vd-modal-tabs">
-              <button
-                type="button"
-                className={`vd-modal-tab${profileTab === 'aparencia' ? ' active' : ''}`}
-                onClick={() => setProfileTab('aparencia')}
-              >
-                <FiUser size={14} /> Aparência
-              </button>
-              <button
-                type="button"
-                className={`vd-modal-tab${profileTab === 'dados-pessoais' ? ' active' : ''}`}
-                onClick={() => setProfileTab('dados-pessoais')}
-              >
-                <FiFileText size={14} /> Dados Pessoais
-              </button>
-              <button
-                type="button"
-                className={`vd-modal-tab${profileTab === 'seguranca' ? ' active' : ''}`}
-                onClick={() => setProfileTab('seguranca')}
-              >
-                <FiLock size={14} /> Segurança
-              </button>
-            </div>
-
-            {profileTab === 'aparencia' && (
-              <form className="vd-modal-form" onSubmit={saveAppearance}>
-                {/* Avatar + photo upload */}
-                <div className="vd-modal-photo-section">
-                  {modalAvatarSrc ? (
-                    <img
-                      src={modalAvatarSrc}
-                      alt="Foto de perfil"
-                      className="vd-modal-avatar"
-                      style={{ borderColor: editPinColor }}
-                    />
-                  ) : (
-                    <div
-                      className="vd-modal-avatar vd-modal-avatar-placeholder"
-                      style={{ borderColor: editPinColor, background: `${editPinColor}22`, color: editPinColor }}
-                    >
-                      {vendor?.name?.charAt(0)?.toUpperCase() || '?'}
-                    </div>
-                  )}
-                  <label className="vd-modal-photo-btn">
-                    Alterar foto
-                    <input type="file" accept="image/*" hidden onChange={handleEditPhoto} />
-                  </label>
-                </div>
-
-                <div className="vd-modal-field">
-                  <label className="vd-modal-label">Cor do Pin</label>
-                  <PinColorPicker value={editPinColor} onChange={setEditPinColor} />
-                </div>
-
-                <div className="vd-modal-field">
-                  <label className="vd-modal-label">Produto</label>
-                  <select
-                    className="vd-modal-input"
-                    value={editProduct}
-                    onChange={e => setEditProduct(e.target.value)}
-                  >
-                    <option value="Bolas de Berlim">Bolas de Berlim</option>
-                    <option value="Gelados">Gelados</option>
-                    <option value="Acessórios de Praia">Acessórios de Praia</option>
-                  </select>
-                </div>
-
-                <div className="vd-modal-field">
-                  <label className="vd-modal-label">Métodos de pagamento aceites</label>
-                  <div className="vd-modal-payments-grid">
-                    {Object.keys(PAYMENT_ICONS).map((method) => (
-                      <button
-                        type="button"
-                        key={method}
-                        className={`vd-modal-payment-chip${editPaymentMethods.includes(method) ? ' active' : ''}`}
-                        onClick={() => togglePaymentMethod(method)}
-                      >
-                        <span className="vd-modal-payment-chip-icon">{PAYMENT_ICONS[method]}</span>
-                        {method}
-                      </button>
-                    ))}
-                  </div>
-                </div>
-
-                {editError && <p className="vd-modal-error">{editError}</p>}
-                {editSuccess && (
-                  <p className="vd-modal-success">
-                    <FiCheck size={14} /> {editSuccess}
-                  </p>
-                )}
-
-                <div className="vd-modal-actions">
-                  <button type="button" className="vd-modal-cancel" onClick={closeProfileModal}>
-                    Cancelar
-                  </button>
-                  <button type="submit" className="vd-modal-save" disabled={editSaving}>
-                    {editSaving ? 'A guardar…' : 'Guardar'}
-                  </button>
-                </div>
-              </form>
-            )}
-
-            {profileTab === 'dados-pessoais' && (
-              <form className="vd-modal-form" onSubmit={savePersonalData}>
-                <div className="vd-modal-field">
-                  <label className="vd-modal-label">Nome</label>
-                  <input
-                    className="vd-modal-input"
-                    type="text"
-                    value={editName}
-                    onChange={e => setEditName(e.target.value)}
-                    required
-                  />
-                </div>
-                <div className="vd-modal-field">
-                  <label className="vd-modal-label">Email</label>
-                  <input
-                    className="vd-modal-input"
-                    type="email"
-                    value={editEmail}
-                    onChange={e => setEditEmail(e.target.value)}
-                    required
-                  />
-                </div>
-                <div className="vd-modal-field">
-                  <label className="vd-modal-label">NIF</label>
-                  <input
-                    className="vd-modal-input"
-                    type="text"
-                    inputMode="numeric"
-                    maxLength={9}
-                    placeholder="123456789"
-                    value={editNif}
-                    onChange={e => setEditNif(e.target.value.replace(/\D/g, ''))}
-                  />
-                </div>
-                <div className="vd-modal-field">
-                  <label className="vd-modal-label">Telemóvel</label>
-                  <input
-                    className="vd-modal-input"
-                    type="tel"
-                    placeholder="912345678"
-                    value={editPhone}
-                    onChange={e => setEditPhone(e.target.value)}
-                  />
-                </div>
-
-                {personalError && <p className="vd-modal-error">{personalError}</p>}
-                {personalSuccess && (
-                  <p className="vd-modal-success">
-                    <FiCheck size={14} /> {personalSuccess}
-                  </p>
-                )}
-
-                <div className="vd-modal-actions">
-                  <button type="button" className="vd-modal-cancel" onClick={closeProfileModal}>
-                    Cancelar
-                  </button>
-                  <button type="submit" className="vd-modal-save" disabled={personalSaving}>
-                    {personalSaving ? 'A guardar…' : 'Guardar'}
-                  </button>
-                </div>
-              </form>
-            )}
-
-            {profileTab === 'seguranca' && (
-              <form className="vd-modal-form" onSubmit={savePassword}>
-                <div className="vd-modal-security-header">
-                  <FiLock size={24} className="vd-modal-security-icon" />
-                  <p className="vd-modal-security-desc">
-                    Introduz a tua palavra-passe atual e escolhe uma nova.
-                  </p>
-                </div>
-
-                <div className="vd-modal-field">
-                  <label className="vd-modal-label">Palavra-passe atual</label>
-                  <input
-                    className="vd-modal-input"
-                    type="password"
-                    placeholder="Palavra-passe atual"
-                    value={secOldPassword}
-                    onChange={e => setSecOldPassword(e.target.value)}
-                    autoComplete="current-password"
-                    required
-                  />
-                </div>
-                <div className="vd-modal-field">
-                  <label className="vd-modal-label">Nova palavra-passe</label>
-                  <input
-                    className="vd-modal-input"
-                    type="password"
-                    placeholder="Mínimo 8 caracteres"
-                    value={secNewPassword}
-                    onChange={e => setSecNewPassword(e.target.value)}
-                    autoComplete="new-password"
-                    required
-                  />
-                </div>
-
-                {secError && <p className="vd-modal-error">{secError}</p>}
-                {secSuccess && (
-                  <p className="vd-modal-success">
-                    <FiCheck size={14} /> {secSuccess}
-                  </p>
-                )}
-
-                <div className="vd-modal-actions">
-                  <button type="button" className="vd-modal-cancel" onClick={closeProfileModal}>
-                    Cancelar
-                  </button>
-                  <button type="submit" className="vd-modal-save" disabled={secSaving}>
-                    {secSaving ? 'A guardar…' : 'Alterar Palavra-passe'}
-                  </button>
-                </div>
-              </form>
-            )}
-
-            {editCropSrc && (
-              <ImageCropper
-                src={editCropSrc}
-                onCancel={handleEditCropCancel}
-                onComplete={handleEditCropComplete}
-              />
-            )}
-          </div>
-        </div>
+      {editCropSrc && (
+        <ImageCropper
+          src={editCropSrc}
+          onCancel={handleEditCropCancel}
+          onComplete={handleEditCropComplete}
+        />
       )}
     </div>
   );


### PR DESCRIPTION
- Web (telemóvel): foto e dados do vendedor em cima, menus agrupados em
  baixo (Atividade, Conta, Negócio, Suporte), no estilo do ecrã Profile
  de referência; as secções abrem em vista de detalhe com botão Voltar
- Web (PC): menu fixo à esquerda e conteúdo da secção ativa a abrir no
  centro da página (Visão geral, Dados pessoais, Aparência, Segurança)
- O antigo modal de perfil passa a três secções do painel; toggle de
  partilha de localização disponível diretamente no menu
- App móvel: dashboard convertido para o mesmo formato de lista agrupada,
  com nova entrada Mapa para regressar ao mapa
- Mantém todas as funções existentes (partilha de localização, resumo de
  hoje, atividade recente, dicas, subscrição, produtos, faturas, logout)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Hmc9UJojpBM145XHpx9wsm