### PR TITLE
Restringe métodos de pagamento, unifica botão de voltar e limpa dashboard/home

### DIFF
--- a/mobile/src/pages/ProfileScreen.jsx
+++ b/mobile/src/pages/ProfileScreen.jsx
@@ -25,11 +25,9 @@ export default function ProfileScreen({ auth, onClose, onUserUpdate }) {
   const fileInputRef = useRef(null);
 
   const PAYMENT_ICONS = {
-    'Numerário': <FiCreditCard />,
     'MB Way': <FiCreditCard />,
-    'Multibanco': <FiCreditCard />,
+    'Numerário': <FiCreditCard />,
     'Cartão': <FiCreditCard />,
-    'NFC': <FiCreditCard />,
   };
 
   const togglePaymentMethod = (method) => {

--- a/sunny_sales_web/src/App.jsx
+++ b/sunny_sales_web/src/App.jsx
@@ -12,6 +12,7 @@ import { lazy, Suspense, useState, useEffect, useRef } from 'react';
 import axios from 'axios';
 import { BASE_URL } from './config';
 import Home from './pages/Home';
+import BackHomeButton from './components/BackHomeButton';
 import Footer from './components/Footer';
 import ScrollToTop from './components/ScrollToTop';
 import LoadingDots from './components/LoadingDots';
@@ -47,6 +48,19 @@ const TermsAndConditions = lazy(() => import('./pages/TermsAndConditions'));
 const LegalNotice = lazy(() => import('./pages/LegalNotice'));
 const CookiesPolicy = lazy(() => import('./pages/CookiesPolicy'));
 const NotFound = lazy(() => import('./pages/NotFound'));
+
+// Rotas sem botão de voltar global: página inicial, mapa (tem UI própria),
+// dashboard (tem navegação interna) e páginas de autenticação.
+const HIDE_BACK_ROUTES = [
+  '/',
+  '/map',
+  '/dashboard',
+  '/login',
+  '/vendor-login',
+  '/register',
+  '/vendor-register',
+  '/forgot-password',
+];
 
 function PageLoader() {
   return (
@@ -215,6 +229,7 @@ function AppLayout() {
       />
 
       <div className="container">
+        {!HIDE_BACK_ROUTES.includes(location.pathname) && <BackHomeButton />}
         <Suspense fallback={<PageLoader />}>
         <Routes>
           <Route path="/" element={<Home />} />

--- a/sunny_sales_web/src/components/BackHomeButton.jsx
+++ b/sunny_sales_web/src/components/BackHomeButton.jsx
@@ -1,11 +1,16 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
+import { FiArrowLeft } from 'react-icons/fi';
 
+// Botão de voltar global: é renderizado uma única vez no layout (App.jsx),
+// por baixo da navbar, para ficar sempre no mesmo sítio em todas as páginas.
 export default function BackHomeButton() {
   const navigate = useNavigate();
   return (
-    <button className="back-btn" onClick={() => navigate(-1)}>
-      ← Voltar
-    </button>
+    <div className="back-btn-row">
+      <button type="button" className="back-btn" onClick={() => navigate(-1)}>
+        <FiArrowLeft size={16} /> Voltar
+      </button>
+    </div>
   );
 }

--- a/sunny_sales_web/src/index.css
+++ b/sunny_sales_web/src/index.css
@@ -830,6 +830,14 @@ h2 {
 .span a { color: var(--text); }
 
 /* ── Back button ─────────────────────────────────────── */
+/* Linha do botão de voltar global: renderizada no layout (App.jsx) por baixo
+   da navbar, garantindo a mesma posição e aspeto em todas as páginas. */
+.back-btn-row {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 0 1rem;
+}
+
 .back-btn {
   background: none;
   border: none;

--- a/sunny_sales_web/src/pages/About.jsx
+++ b/sunny_sales_web/src/pages/About.jsx
@@ -1,12 +1,10 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
-import BackHomeButton from '../components/BackHomeButton';
 
 export default function About() {
   const navigate = useNavigate();
   return (
     <div className="page-wrapper">
-      <BackHomeButton />
       <h2>Sobre e Ajuda</h2>
 
       <ul className="page-list">

--- a/sunny_sales_web/src/pages/AccountSettings.jsx
+++ b/sunny_sales_web/src/pages/AccountSettings.jsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from 'react';
-import BackHomeButton from '../components/BackHomeButton';
 import './VendorLogin.css';
 
 const isNotificationsEnabled = () =>
@@ -38,7 +37,6 @@ export default function AccountSettings() {
 
   return (
     <div className="form-box">
-      <BackHomeButton />
       <h2 className="title">Definições da Conta</h2>
 
       <div className="form">

--- a/sunny_sales_web/src/pages/Contacto.jsx
+++ b/sunny_sales_web/src/pages/Contacto.jsx
@@ -1,6 +1,5 @@
 import { useState } from 'react';
 import { FiMail, FiSend, FiCheckCircle, FiUser, FiMessageSquare } from 'react-icons/fi';
-import BackHomeButton from '../components/BackHomeButton';
 import { BASE_URL } from '../config';
 import './InfoPage.css';
 import './Contacto.css';
@@ -81,7 +80,6 @@ export default function Contacto() {
   if (enviado) {
     return (
       <div className="info-page">
-        <BackHomeButton />
         <div className="contacto-success">
           <FiCheckCircle className="contacto-success-icon" />
           <h2 className="contacto-success-title">Mensagem enviada!</h2>
@@ -98,7 +96,6 @@ export default function Contacto() {
 
   return (
     <div className="info-page">
-      <BackHomeButton />
 
       <div className="info-hero">
         <h1 className="info-hero-title">

--- a/sunny_sales_web/src/pages/FAQ.jsx
+++ b/sunny_sales_web/src/pages/FAQ.jsx
@@ -1,6 +1,5 @@
 import { useState } from 'react';
 import { FiUsers, FiShoppingBag } from 'react-icons/fi';
-import BackHomeButton from '../components/BackHomeButton';
 import './FAQ.css';
 
 const FAQS_BANHISTAS = [
@@ -18,7 +17,7 @@ const FAQS_BANHISTAS = [
   },
   {
     q: 'Como pago aos vendedores?',
-    a: 'O pagamento é feito diretamente ao vendedor no momento da compra, com os métodos de pagamento que ele tiver disponíveis (numerário, MB Way, Multibanco, cartão ou NFC).',
+    a: 'O pagamento é feito diretamente ao vendedor no momento da compra, com os métodos de pagamento que ele tiver disponíveis (MB Way, numerário ou cartão).',
   },
   {
     q: 'A localização dos vendedores é em tempo real?',
@@ -67,7 +66,6 @@ export default function FAQ() {
 
   return (
     <div className="info-page faq-page">
-      <BackHomeButton />
 
       <div className="info-hero">
         <h1 className="info-hero-title">

--- a/sunny_sales_web/src/pages/Home.jsx
+++ b/sunny_sales_web/src/pages/Home.jsx
@@ -45,29 +45,6 @@ export default function Home() {
               </Link>
             </div>
 
-            <div className="home-stats">
-              <div className="home-stat">
-                <FiUsers className="home-stat-icon" />
-                <div>
-                  <div className="home-stat-value">+320</div>
-                  <div className="home-stat-label">Vendedores ativos</div>
-                </div>
-              </div>
-              <div className="home-stat">
-                <FiMapPin className="home-stat-icon" />
-                <div>
-                  <div className="home-stat-value">12</div>
-                  <div className="home-stat-label">Praias</div>
-                </div>
-              </div>
-              <div className="home-stat">
-                <FiClock className="home-stat-icon" />
-                <div>
-                  <div className="home-stat-value">100%</div>
-                  <div className="home-stat-label">Em tempo real</div>
-                </div>
-              </div>
-            </div>
           </div>
 
           {/* Telemóvel ilustrativo */}

--- a/sunny_sales_web/src/pages/HowItWorks.jsx
+++ b/sunny_sales_web/src/pages/HowItWorks.jsx
@@ -1,13 +1,11 @@
 import React from 'react';
 import { FiCompass, FiGrid, FiZap } from 'react-icons/fi';
-import BackHomeButton from '../components/BackHomeButton';
 import InfoBanner from '../components/InfoBanner';
 import './InfoPage.css';
 
 export default function HowItWorks() {
   return (
     <div className="info-page">
-      <BackHomeButton />
 
       <div className="info-hero">
         <h1 className="info-hero-title">

--- a/sunny_sales_web/src/pages/Invoices.jsx
+++ b/sunny_sales_web/src/pages/Invoices.jsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import axios from 'axios';
 import { BASE_URL } from '../config';
-import BackHomeButton from '../components/BackHomeButton';
 
 export default function Invoices() {
   const [weeks, setWeeks] = useState([]);
@@ -27,7 +26,6 @@ export default function Invoices() {
 
   return (
     <div className="page-wrapper">
-      <BackHomeButton />
       <h2>Faturas Pagas</h2>
       {weeks.length === 0 && (
         <p className="page-empty">Sem faturas disponíveis.</p>

--- a/sunny_sales_web/src/pages/ManageAccount.jsx
+++ b/sunny_sales_web/src/pages/ManageAccount.jsx
@@ -3,7 +3,6 @@ import axios from 'axios';
 import { BASE_URL, mediaUrl } from '../config';
 import ImageCropper from '../components/ImageCropper';
 import PinColorPicker from '../components/PinColorPicker';
-import BackHomeButton from '../components/BackHomeButton';
 import {
   FiUser, FiLock, FiCamera, FiCheck,
   FiChevronDown, FiChevronUp, FiSave, FiDroplet,
@@ -112,7 +111,6 @@ export default function ManageAccount() {
   if (!vendor) {
     return (
       <div className="ma-wrapper">
-        <BackHomeButton />
         <p className="page-empty">Utilizador não autenticado.</p>
       </div>
     );
@@ -120,7 +118,6 @@ export default function ManageAccount() {
 
   return (
     <div className="ma-wrapper">
-      <BackHomeButton />
       <div className="ma-container">
         <h1 className="ma-title">Definições de Conta</h1>
 

--- a/sunny_sales_web/src/pages/ModernMapLayout.jsx
+++ b/sunny_sales_web/src/pages/ModernMapLayout.jsx
@@ -11,17 +11,16 @@ import WelcomeCard from '../components/WelcomeCard';
 import WeatherCard from '../components/WeatherCard';
 import {
   FiMapPin, FiTag, FiShoppingBag,
-  FiDollarSign, FiSmartphone, FiTerminal, FiCreditCard, FiWifi,
+  FiSmartphone, FiCreditCard,
   FiSliders, FiCheck, FiX,
 } from 'react-icons/fi';
+import { TbCurrencyEuro } from 'react-icons/tb';
 import './ModernMapLayout.css';
 
 const PAYMENT_ICONS = {
-  'Numerário':   FiDollarSign,
   'MB Way':      FiSmartphone,
-  'Multibanco':  FiTerminal,
+  'Numerário':   TbCurrencyEuro,
   'Cartão':      FiCreditCard,
-  'NFC':         FiWifi,
 };
 
 const DISTANCE_OPTIONS = [

--- a/sunny_sales_web/src/pages/PaidWeeksScreen.jsx
+++ b/sunny_sales_web/src/pages/PaidWeeksScreen.jsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import axios from 'axios';
 import { BASE_URL } from '../config';
-import BackHomeButton from '../components/BackHomeButton';
 import { FiCalendar, FiFileText, FiCheckCircle, FiCreditCard } from 'react-icons/fi';
 import './PaidWeeksScreen.css';
 
@@ -27,7 +26,6 @@ export default function PaidWeeksScreen() {
 
   return (
     <div className="pw-wrapper">
-      <BackHomeButton />
       <div className="pw-container">
 
         <div className="pw-header">

--- a/sunny_sales_web/src/pages/PlanosVendedores.jsx
+++ b/sunny_sales_web/src/pages/PlanosVendedores.jsx
@@ -1,7 +1,6 @@
 import { useNavigate } from 'react-router-dom';
 import axios from 'axios';
 import { FiCheck, FiZap, FiStar, FiTrendingUp, FiHelpCircle } from 'react-icons/fi';
-import BackHomeButton from '../components/BackHomeButton';
 import InfoBanner from '../components/InfoBanner';
 import { BASE_URL } from '../config';
 import './InfoPage.css';
@@ -107,7 +106,6 @@ export default function PlanosVendedores() {
 
   return (
     <div className="pv-page">
-      <BackHomeButton />
 
       {/* ── Hero ── */}
       <div className="pv-hero">

--- a/sunny_sales_web/src/pages/ProductsScreen.jsx
+++ b/sunny_sales_web/src/pages/ProductsScreen.jsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import axios from 'axios';
 import { BASE_URL, mediaUrl } from '../config';
-import BackHomeButton from '../components/BackHomeButton';
 import ImageCropper from '../components/ImageCropper';
 import { FiShoppingBag, FiPlus, FiTrash2, FiTag, FiEdit2, FiX, FiCheck } from 'react-icons/fi';
 import './ProductsScreen.css';
@@ -176,7 +175,6 @@ export default function ProductsScreen() {
 
   return (
     <div className="ps-wrapper">
-      <BackHomeButton />
       <div className="ps-container">
 
         <div className="ps-header">

--- a/sunny_sales_web/src/pages/RouteDetail.jsx
+++ b/sunny_sales_web/src/pages/RouteDetail.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { useLocation } from 'react-router-dom';
 import { MapContainer, TileLayer, Polyline } from 'react-leaflet';
 import 'leaflet/dist/leaflet.css';
-import BackHomeButton from '../components/BackHomeButton';
 import { FiMapPin, FiClock, FiNavigation, FiCalendar } from 'react-icons/fi';
 import './RouteDetail.css';
 
@@ -13,7 +12,6 @@ export default function RouteDetail() {
   if (!route) {
     return (
       <div className="rd-wrapper">
-        <BackHomeButton />
         <div className="rd-empty">
           <FiMapPin className="rd-empty-icon" />
           <p>Trajeto não encontrado.</p>
@@ -33,7 +31,6 @@ export default function RouteDetail() {
 
   return (
     <div className="rd-wrapper">
-      <BackHomeButton />
       <div className="rd-container">
 
         <div className="rd-header">

--- a/sunny_sales_web/src/pages/RoutesScreen.jsx
+++ b/sunny_sales_web/src/pages/RoutesScreen.jsx
@@ -2,7 +2,6 @@ import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import axios from 'axios';
 import { BASE_URL } from '../config';
-import BackHomeButton from '../components/BackHomeButton';
 import { FiMap, FiNavigation, FiClock, FiCalendar, FiChevronRight } from 'react-icons/fi';
 import './RoutesScreen.css';
 
@@ -33,7 +32,6 @@ export default function RoutesScreen() {
 
   return (
     <div className="rs-wrapper">
-      <BackHomeButton />
       <div className="rs-container">
 
         <div className="rs-header">

--- a/sunny_sales_web/src/pages/Sessions.jsx
+++ b/sunny_sales_web/src/pages/Sessions.jsx
@@ -2,7 +2,6 @@ import { useCallback, useEffect, useState } from 'react';
 import axios from 'axios';
 import { BASE_URL } from '../config';
 import { useNavigate } from 'react-router-dom';
-import BackHomeButton from '../components/BackHomeButton';
 
 export default function Sessions() {
   const [sessions, setSessions] = useState([]);
@@ -43,7 +42,6 @@ export default function Sessions() {
 
   return (
     <div className="page-wrapper">
-      <BackHomeButton />
       <h2>Sessões Ativas</h2>
       {sessions.length === 0 && (
         <p className="page-empty">Sem sessões ativas.</p>

--- a/sunny_sales_web/src/pages/SobreProjeto.jsx
+++ b/sunny_sales_web/src/pages/SobreProjeto.jsx
@@ -8,7 +8,6 @@ import {
   FiHeart,
   FiCompass,
 } from 'react-icons/fi';
-import BackHomeButton from '../components/BackHomeButton';
 import './SobreProjeto.css';
 
 const HERO_IMAGE =
@@ -47,7 +46,6 @@ const steps = [
 export default function SobreProjeto() {
   return (
     <div className="sobre-page">
-      <BackHomeButton />
 
       {/* ── Hero ─────────────────────────────────────────── */}
       <section className="sobre-hero">

--- a/sunny_sales_web/src/pages/StatsScreen.jsx
+++ b/sunny_sales_web/src/pages/StatsScreen.jsx
@@ -4,7 +4,6 @@ import { BASE_URL } from '../config';
 import {
   BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, CartesianGrid,
 } from 'recharts';
-import BackHomeButton from '../components/BackHomeButton';
 import { FiBarChart2, FiNavigation, FiCalendar, FiTrendingUp } from 'react-icons/fi';
 import './StatsScreen.css';
 
@@ -63,7 +62,6 @@ export default function StatsScreen() {
 
   return (
     <div className="ss-wrapper">
-      <BackHomeButton />
       <div className="ss-container">
 
         <div className="ss-header">

--- a/sunny_sales_web/src/pages/Sustentabilidade.jsx
+++ b/sunny_sales_web/src/pages/Sustentabilidade.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { MdDelete, MdRecycling, MdWaves, MdCleaningServices, MdWbSunny, MdLocalDrink, MdPeople, MdEco } from 'react-icons/md';
 import { FiHeart } from 'react-icons/fi';
-import BackHomeButton from '../components/BackHomeButton';
 import InfoBanner from '../components/InfoBanner';
 import './InfoPage.css';
 
@@ -31,7 +30,6 @@ export default function Sustentabilidade() {
 
   return (
     <div className="info-page">
-      <BackHomeButton />
 
       <div className="info-hero green">
         <h1 className="info-hero-title">

--- a/sunny_sales_web/src/pages/TermsScreen.jsx
+++ b/sunny_sales_web/src/pages/TermsScreen.jsx
@@ -1,12 +1,10 @@
 import React from 'react';
-import BackHomeButton from '../components/BackHomeButton';
 import './TermsScreen.css';
 import './InfoPage.css';
 
 export default function TermsScreen() {
   return (
     <div className="page-wrapper terms-page">
-      <BackHomeButton />
       <h2>Termos e Condições</h2>
 
       <div className="terms-section">

--- a/sunny_sales_web/src/pages/VendorDashboard.jsx
+++ b/sunny_sales_web/src/pages/VendorDashboard.jsx
@@ -5,13 +5,14 @@ import axios from 'axios';
 import {
   FiFileText,
   FiCreditCard, FiMail, FiMapPin,
-  FiDollarSign, FiSmartphone, FiTerminal, FiWifi,
+  FiSmartphone,
   FiUser, FiLock, FiCheck,
   FiShoppingBag, FiNavigation, FiBarChart2,
   FiEdit2, FiAlertCircle, FiX,
-  FiClock, FiTrendingUp, FiLogOut, FiSettings,
+  FiClock, FiTrendingUp, FiLogOut,
   FiHelpCircle, FiChevronRight, FiArrowLeft, FiRefreshCw,
 } from 'react-icons/fi';
+import { TbCurrencyEuro } from 'react-icons/tb';
 import ImageCropper from '../components/ImageCropper';
 import PinColorPicker from '../components/PinColorPicker';
 import './VendorDashboard.css';
@@ -31,11 +32,9 @@ function haversineDistance(lat1, lng1, lat2, lng2) {
 }
 
 const PAYMENT_ICONS = {
-  'Numerário': <FiDollarSign />,
   'MB Way': <FiSmartphone />,
-  'Multibanco': <FiTerminal />,
+  'Numerário': <TbCurrencyEuro />,
   'Cartão': <FiCreditCard />,
-  'NFC': <FiWifi />,
 };
 
 let watchId = null;
@@ -253,7 +252,11 @@ export default function VendorDashboard() {
     setEditPhone(vendor.phone || '');
     setEditProduct(vendor.product || '');
     setEditPinColor(vendor.pin_color || '#7B61FF');
-    setEditPaymentMethods(vendor.payment_methods ? vendor.payment_methods.split(',').filter(Boolean) : []);
+    setEditPaymentMethods(
+      vendor.payment_methods
+        ? vendor.payment_methods.split(',').map((m) => m.trim()).filter((m) => m in PAYMENT_ICONS)
+        : []
+    );
   }, [vendor]);
 
   // Carrega os trajetos para calcular o resumo do dia e a atividade recente
@@ -528,7 +531,6 @@ export default function VendorDashboard() {
         { id: 'dados', type: 'section', icon: <FiUser />, label: 'Dados pessoais' },
         { id: 'aparencia', type: 'section', icon: <FiEdit2 />, label: 'Aparência' },
         { id: 'seguranca', type: 'section', icon: <FiLock />, label: 'Segurança' },
-        { type: 'route', path: '/settings', icon: <FiSettings />, label: 'Definições' },
       ],
     },
     {

--- a/sunny_sales_web/src/pages/VendorDetailScreen.jsx
+++ b/sunny_sales_web/src/pages/VendorDetailScreen.jsx
@@ -2,7 +2,6 @@ import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import axios from 'axios';
 import { BASE_URL, mediaUrl } from '../config';
-import BackHomeButton from '../components/BackHomeButton';
 import { FiShoppingBag, FiTag } from 'react-icons/fi';
 import './VendorDetailScreen.css';
 
@@ -60,7 +59,6 @@ export default function VendorDetailScreen() {
   if (loading) {
     return (
       <div className="page-wrapper">
-        <BackHomeButton />
         <p className="page-empty">A carregar...</p>
       </div>
     );
@@ -69,7 +67,6 @@ export default function VendorDetailScreen() {
   if (error || !vendor) {
     return (
       <div className="page-wrapper">
-        <BackHomeButton />
         <p className="page-empty">{error || 'Vendedor não encontrado.'}</p>
       </div>
     );
@@ -77,7 +74,6 @@ export default function VendorDetailScreen() {
 
   return (
     <div className="page-wrapper">
-      <BackHomeButton />
 
       <div className="vds-header">
         {vendor.profile_photo ? (


### PR DESCRIPTION
- Métodos de pagamento limitados a MB Way, Numerário e Cartão (web e mobile);
  o Numerário passa a usar o símbolo € e métodos antigos guardados
  (Multibanco/NFC) são filtrados ao carregar o perfil
- Remove o botão Definições do menu do dashboard do vendedor
- Botão de voltar passa a ser renderizado uma única vez no layout global,
  garantindo o mesmo aspeto e posição em todas as páginas
- Remove o bloco de estatísticas (+320 / 12 Praias / 100%) da página principal
- Atualiza o texto do FAQ sobre métodos de pagamento

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016r4wtkHN36rGmQwskiDYGk