### PR TITLE
Redesign Home page to single hero layout with side-by-side text and phone mockup

### DIFF
--- a/sunny_sales_web/src/pages/Home.css
+++ b/sunny_sales_web/src/pages/Home.css
@@ -1,100 +1,13 @@
-/* ── Sunny Sales — Landing page (verão) ─────────────────── */
+/* ── Sunny Sales — Landing page (hero único de verão) ───── */
 
 .home {
   color: var(--text);
   font-family: 'Inter', system-ui, sans-serif;
 }
 
-/* Secções de conteúdo (por baixo do hero) centradas e limitadas */
-.home-section {
-  max-width: 1080px;
-  margin: 0 auto;
-  padding: 0 1.25rem;
-}
-
-/* Shared buttons ------------------------------------------- */
-.home-btn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 9px;
-  font-weight: 650;
-  font-size: 0.98rem;
-  padding: 14px 28px;
-  border-radius: var(--radius-full);
-  text-decoration: none;
-  cursor: pointer;
-  transition: background var(--transition), color var(--transition),
-    border-color var(--transition), transform var(--transition),
-    box-shadow var(--transition);
-  white-space: nowrap;
-}
-.home-btn:active { transform: scale(0.98); }
-
-/* CTA principal — laranja sol, ao estilo da referência */
-.home-btn-primary {
-  background: var(--secondary);
-  color: #fff;
-  box-shadow: 0 12px 26px -10px rgba(232, 137, 10, 0.85);
-}
-.home-btn-primary:hover {
-  background: var(--secondary-hover);
-  transform: translateY(-2px);
-  box-shadow: 0 16px 34px -10px rgba(232, 137, 10, 0.95);
-}
-.home-btn-arrow { transition: transform var(--transition); }
-.home-btn-primary:hover .home-btn-arrow { transform: translateX(3px); }
-
-/* Botão de vidro sobre o hero colorido */
-.home-btn-glass {
-  background: rgba(255, 255, 255, 0.16);
-  color: #fff;
-  border: 1px solid rgba(255, 255, 255, 0.45);
-  -webkit-backdrop-filter: blur(6px);
-  backdrop-filter: blur(6px);
-}
-.home-btn-glass:hover {
-  background: rgba(255, 255, 255, 0.28);
-  transform: translateY(-2px);
-}
-
-/* Botão claro sobre o painel escuro dos vendedores */
-.home-btn-light {
-  background: #fff;
-  color: var(--navy);
-  box-shadow: var(--shadow-sm);
-}
-.home-btn-light:hover {
-  background: #eef4f8;
-  transform: translateY(-2px);
-  box-shadow: 0 12px 28px -8px rgba(0, 0, 0, 0.4);
-}
-.home-btn-light svg { transition: transform var(--transition); }
-.home-btn-light:hover svg { transform: translateX(3px); }
-
-/* Kicker / etiqueta de secção ------------------------------ */
-.home-kicker {
-  font-size: 0.78rem;
-  font-weight: 700;
-  letter-spacing: 0.09em;
-  text-transform: uppercase;
-  color: var(--primary);
-  margin: 0 0 10px;
-}
-.home-kicker-light { color: #7fd0ea; }
-
-.home-section-title {
-  font-size: clamp(1.4rem, 2.6vw, 1.8rem);
-  font-weight: 750;
-  letter-spacing: -0.02em;
-  line-height: 1.2;
-  color: var(--navy);
-  margin: 0 0 28px;
-}
-
 /* ════════════════════════════════════════════════════════
-   Hero — ecrã de sol (fundo amarelo→âmbar) com o mockup do
-   site num telemóvel ao centro. Inspirado na referência.
+   Hero — ecrã de sol (fundo amarelo suave) com o texto à
+   esquerda e o mockup do site num telemóvel à direita.
    ════════════════════════════════════════════════════════ */
 .home-hero {
   position: relative;
@@ -102,33 +15,34 @@
   width: 100vw;
   margin-left: calc(50% - 50vw);
   margin-top: calc(-1 * (var(--navbar-h) + 16px));
-  margin-bottom: 3.5rem;
-  padding: calc(var(--navbar-h) + 38px) 1.5rem 3rem;
+  margin-bottom: 0;
+  padding: calc(var(--navbar-h) + 24px) 1.5rem 3rem;
   min-height: 100vh;
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   overflow: hidden;
   isolation: isolate;
-  /* Céu de sol: halo claro ao centro + gradiente limão→âmbar */
+  /* Céu de sol: brilho claro à direita (por trás do telemóvel) +
+     gradiente creme→amarelo suave, mais leve que o splash original. */
   background:
-    radial-gradient(58% 42% at 50% 44%, rgba(255, 255, 255, 0.55) 0%, rgba(255, 248, 214, 0) 60%),
-    linear-gradient(179deg, #ffe14a 0%, #ffcb24 48%, #ffab16 100%);
+    radial-gradient(46% 52% at 74% 46%, rgba(255, 255, 255, 0.75) 0%, rgba(255, 249, 219, 0) 60%),
+    linear-gradient(150deg, #fffdf4 0%, #fff4cf 52%, #ffe49a 100%);
 }
 
-/* Raios de sol (evocam o "splash" da referência) */
+/* Raios de sol suaves por trás do telemóvel (lado direito) */
 .hero-rays {
   position: absolute;
-  top: 52%;
-  left: 50%;
-  width: 700px;
-  height: 700px;
+  top: 46%;
+  left: 74%;
+  width: 640px;
+  height: 640px;
   transform: translate(-50%, -50%);
   border-radius: 50%;
   background: repeating-conic-gradient(from 0deg,
-    rgba(255, 255, 255, 0.22) 0deg 5deg,
+    rgba(255, 255, 255, 0.4) 0deg 5deg,
     rgba(255, 255, 255, 0) 5deg 13deg);
-  -webkit-mask: radial-gradient(circle, transparent 26%, #000 40%, transparent 72%);
-  mask: radial-gradient(circle, transparent 26%, #000 40%, transparent 72%);
+  -webkit-mask: radial-gradient(circle, transparent 24%, #000 40%, transparent 72%);
+  mask: radial-gradient(circle, transparent 24%, #000 40%, transparent 72%);
   animation: sunSpin 60s linear infinite;
   z-index: 0;
   pointer-events: none;
@@ -140,30 +54,40 @@
 /* Brilho quente por trás do telemóvel */
 .hero-sun {
   position: absolute;
-  top: 52%;
-  left: 50%;
+  top: 46%;
+  left: 74%;
   width: 500px;
   height: 500px;
   transform: translate(-50%, -50%);
   border-radius: 50%;
   background: radial-gradient(circle,
     rgba(255, 255, 255, 0.9) 0%,
-    rgba(255, 241, 196, 0.4) 42%,
-    rgba(255, 241, 196, 0) 70%);
+    rgba(255, 243, 202, 0.4) 42%,
+    rgba(255, 243, 202, 0) 70%);
   filter: blur(4px);
   z-index: 0;
   pointer-events: none;
 }
 
+/* Grelha de duas colunas: texto | telemóvel */
 .home-hero-inner {
   position: relative;
   z-index: 1;
-  max-width: 660px;
+  width: 100%;
+  max-width: 1140px;
   margin: 0 auto;
+  display: grid;
+  grid-template-columns: 1.05fr 0.95fr;
+  align-items: center;
+  gap: 3rem;
+}
+
+/* ── Coluna do texto ─────────────────────────────────── */
+.hero-copy {
   display: flex;
   flex-direction: column;
-  align-items: center;
-  text-align: center;
+  align-items: flex-start;
+  text-align: left;
 }
 
 .home-hero-badge {
@@ -173,11 +97,11 @@
   font-size: 0.8rem;
   font-weight: 650;
   color: var(--navy);
-  background: rgba(255, 255, 255, 0.55);
-  border: 1px solid rgba(255, 255, 255, 0.85);
+  background: rgba(255, 255, 255, 0.7);
+  border: 1px solid rgba(255, 255, 255, 0.9);
   border-radius: var(--radius-full);
   padding: 7px 16px;
-  margin-bottom: 22px;
+  margin-bottom: 24px;
   -webkit-backdrop-filter: blur(6px);
   backdrop-filter: blur(6px);
   animation: fadeInUp 0.55s var(--ease-out) both;
@@ -196,56 +120,98 @@
 }
 
 .home-hero-title {
-  font-size: clamp(1.9rem, 3.4vw, 2.4rem);
+  font-size: clamp(2.1rem, 4vw, 3.15rem);
   font-weight: 800;
-  line-height: 1.12;
+  line-height: 1.08;
   letter-spacing: -0.03em;
   color: #10233a;
-  margin: 0 0 6px;
-  max-width: 480px;
+  margin: 0 0 18px;
+  max-width: 12ch;
   text-wrap: balance;
   animation: fadeInUp 0.55s var(--ease-out) 0.06s both;
 }
 .home-hero-accent {
-  color: #b4470a;
+  color: #e8890a;
 }
 
 .home-hero-lead {
-  font-size: clamp(0.96rem, 1.3vw, 1.06rem);
+  font-size: clamp(1rem, 1.3vw, 1.12rem);
   line-height: 1.55;
-  color: rgba(16, 35, 58, 0.78);
-  max-width: 460px;
-  margin: 0 0 4px;
+  color: rgba(16, 35, 58, 0.72);
+  max-width: 32ch;
+  margin: 0 0 30px;
   text-wrap: pretty;
   animation: fadeInUp 0.55s var(--ease-out) 0.12s both;
+}
+
+/* ── Botão "Explorar Mapa" ───────────────────────────── */
+.hero-pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 9px;
+  font-size: 1rem;
+  font-weight: 650;
+  padding: 15px 30px;
+  border-radius: var(--radius-full);
+  text-decoration: none;
+  cursor: pointer;
+  color: var(--navy);
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow:
+    0 10px 24px -12px rgba(140, 82, 0, 0.55),
+    inset 0 0 0 1px rgba(255, 255, 255, 0.7);
+  transition: background var(--transition), color var(--transition),
+    transform var(--transition), box-shadow var(--transition);
+  white-space: nowrap;
+  animation: fadeInUp 0.55s var(--ease-out) 0.2s both;
+}
+.hero-pill:hover {
+  transform: translateY(-2px);
+}
+.hero-pill:active { transform: scale(0.98); }
+.hero-pill:focus-visible {
+  outline: 2px solid var(--navy);
+  outline-offset: 2px;
+}
+.hero-pill-primary {
+  background: var(--ink);
+  color: #fff;
+  box-shadow: 0 14px 30px -12px rgba(12, 27, 42, 0.65);
+}
+.hero-pill-primary:hover {
+  background: var(--navy-light);
+  color: #fff;
+  box-shadow: 0 18px 36px -12px rgba(12, 27, 42, 0.7);
 }
 
 /* ── Telemóvel com o mockup do site ──────────────────── */
 .hero-phone {
   position: relative;
   z-index: 2;
-  width: 232px;
-  height: 384px;
-  border-radius: 40px;
+  justify-self: center;
+  width: 268px;
+  height: 552px;
+  border-radius: 44px;
   background: #0d2136;
   padding: 12px;
-  margin: 22px 0;
   box-shadow:
-    0 50px 90px -30px rgba(140, 82, 0, 0.5),
+    0 60px 100px -34px rgba(140, 82, 0, 0.5),
     0 0 0 1px rgba(255, 255, 255, 0.1) inset;
+  transform: perspective(1600px) rotateY(-15deg) rotateX(4deg);
   animation: heroFloat 6s ease-in-out infinite;
 }
 @keyframes heroFloat {
-  0%, 100% { transform: translateY(0); }
-  50% { transform: translateY(-12px); }
+  0%, 100% { transform: perspective(1600px) rotateY(-15deg) rotateX(4deg) translateY(0); }
+  50% { transform: perspective(1600px) rotateY(-15deg) rotateX(4deg) translateY(-12px); }
 }
 .hero-phone-notch {
   position: absolute;
   top: 12px;
   left: 50%;
   transform: translateX(-50%);
-  width: 88px;
-  height: 20px;
+  width: 96px;
+  height: 22px;
   background: #0d2136;
   border-radius: 0 0 14px 14px;
   z-index: 3;
@@ -254,7 +220,7 @@
   position: relative;
   width: 100%;
   height: 100%;
-  border-radius: 32px;
+  border-radius: 34px;
   overflow: hidden;
   background: #f4f7f9;
   display: flex;
@@ -266,11 +232,11 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 14px 13px 10px;
+  padding: 16px 15px 12px;
   background: linear-gradient(180deg, #ffe14a 0%, #ffd42a 100%);
 }
 .ps-logo {
-  font-size: 0.74rem;
+  font-size: 0.82rem;
   font-weight: 800;
   letter-spacing: -0.02em;
   color: var(--navy);
@@ -281,7 +247,7 @@
   gap: 2.5px;
 }
 .ps-burger i {
-  width: 14px;
+  width: 15px;
   height: 2px;
   border-radius: 2px;
   background: var(--navy);
@@ -289,33 +255,33 @@
 
 /* Mini-hero do site */
 .ps-hero {
-  padding: 10px 13px 12px;
+  padding: 12px 15px 14px;
   background: linear-gradient(180deg, #ffd42a 0%, #ffc21c 100%);
   display: flex;
   flex-direction: column;
-  gap: 5px;
+  gap: 6px;
 }
 .ps-tag {
-  font-size: 0.5rem;
+  font-size: 0.56rem;
   font-weight: 800;
   letter-spacing: 0.09em;
   text-transform: uppercase;
   color: #8a4b00;
 }
 .ps-title {
-  font-size: 0.82rem;
+  font-size: 0.94rem;
   font-weight: 800;
   line-height: 1.15;
   color: var(--navy);
 }
 .ps-cta {
   align-self: flex-start;
-  margin-top: 3px;
-  font-size: 0.58rem;
+  margin-top: 4px;
+  font-size: 0.64rem;
   font-weight: 700;
   color: #fff;
   background: var(--ink);
-  padding: 5px 12px;
+  padding: 6px 14px;
   border-radius: var(--radius-full);
 }
 
@@ -332,7 +298,7 @@
   background-image:
     linear-gradient(rgba(13, 33, 54, 0.06) 1px, transparent 1px),
     linear-gradient(90deg, rgba(13, 33, 54, 0.06) 1px, transparent 1px);
-  background-size: 26px 26px;
+  background-size: 30px 30px;
 }
 .ps-map::before {
   content: '';
@@ -340,7 +306,7 @@
   left: -20%;
   right: -20%;
   top: 58%;
-  height: 34px;
+  height: 40px;
   background: rgba(255, 255, 255, 0.6);
   transform: rotate(-10deg);
 }
@@ -349,12 +315,12 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 22px;
-  height: 22px;
+  width: 26px;
+  height: 26px;
   border-radius: 50% 50% 50% 2px;
   color: #fff;
   transform: rotate(-45deg);
-  box-shadow: 0 5px 12px -3px rgba(11, 60, 90, 0.5);
+  box-shadow: 0 6px 14px -3px rgba(11, 60, 90, 0.5);
 }
 .ps-pin svg { transform: rotate(45deg); }
 .ps-pin-a { top: 20%; left: 22%; background: var(--secondary); animation: pinPop 3.4s ease-in-out infinite; }
@@ -371,8 +337,8 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 24px;
-  height: 24px;
+  width: 28px;
+  height: 28px;
   border-radius: 50%;
   background: var(--primary);
   color: #fff;
@@ -384,21 +350,21 @@
 .ps-card {
   display: flex;
   align-items: center;
-  gap: 8px;
-  margin: 8px;
-  padding: 8px 10px;
+  gap: 9px;
+  margin: 10px;
+  padding: 10px 12px;
   background: #fff;
-  border-radius: 14px;
-  box-shadow: 0 8px 20px -10px rgba(9, 40, 60, 0.4);
+  border-radius: 16px;
+  box-shadow: 0 10px 24px -10px rgba(9, 40, 60, 0.4);
 }
 .ps-card-emoji {
-  font-size: 1.1rem;
-  width: 30px;
-  height: 30px;
+  font-size: 1.25rem;
+  width: 34px;
+  height: 34px;
   display: flex;
   align-items: center;
   justify-content: center;
-  border-radius: 10px;
+  border-radius: 11px;
   background: var(--surface-warm);
   flex-shrink: 0;
 }
@@ -409,204 +375,62 @@
   flex: 1;
 }
 .ps-card-body strong {
-  font-size: 0.68rem;
+  font-size: 0.76rem;
   font-weight: 700;
   color: var(--navy);
 }
 .ps-card-body span {
-  font-size: 0.58rem;
+  font-size: 0.64rem;
   color: var(--text-secondary);
 }
 .ps-card-go {
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 22px;
-  height: 22px;
+  width: 26px;
+  height: 26px;
   border-radius: 50%;
   background: var(--secondary);
   color: #fff;
   flex-shrink: 0;
 }
 
-/* ── Trio de botões (como Retailers / See Products / Press) ── */
-.hero-cta-row {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 14px;
-  justify-content: center;
-  animation: fadeInUp 0.55s var(--ease-out) 0.2s both;
-}
-.hero-pill {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 8px;
-  font-size: 0.95rem;
-  font-weight: 650;
-  padding: 13px 26px;
-  border-radius: var(--radius-full);
-  text-decoration: none;
-  cursor: pointer;
-  color: var(--navy);
-  background: rgba(255, 255, 255, 0.92);
-  box-shadow:
-    0 10px 24px -12px rgba(140, 82, 0, 0.55),
-    inset 0 0 0 1px rgba(255, 255, 255, 0.7);
-  transition: background var(--transition), color var(--transition),
-    transform var(--transition), box-shadow var(--transition);
-  white-space: nowrap;
-}
-.hero-pill:hover {
-  background: #fff;
-  transform: translateY(-2px);
-  box-shadow: 0 16px 30px -12px rgba(140, 82, 0, 0.6);
-}
-.hero-pill:active { transform: scale(0.98); }
-.hero-pill:focus-visible {
-  outline: 2px solid var(--navy);
-  outline-offset: 2px;
-}
-.hero-pill-primary {
-  background: var(--ink);
-  color: #fff;
-  box-shadow: 0 12px 26px -10px rgba(12, 27, 42, 0.6);
-}
-.hero-pill-primary:hover {
-  background: var(--navy-light);
-  color: #fff;
-}
-
-/* ── Funcionalidades ──────────────────────────────────── */
-.home-features-section {
-  margin-bottom: 3rem;
-  text-align: center;
-  animation: fadeInUp 0.55s var(--ease-out) 0.1s both;
-}
-.home-features {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
-  gap: 1rem;
-  text-align: left;
-}
-.home-feature {
-  display: flex;
-  gap: 14px;
-  align-items: flex-start;
-  padding: 22px 20px;
-  text-decoration: none;
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-lg);
-  box-shadow: var(--shadow-xs);
-  transition: border-color var(--transition), transform var(--transition),
-    box-shadow var(--transition);
-}
-.home-feature:hover {
-  border-color: rgba(14, 124, 158, 0.35);
-  transform: translateY(-3px);
-  box-shadow: var(--shadow-md);
-}
-.home-feature:focus-visible {
-  outline: 2px solid var(--primary);
-  outline-offset: 2px;
-}
-.home-feature-icon {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 42px;
-  height: 42px;
-  border-radius: var(--radius-md);
-  background: var(--primary-light-solid);
-  color: var(--primary-dark);
-  flex-shrink: 0;
-  transition: background var(--transition), color var(--transition),
-    transform var(--transition);
-}
-.home-feature:hover .home-feature-icon {
-  background: var(--primary);
-  color: #fff;
-  transform: scale(1.06);
-}
-.home-feature-title {
-  font-size: 0.95rem;
-  font-weight: 650;
-  color: var(--text);
-  margin: 0 0 4px;
-}
-.home-feature-text {
-  font-size: 0.84rem;
-  color: var(--text-secondary);
-  line-height: 1.55;
-  margin: 0;
-}
-
-/* ── Vendedores ───────────────────────────────────────── */
-.home-mid {
-  margin-bottom: 1rem;
-  animation: fadeInUp 0.55s var(--ease-out) 0.16s both;
-}
-.home-vendor-card {
-  position: relative;
-  overflow: hidden;
-  background: linear-gradient(135deg, var(--navy) 0%, #123a56 60%, #0e4d66 100%);
-  border-radius: var(--radius-2xl);
-  padding: 3rem 2.75rem;
-  box-shadow: var(--shadow-lg);
-}
-.home-vendor-card::after {
-  content: '';
-  position: absolute;
-  top: -140px;
-  right: -120px;
-  width: 420px;
-  height: 420px;
-  border-radius: 50%;
-  background: radial-gradient(circle, rgba(244, 147, 31, 0.3), transparent 65%);
-  pointer-events: none;
-}
-.home-vendor-body {
-  position: relative;
-  z-index: 1;
-  max-width: 540px;
-}
-.home-vendor-title {
-  font-size: clamp(1.4rem, 2.6vw, 1.8rem);
-  font-weight: 750;
-  letter-spacing: -0.02em;
-  color: #fff;
-  margin: 0 0 10px;
-}
-.home-vendor-lead {
-  font-size: 0.98rem;
-  color: rgba(255, 255, 255, 0.78);
-  line-height: 1.65;
-  margin: 0 0 20px;
-}
-.home-vendor-list {
-  list-style: none;
-  padding: 0;
-  margin: 0 0 26px;
-  display: flex;
-  flex-direction: column;
-  gap: 11px;
-}
-.home-vendor-list li {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  font-size: 0.92rem;
-  color: rgba(255, 255, 255, 0.92);
-}
-.home-vendor-list svg {
-  color: #64d3a9;
-  flex-shrink: 0;
+@keyframes fadeInUp {
+  from { opacity: 0; transform: translateY(16px); }
+  to { opacity: 1; transform: translateY(0); }
 }
 
 /* ── Responsive ───────────────────────────────────────── */
+@media (max-width: 900px) {
+  .home-hero {
+    padding: calc(var(--navbar-h) + 28px) 1.25rem 3rem;
+    min-height: auto;
+  }
+  .home-hero-inner {
+    grid-template-columns: 1fr;
+    gap: 2.25rem;
+    justify-items: center;
+  }
+  .hero-copy {
+    align-items: center;
+    text-align: center;
+    order: 1;
+  }
+  .home-hero-title { max-width: 16ch; }
+  .home-hero-lead { max-width: 42ch; }
+  .hero-phone {
+    order: 2;
+    transform: none;
+    animation: heroFloatFlat 6s ease-in-out infinite;
+  }
+  @keyframes heroFloatFlat {
+    0%, 100% { transform: translateY(0); }
+    50% { transform: translateY(-10px); }
+  }
+  .hero-rays, .hero-sun { left: 50%; top: 62%; }
+}
+
 @media (max-width: 768px) {
-  /* container reduz o padding-top no topo neste breakpoint */
   .home-hero {
     margin-top: calc(-1 * (var(--navbar-h) + 8px));
   }
@@ -614,22 +438,10 @@
 
 @media (max-width: 640px) {
   .home-hero {
-    padding: calc(var(--navbar-h) + 30px) 1.1rem 3rem;
-    min-height: auto;
-    margin-bottom: 2.5rem;
+    padding: calc(var(--navbar-h) + 24px) 1.1rem 2.5rem;
   }
-  .home-hero-title { font-size: clamp(1.9rem, 8vw, 2.4rem); }
-  .hero-phone { width: 218px; height: 372px; margin: 24px 0; }
+  .home-hero-title { font-size: clamp(2rem, 8.5vw, 2.6rem); }
+  .hero-phone { width: 240px; height: 494px; }
   .hero-rays, .hero-sun { width: 440px; height: 440px; }
-  .hero-cta-row { width: 100%; }
-  .hero-pill { flex: 1 1 auto; }
-  .home-vendor-card {
-    padding: 2rem 1.5rem;
-    border-radius: var(--radius-xl);
-  }
-  .home-btn-light { width: 100%; }
-}
-
-@media (max-width: 400px) {
-  .hero-pill { flex: 1 1 100%; }
+  .hero-pill { width: 100%; }
 }

--- a/sunny_sales_web/src/pages/Home.jsx
+++ b/sunny_sales_web/src/pages/Home.jsx
@@ -1,37 +1,46 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import {
-  FiMapPin, FiShield, FiArrowRight, FiCheckCircle, FiSmartphone,
-  FiNavigation,
-} from 'react-icons/fi';
-import { FaLeaf } from 'react-icons/fa';
+import { FiMapPin, FiArrowRight, FiNavigation } from 'react-icons/fi';
 import './Home.css';
 
-// (em português) Página inicial / landing com apresentação da Sunny Sales.
-// Hero de ecrã inteiro com fundo de sol (amarelo→âmbar) e o mockup do site
-// dentro de um telemóvel ao centro. O header fica sem fundo por cima do hero
-// (tratado em App.jsx). Os menus e as funcionalidades mantêm-se iguais.
+// (em português) Página inicial / landing da Sunny Sales.
+// Um único ecrã (hero): à esquerda o texto e o botão "Explorar Mapa";
+// à direita o mockup do site dentro de um telemóvel, com um brilho de sol
+// por trás. Sem secções adicionais — apenas o hero. O header e o rodapé
+// são geridos em App.jsx.
 export default function Home() {
   return (
     <div className="home">
-      {/* ── Hero (ecrã de sol) ───────────────────────────── */}
       <section className="home-hero">
-        {/* Fundo: raios de sol + brilho quente (evocam o splash) */}
+        {/* Fundo: raios de sol + brilho quente por trás do telemóvel */}
         <span className="hero-rays" aria-hidden="true" />
         <span className="hero-sun" aria-hidden="true" />
 
         <div className="home-hero-inner">
-          <span className="home-hero-badge">
-            <span className="home-hero-badge-dot" aria-hidden="true" />
-            Em tempo real nas praias portuguesas
-          </span>
+          {/* ── Coluna do texto ─────────────────────────────── */}
+          <div className="hero-copy">
+            <span className="home-hero-badge">
+              <span className="home-hero-badge-dot" aria-hidden="true" />
+              Em tempo real nas praias portuguesas
+            </span>
 
-          <h1 className="home-hero-title">
-            Os <span className="home-hero-accent">vendedores de praia</span>{' '}
-            perto de ti, em tempo real
-          </h1>
+            <h1 className="home-hero-title">
+              Os vendedores de praia perto de ti,{' '}
+              <span className="home-hero-accent">em tempo real</span>
+            </h1>
 
-          {/* Mockup do site dentro de um telemóvel */}
+            <p className="home-hero-lead">
+              Encontra gelados, bebidas, bolas de Berlim e muito mais,
+              a poucos passos de ti.
+            </p>
+
+            <Link to="/map" className="hero-pill hero-pill-primary">
+              <FiMapPin size={16} />
+              Explorar Mapa
+            </Link>
+          </div>
+
+          {/* ── Coluna do telemóvel (mockup do site) ────────── */}
           <div className="hero-phone" aria-hidden="true">
             <span className="hero-phone-notch" />
             <div className="hero-phone-screen">
@@ -60,92 +69,6 @@ export default function Home() {
                 <span className="ps-card-go"><FiArrowRight size={12} /></span>
               </div>
             </div>
-          </div>
-
-          {/* Trio de botões */}
-          <div className="hero-cta-row">
-            <Link to="/map" className="hero-pill hero-pill-primary">
-              <FiMapPin size={16} />
-              Explorar Mapa
-            </Link>
-            <Link to="/como-funciona" className="hero-pill">
-              Como Funciona
-            </Link>
-            <Link to="/planos" className="hero-pill">
-              Para Vendedores
-            </Link>
-          </div>
-        </div>
-      </section>
-
-      {/* ── Funcionalidades ──────────────────────────────── */}
-      <section className="home-section home-features-section">
-        <p className="home-kicker">Porquê a Sunny Sales</p>
-        <h2 className="home-section-title">
-          Tudo o que precisas para viver a praia
-        </h2>
-
-        <div className="home-features">
-          <Link to="/map" className="home-feature">
-            <span className="home-feature-icon"><FiMapPin size={20} /></span>
-            <div>
-              <h3 className="home-feature-title">Mapa Interativo</h3>
-              <p className="home-feature-text">
-                Explora o mapa e encontra vendedores perto de ti.
-              </p>
-            </div>
-          </Link>
-
-          <Link to="/faqs" className="home-feature">
-            <span className="home-feature-icon"><FiShield size={20} /></span>
-            <div>
-              <h3 className="home-feature-title">Seguro e Confiável</h3>
-              <p className="home-feature-text">
-                Todos os vendedores são verificados para garantir a tua segurança.
-              </p>
-            </div>
-          </Link>
-
-          <Link to="/sustentabilidade" className="home-feature">
-            <span className="home-feature-icon"><FaLeaf size={18} /></span>
-            <div>
-              <h3 className="home-feature-title">Sustentável</h3>
-              <p className="home-feature-text">
-                Promovemos o comércio local e práticas sustentáveis.
-              </p>
-            </div>
-          </Link>
-
-          <Link to="/como-funciona" className="home-feature">
-            <span className="home-feature-icon"><FiSmartphone size={20} /></span>
-            <div>
-              <h3 className="home-feature-title">Sempre Contigo</h3>
-              <p className="home-feature-text">
-                Disponível na web e em mobile, onde estiveres.
-              </p>
-            </div>
-          </Link>
-        </div>
-      </section>
-
-      {/* ── Vendedores ───────────────────────────────────── */}
-      <section className="home-section home-mid">
-        <div className="home-vendor-card">
-          <div className="home-vendor-body">
-            <p className="home-kicker home-kicker-light">Para vendedores</p>
-            <h2 className="home-vendor-title">És vendedor de praia?</h2>
-            <p className="home-vendor-lead">
-              Aumenta a tua visibilidade e chega a mais clientes todos os dias.
-            </p>
-            <ul className="home-vendor-list">
-              <li><FiCheckCircle /> Mostra a tua localização em tempo real</li>
-              <li><FiCheckCircle /> Gere os teus produtos e horários</li>
-              <li><FiCheckCircle /> Recebe mais clientes na tua zona</li>
-            </ul>
-            <Link to="/planos" className="home-btn home-btn-light">
-              Saber mais para Vendedores
-              <FiArrowRight size={16} />
-            </Link>
           </div>
         </div>
       </section>


### PR DESCRIPTION
## Summary
Completely redesigned the Home landing page to feature a single, full-screen hero section with a two-column layout: marketing copy and CTA on the left, phone mockup on the right. Removed all secondary sections (features, vendor cards) to create a focused, minimal entry point.

## Key Changes

**Layout & Structure**
- Converted hero from centered single-column to a two-column grid layout (text | phone mockup)
- Removed all sections below the hero: features section, vendor card section, and associated styling
- Hero now spans full viewport height with centered vertical alignment

**Hero Section Updates**
- Repositioned sun rays and glow effects from center (50%) to right side (74%) to frame the phone mockup
- Adjusted background gradient to softer, lighter tones (creme → yellow instead of yellow → amber)
- Added 3D perspective transform to phone mockup (`rotateY(-15deg) rotateX(4deg)`)
- Increased phone mockup size from 232×384px to 268×552px for better prominence
- Updated phone notch dimensions and screen border radius

**Typography & Content**
- Increased hero title font size (clamp 2.1rem–3.15rem) and adjusted line-height for better hierarchy
- Changed accent color from darker brown (#b4470a) to brighter orange (#e8890a)
- Moved lead paragraph from below title to above CTA button
- Repositioned badge, title, and lead text to left-align within the text column

**Button Styling**
- Redesigned `.hero-pill` button with updated padding (15px 30px), shadow, and hover states
- Added `.hero-pill-primary` variant with dark background for primary CTA
- Removed secondary button variants (glass, light) that were used in removed sections

**Responsive Behavior**
- Added breakpoint at 900px to stack columns vertically on tablets
- Adjusted phone mockup animation to simple vertical float on smaller screens
- Maintained mobile-first approach with appropriate padding and sizing adjustments

**Removed Components**
- Deleted all `.home-btn-*` button variants (primary, glass, light)
- Removed `.home-section`, `.home-kicker`, `.home-section-title` utilities
- Removed `.home-features*`, `.home-feature*` feature card styles
- Removed `.home-vendor-*` vendor card section and related styles
- Removed secondary navigation buttons (Como Funciona, Para Vendedores)

**Code Cleanup**
- Simplified Home.jsx to contain only the hero section with essential imports
- Removed feature cards and vendor section JSX
- Reduced icon imports to only those used in hero (FiMapPin, FiArrowRight, FiNavigation)

https://claude.ai/code/session_01FYivEH12aZqnaHRRkaoapg