### PR TITLE
Redesenha card de perfil do dashboard do vendedor e corrige cores do pin

### DIFF
--- a/sunny_sales_web/src/components/PinColorPicker.css
+++ b/sunny_sales_web/src/components/PinColorPicker.css
@@ -87,6 +87,8 @@
   width: 100%;
   aspect-ratio: 1;
   border-radius: var(--radius-sm);
+  /* Anula o gradiente global de button, que tapava a cor definida inline */
+  background-image: none;
   border: 2.5px solid transparent;
   padding: 0;
   cursor: pointer;

--- a/sunny_sales_web/src/components/PinColorPicker.jsx
+++ b/sunny_sales_web/src/components/PinColorPicker.jsx
@@ -34,7 +34,7 @@ export default function PinColorPicker({ value, onChange }) {
               type="button"
               className={`pcp-color-btn ${value === color.value ? 'active' : ''}`}
               onClick={() => onChange(color.value)}
-              style={{ backgroundColor: color.value }}
+              style={{ background: color.value }}
               title={color.name}
               aria-label={`Cor ${color.name}`}
             />

--- a/sunny_sales_web/src/pages/VendorDashboard.css
+++ b/sunny_sales_web/src/pages/VendorDashboard.css
@@ -31,32 +31,47 @@
   min-width: 0;
 }
 
-.vd-profile-head {
+.vd-profile-card {
   display: flex;
+  flex-direction: column;
   align-items: center;
   gap: 14px;
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: var(--radius-xl);
-  padding: 18px 16px;
+  padding: 22px 16px 16px;
   box-shadow: var(--shadow-sm);
-  cursor: pointer;
-  text-align: left;
-  width: 100%;
-  min-height: auto;
-  color: var(--text);
-  transition: box-shadow var(--transition), border-color var(--transition);
   animation: fadeIn 0.35s ease;
 }
 
+/* Foto centrada com o nome e restantes infos por baixo */
+.vd-profile-head {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  background: transparent;
+  border: none;
+  border-radius: var(--radius-lg);
+  padding: 0;
+  box-shadow: none;
+  cursor: pointer;
+  text-align: center;
+  width: 100%;
+  min-height: auto;
+  color: var(--text);
+  transition: opacity var(--transition);
+}
+
 .vd-profile-head:hover {
-  box-shadow: var(--shadow-warm);
-  border-color: var(--primary-light-solid);
+  opacity: 0.85;
+  box-shadow: none;
+  transform: none;
 }
 
 .vd-avatar {
-  width: 64px;
-  height: 64px;
+  width: 84px;
+  height: 84px;
   border-radius: 50%;
   object-fit: cover;
   border: 3px solid var(--primary-light-solid);
@@ -78,13 +93,14 @@
 .vd-profile-head-meta {
   display: flex;
   flex-direction: column;
+  align-items: center;
   gap: 3px;
   min-width: 0;
-  flex: 1;
+  width: 100%;
 }
 
 .vd-profile-head-name {
-  font-size: 1.02rem;
+  font-size: 1.08rem;
   font-weight: 800;
   color: var(--text);
   white-space: nowrap;
@@ -130,6 +146,77 @@
 .vd-sub-date {
   font-weight: 500;
   opacity: 0.8;
+}
+
+/* Botão para renovar a subscrição (reencaminha para /planos) */
+.vd-renew-btn {
+  width: 100%;
+  background: var(--primary);
+  border: none;
+  border-radius: var(--radius-full);
+  padding: 10px 20px;
+  font-size: 0.85rem;
+  font-weight: 700;
+  color: #fff;
+  cursor: pointer;
+  min-height: auto;
+  box-shadow: var(--shadow-warm);
+  transition: background var(--transition), box-shadow var(--transition), transform var(--transition);
+}
+
+.vd-renew-btn:hover {
+  background: var(--primary-hover);
+  box-shadow: var(--shadow-warm-lg);
+  transform: translateY(-1px);
+}
+
+/* Partilha de localização fixa no card do perfil */
+.vd-profile-location {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding-top: 14px;
+  border-top: 1px solid var(--border);
+}
+
+.vd-profile-location-icon {
+  width: 34px;
+  height: 34px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: var(--surface-alt);
+  border: 1.5px solid var(--border);
+  color: var(--text-muted);
+  font-size: 1rem;
+  flex-shrink: 0;
+}
+
+.vd-profile-location-text {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  flex: 1;
+  min-width: 0;
+  text-align: left;
+}
+
+.vd-profile-location-title {
+  font-size: 0.82rem;
+  font-weight: 700;
+  color: var(--text);
+}
+
+.vd-profile-location-status {
+  font-size: 0.74rem;
+  color: var(--text-muted);
+}
+
+.vd-profile-location-status.on {
+  color: #2e7d32;
+  font-weight: 600;
 }
 
 /* ── Grupos de menu (formato lista, como no ecrã Profile) */

--- a/sunny_sales_web/src/pages/VendorDashboard.jsx
+++ b/sunny_sales_web/src/pages/VendorDashboard.jsx
@@ -10,7 +10,7 @@ import {
   FiShoppingBag, FiNavigation, FiBarChart2,
   FiEdit2, FiAlertCircle, FiX,
   FiClock, FiTrendingUp, FiLogOut, FiSettings,
-  FiHome, FiHelpCircle, FiChevronRight, FiArrowLeft,
+  FiHelpCircle, FiChevronRight, FiArrowLeft, FiRefreshCw,
 } from 'react-icons/fi';
 import ImageCropper from '../components/ImageCropper';
 import PinColorPicker from '../components/PinColorPicker';
@@ -518,8 +518,6 @@ export default function VendorDashboard() {
     {
       label: 'Atividade',
       items: [
-        { id: 'inicio', type: 'section', icon: <FiHome />, label: 'Visão geral' },
-        { id: 'location', type: 'toggle', icon: <FiMapPin />, label: 'Partilha de localização' },
         { type: 'route', path: '/routes', icon: <FiNavigation />, label: 'Trajetos' },
         { type: 'route', path: '/stats', icon: <FiBarChart2 />, label: 'Estatísticas' },
       ],
@@ -558,22 +556,6 @@ export default function VendorDashboard() {
   ];
 
   const renderMenuItem = (item) => {
-    if (item.type === 'toggle') {
-      return (
-        <div key={item.id} className="vd-menu-row vd-menu-row-static">
-          <span className="vd-menu-row-icon">{item.icon}</span>
-          <span className="vd-menu-row-label">{item.label}</span>
-          <label className="vendor-switch" aria-label="Ativar/desativar localização">
-            <input
-              type="checkbox"
-              checked={sharing}
-              onChange={sharing ? stopSharing : startSharing}
-            />
-            <span className="slider" />
-          </label>
-        </div>
-      );
-    }
     if (item.type === 'section') {
       const active = activeSection === item.id;
       return (
@@ -631,34 +613,57 @@ export default function VendorDashboard() {
                PC: coluna fixa à esquerda) ─────────────────── */}
         <aside className="vd-menu">
           {vendor && (
-            <button type="button" className="vd-profile-head" onClick={() => openSection('dados')}>
-              {vendor.profile_photo ? (
-                <img
-                  src={mediaUrl(vendor.profile_photo)}
-                  alt="Foto de perfil"
-                  className="vd-avatar"
-                  style={{ borderColor: pinColor }}
-                />
-              ) : (
-                <div
-                  className="vd-avatar vd-avatar-placeholder"
-                  style={{ borderColor: pinColor, background: `${pinColor}22`, color: pinColor }}
-                >
-                  {vendor.name?.charAt(0)?.toUpperCase() || '?'}
+            <div className="vd-profile-card">
+              <button type="button" className="vd-profile-head" onClick={() => openSection('dados')}>
+                {vendor.profile_photo ? (
+                  <img
+                    src={mediaUrl(vendor.profile_photo)}
+                    alt="Foto de perfil"
+                    className="vd-avatar"
+                    style={{ borderColor: pinColor }}
+                  />
+                ) : (
+                  <div
+                    className="vd-avatar vd-avatar-placeholder"
+                    style={{ borderColor: pinColor, background: `${pinColor}22`, color: pinColor }}
+                  >
+                    {vendor.name?.charAt(0)?.toUpperCase() || '?'}
+                  </div>
+                )}
+                <div className="vd-profile-head-meta">
+                  <span className="vd-profile-head-name">{vendor.name}</span>
+                  <span className="vd-profile-head-email">{vendor.email}</span>
+                  <span className={`vd-sub-badge${subscriptionActive ? ' active' : ' inactive'}`}>
+                    <span className="vd-sub-dot" />
+                    {subscriptionActive
+                      ? <>Subscrição ativa{subscriptionDate && <span className="vd-sub-date"> · até {subscriptionDate}</span>}</>
+                      : 'Subscrição inativa'}
+                  </span>
                 </div>
-              )}
-              <div className="vd-profile-head-meta">
-                <span className="vd-profile-head-name">{vendor.name}</span>
-                <span className="vd-profile-head-email">{vendor.email}</span>
-                <span className={`vd-sub-badge${subscriptionActive ? ' active' : ' inactive'}`}>
-                  <span className="vd-sub-dot" />
-                  {subscriptionActive
-                    ? <>Subscrição ativa{subscriptionDate && <span className="vd-sub-date"> · até {subscriptionDate}</span>}</>
-                    : 'Subscrição inativa'}
-                </span>
+              </button>
+
+              <button type="button" className="vd-renew-btn" onClick={() => navigate('/planos')}>
+                <FiRefreshCw size={14} /> Renovar subscrição
+              </button>
+
+              <div className="vd-profile-location">
+                <span className="vd-profile-location-icon"><FiMapPin /></span>
+                <div className="vd-profile-location-text">
+                  <span className="vd-profile-location-title">Partilha de localização</span>
+                  <span className={`vd-profile-location-status${sharing ? ' on' : ''}`}>
+                    {sharing ? 'Ativa — visível no mapa' : 'Desligada'}
+                  </span>
+                </div>
+                <label className="vendor-switch" aria-label="Ativar/desativar localização">
+                  <input
+                    type="checkbox"
+                    checked={sharing}
+                    onChange={sharing ? stopSharing : startSharing}
+                  />
+                  <span className="slider" />
+                </label>
               </div>
-              <FiChevronRight className="vd-menu-row-chevron" />
-            </button>
+            </div>
           )}
 
           {menuGroups.map((group) => (


### PR DESCRIPTION
- Centra a foto de perfil com nome, email e subscrição por baixo
- Remove o botão 'Visão geral' do menu
- Fixa o toggle de partilha de localização no card do perfil
- Adiciona botão 'Renovar subscrição' que reencaminha para /planos
- Corrige as cores do seletor de pin (o gradiente global de button
  tapava a cor inline, ficando todas azuis)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017cVwtgvbrVwMmB8g1BF95p