### PR TITLE
Melhora organização e design do dashboard do vendedor (web)

### DIFF
--- a/sunny_sales_web/src/pages/VendorDashboard.css
+++ b/sunny_sales_web/src/pages/VendorDashboard.css
@@ -181,6 +181,7 @@
 }
 
 .vd-profile-location-icon {
+  position: relative;
   width: 34px;
   height: 34px;
   display: flex;
@@ -192,6 +193,22 @@
   color: var(--text-muted);
   font-size: 1rem;
   flex-shrink: 0;
+  transition: background var(--transition), border-color var(--transition), color var(--transition);
+}
+
+.vd-profile-location.active .vd-profile-location-icon {
+  background: rgba(76, 175, 80, 0.10);
+  border-color: rgba(76, 175, 80, 0.3);
+  color: #2e7d32;
+}
+
+.vd-profile-location-pulse {
+  position: absolute;
+  inset: -4px;
+  border-radius: 50%;
+  border: 2px solid rgba(76, 175, 80, 0.5);
+  animation: locPulse 1.8s ease-out infinite;
+  pointer-events: none;
 }
 
 .vd-profile-location-text {
@@ -648,100 +665,17 @@
   transform: translateY(-1px);
 }
 
-/* ── Location card ───────────────────────────────────── */
-
-.vd-location-card {
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-xl);
-  padding: 18px 20px;
-  box-shadow: var(--shadow-sm);
-  display: flex;
-  align-items: center;
-  gap: 14px;
-  transition: border-color var(--transition), box-shadow var(--transition);
-}
-
-.vd-location-card.active {
-  border-color: rgba(76, 175, 80, 0.35);
-  box-shadow: 0 2px 12px rgba(76, 175, 80, 0.12), var(--shadow-sm);
-}
-
-.vd-location-icon-wrap {
-  position: relative;
-  width: 42px;
-  height: 42px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: 50%;
-  background: var(--surface-alt);
-  border: 1.5px solid var(--border);
-  flex-shrink: 0;
-  transition: background var(--transition), border-color var(--transition);
-}
-
-.vd-location-card.active .vd-location-icon-wrap {
-  background: rgba(76, 175, 80, 0.10);
-  border-color: rgba(76, 175, 80, 0.3);
-}
-
-.vd-location-icon {
-  font-size: 1.1rem;
-  color: var(--text-muted);
-  transition: color var(--transition);
-  flex-shrink: 0;
-}
-
-.vd-location-card.active .vd-location-icon {
-  color: #2e7d32;
-}
-
-.vd-location-pulse {
-  position: absolute;
-  inset: -4px;
-  border-radius: 50%;
-  border: 2px solid rgba(76, 175, 80, 0.5);
-  animation: locPulse 1.8s ease-out infinite;
-  pointer-events: none;
-}
-
 @keyframes locPulse {
   0%   { transform: scale(0.85); opacity: 0.9; }
   70%  { transform: scale(1.4);  opacity: 0; }
   100% { transform: scale(1.4);  opacity: 0; }
 }
 
-.vd-location-text {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  flex: 1;
-  min-width: 0;
-}
-
-.vd-location-title {
-  font-size: 0.9rem;
-  font-weight: 700;
-  color: var(--text);
-}
-
-.vd-location-status {
-  font-size: 0.78rem;
-  color: var(--text-muted);
-  transition: color var(--transition);
-}
-
-.vd-location-card.active .vd-location-status {
-  color: #2e7d32;
-  font-weight: 600;
-}
-
 /* ── Info card (dica app móvel) ──────────────────────── */
 
 .vd-info-card {
-  background: #f0f4ff;
-  border: 1px solid #dbe4f8;
+  background: var(--primary-light);
+  border: 1px solid rgba(75, 163, 195, 0.22);
   border-left: 4px solid var(--primary);
   border-radius: var(--radius-lg);
   padding: 13px 16px;
@@ -916,98 +850,70 @@
 /* ── Tips Card ───────────────────────────────────────── */
 
 .vd-tips-card {
-  background: linear-gradient(135deg, var(--primary) 0%, var(--primary-dark) 100%);
+  background: var(--surface);
+  border: 1px solid var(--border);
   border-radius: var(--radius-xl);
-  padding: 24px 20px;
-  color: white;
-  box-shadow: var(--shadow-warm);
+  padding: 22px 20px;
+  box-shadow: var(--shadow-sm);
   display: flex;
   flex-direction: column;
   gap: 14px;
-  position: relative;
-  overflow: hidden;
-}
-
-.vd-tips-card::before {
-  content: '';
-  position: absolute;
-  top: -40px;
-  right: -40px;
-  width: 120px;
-  height: 120px;
-  background: rgba(255, 255, 255, 0.08);
-  border-radius: 50%;
-  pointer-events: none;
-}
-
-.vd-tips-card::after {
-  content: '';
-  position: absolute;
-  bottom: -30px;
-  left: -30px;
-  width: 100px;
-  height: 100px;
-  background: rgba(255, 255, 255, 0.05);
-  border-radius: 50%;
-  pointer-events: none;
 }
 
 .vd-tips-title {
-  font-size: 1rem;
+  font-size: 0.95rem;
   font-weight: 800;
-  position: relative;
-  z-index: 1;
+  color: var(--text);
 }
 
 .vd-tips-items {
   display: flex;
   flex-direction: column;
   gap: 10px;
-  position: relative;
-  z-index: 1;
 }
 
 .vd-tip-item {
   display: flex;
   align-items: flex-start;
-  gap: 8px;
-  font-size: 0.85rem;
+  gap: 10px;
+  font-size: 0.86rem;
   line-height: 1.5;
+  color: var(--text-secondary);
 }
 
 .vd-tip-item-icon {
   width: 20px;
   height: 20px;
   border-radius: 50%;
-  background: rgba(255, 255, 255, 0.2);
+  background: var(--primary-light);
+  color: var(--primary-dark);
   display: flex;
   align-items: center;
   justify-content: center;
   font-size: 0.7rem;
+  font-weight: 800;
   flex-shrink: 0;
   margin-top: 1px;
 }
 
 .vd-tips-footer {
-  margin-top: 8px;
-  position: relative;
-  z-index: 1;
+  margin-top: 4px;
 }
 
 .vd-tips-learn-more {
-  display: flex;
+  display: inline-flex;
   align-items: center;
   gap: 4px;
   font-size: 0.85rem;
   font-weight: 700;
-  color: white;
+  color: var(--primary-dark);
   text-decoration: none;
   cursor: pointer;
   transition: opacity var(--transition);
 }
 
 .vd-tips-learn-more:hover {
-  opacity: 0.9;
+  opacity: 0.8;
 }
 
 /* ── Location toggle switch ──────────────────────────── */

--- a/sunny_sales_web/src/pages/VendorDashboard.jsx
+++ b/sunny_sales_web/src/pages/VendorDashboard.jsx
@@ -11,6 +11,7 @@ import {
   FiEdit2, FiAlertCircle, FiX,
   FiClock, FiTrendingUp, FiLogOut,
   FiHelpCircle, FiChevronRight, FiArrowLeft, FiRefreshCw,
+  FiHome,
 } from 'react-icons/fi';
 import { TbCurrencyEuro } from 'react-icons/tb';
 import ImageCropper from '../components/ImageCropper';
@@ -519,6 +520,12 @@ export default function VendorDashboard() {
 
   const menuGroups = [
     {
+      label: 'Painel',
+      items: [
+        { id: 'inicio', type: 'section', icon: <FiHome />, label: 'Visão geral' },
+      ],
+    },
+    {
       label: 'Atividade',
       items: [
         { type: 'route', path: '/routes', icon: <FiNavigation />, label: 'Trajetos' },
@@ -648,12 +655,19 @@ export default function VendorDashboard() {
                 <FiRefreshCw size={14} /> Renovar subscrição
               </button>
 
-              <div className="vd-profile-location">
-                <span className="vd-profile-location-icon"><FiMapPin /></span>
+              <div className={`vd-profile-location${sharing ? ' active' : ''}`}>
+                <span className="vd-profile-location-icon">
+                  <FiMapPin />
+                  {sharing && <span className="vd-profile-location-pulse" />}
+                </span>
                 <div className="vd-profile-location-text">
                   <span className="vd-profile-location-title">Partilha de localização</span>
                   <span className={`vd-profile-location-status${sharing ? ' on' : ''}`}>
-                    {sharing ? 'Ativa — visível no mapa' : 'Desligada'}
+                    {sharing
+                      ? 'Ativa — visível no mapa'
+                      : subscriptionActive
+                        ? 'Desligada'
+                        : 'Requer subscrição'}
                   </span>
                 </div>
                 <label className="vendor-switch" aria-label="Ativar/desativar localização">
@@ -744,35 +758,10 @@ export default function VendorDashboard() {
                 </div>
               )}
 
-              {/* Partilha de localização */}
-              <div className={`vd-location-card${sharing ? ' active' : ''}`}>
-                <div className="vd-location-icon-wrap">
-                  <FiMapPin className="vd-location-icon" />
-                  {sharing && <span className="vd-location-pulse" />}
-                </div>
-                <div className="vd-location-text">
-                  <span className="vd-location-title">Partilha de localização</span>
-                  <span className="vd-location-status">
-                    {sharing
-                      ? 'Ativa — estás visível no mapa'
-                      : subscriptionActive
-                        ? 'Desligada — não apareces no mapa'
-                        : 'Requer subscrição ativa'}
-                  </span>
-                </div>
-                <label className="vendor-switch" aria-label="Ativar/desativar localização">
-                  <input
-                    type="checkbox"
-                    checked={sharing}
-                    onChange={sharing ? stopSharing : startSharing}
-                  />
-                  <span className="slider" />
-                </label>
-              </div>
-
               <div className="vd-info-card">
                 💡 <strong>Dica:</strong> a app web partilha a localização enquanto o separador estiver
-                ativo. Para partilha contínua em segundo plano, usa a <strong>app móvel</strong>.
+                ativo. Podes ligá-la no interruptor <strong>Partilha de localização</strong>, no teu
+                perfil. Para partilha contínua em segundo plano, usa a <strong>app móvel</strong>.
               </div>
 
               {/* Resumo de hoje (dados reais dos trajetos) */}
@@ -785,7 +774,7 @@ export default function VendorDashboard() {
                       <div className="vd-stat-value">
                         {stats ? formatDistance(stats.distToday) : '—'}
                       </div>
-                      <div className="vd-stat-label">Distância percorrida</div>
+                      <div className="vd-stat-label">Distância hoje</div>
                     </div>
                     <div className="vd-stat-card">
                       <div className="vd-stat-icon"><FiClock /></div>
@@ -799,7 +788,7 @@ export default function VendorDashboard() {
                       <div className="vd-stat-value">
                         {stats ? stats.sessionsToday : '—'}
                       </div>
-                      <div className="vd-stat-label">Sessões de partilha</div>
+                      <div className="vd-stat-label">Sessões hoje</div>
                     </div>
                     <div className="vd-stat-card">
                       <div className="vd-stat-icon"><FiTrendingUp /></div>


### PR DESCRIPTION
- Adiciona o item "Visão geral" ao menu (grupo "Painel"). No telemóvel
  o resumo (estatísticas, atividade e dicas) passa a estar acessível e,
  no PC, é possível voltar à visão geral depois de abrir uma secção de
  conta — antes não havia forma de regressar.
- Remove o interruptor de localização duplicado: fica um único controlo
  no cartão de perfil, agora com estado "Requer subscrição" e um efeito
  de pulso quando a partilha está ativa.
- Aligeira o cartão de dicas (deixa de ser um bloco em gradiente pesado)
  e alinha o cartão informativo à paleta, deixando o hero como único
  ponto focal em gradiente.
- Encurta os rótulos das estatísticas ("Distância hoje", "Sessões hoje")
  para evitar quebras de linha.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BQWURKa4cz982C936H1HYi