### PR TITLE
Redesign hero section with centered layout on yellow background

### DIFF
--- a/sunny_sales_web/src/index.css
+++ b/sunny_sales_web/src/index.css
@@ -105,10 +105,8 @@ html { scroll-behavior: smooth; }
 body {
   margin: 0;
   padding: 0;
-  background-color: var(--bg);
-  /* Luz ambiente muito subtil no topo da página (brilho dourado). */
-  background-image:
-    radial-gradient(820px 400px at 88% -10%, rgba(236, 208, 111, 0.16), transparent 60%);
+  /* Fundo amarelo da marca em todas as páginas. */
+  background-color: var(--gold);
   background-repeat: no-repeat;
   overflow-x: hidden;
   -webkit-text-size-adjust: 100%;

--- a/sunny_sales_web/src/pages/Home.css
+++ b/sunny_sales_web/src/pages/Home.css
@@ -1,6 +1,6 @@
-/* ── Sunny Sales — Landing page (hero editorial preto/dourado) ──
-   Estilo inspirado em YellowTelescope: alto contraste preto sobre
-   branco, tipografia display gigante e o dourado como único acento. */
+/* ── Sunny Sales — Landing page (hero centrado sobre amarelo) ──
+   Fundo amarelo da marca, com todo o conteúdo centrado: badge,
+   título display, texto e ações. */
 
 .home {
   color: var(--text);
@@ -8,8 +8,7 @@
 }
 
 /* ════════════════════════════════════════════════════════
-   Hero — texto editorial à esquerda, mockup do site num
-   telemóvel à direita, sobre um grande anel dourado.
+   Hero — conteúdo editorial centrado sobre fundo amarelo.
    ════════════════════════════════════════════════════════ */
 .home-hero {
   position: relative;
@@ -22,76 +21,32 @@
   min-height: 100vh;
   display: flex;
   align-items: center;
+  justify-content: center;
   overflow: hidden;
   isolation: isolate;
-  /* Branco puro com um brilho dourado muito subtil à direita. */
-  background:
-    radial-gradient(52% 60% at 76% 44%, rgba(236, 208, 111, 0.18) 0%, rgba(236, 208, 111, 0) 62%),
-    #ffffff;
+  /* Fundo amarelo da marca */
+  background: var(--gold);
 }
 
-/* Anel dourado tracejado a rodar lentamente (nota gráfica / "telescópio") */
-.hero-rays {
-  position: absolute;
-  top: 44%;
-  left: 76%;
-  width: 620px;
-  height: 620px;
-  transform: translate(-50%, -50%);
-  border-radius: 50%;
-  border: 2px dashed rgba(169, 130, 27, 0.35);
-  animation: sunSpin 90s linear infinite;
-  z-index: 0;
-  pointer-events: none;
-}
-.hero-rays::before {
-  content: '';
-  position: absolute;
-  inset: 46px;
-  border-radius: 50%;
-  border: 1px solid rgba(169, 130, 27, 0.22);
-}
-@keyframes sunSpin {
-  to { transform: translate(-50%, -50%) rotate(360deg); }
-}
-
-/* Disco dourado suave por trás do telemóvel */
-.hero-sun {
-  position: absolute;
-  top: 44%;
-  left: 76%;
-  width: 440px;
-  height: 440px;
-  transform: translate(-50%, -50%);
-  border-radius: 50%;
-  background: radial-gradient(circle,
-    var(--gold) 0%,
-    rgba(236, 208, 111, 0.55) 46%,
-    rgba(236, 208, 111, 0) 72%);
-  filter: blur(2px);
-  z-index: 0;
-  pointer-events: none;
-}
-
-/* Grelha de duas colunas: texto | telemóvel */
+/* Conteúdo centrado numa única coluna */
 .home-hero-inner {
   position: relative;
   z-index: 1;
   width: 100%;
-  max-width: 1180px;
+  max-width: 720px;
   margin: 0 auto;
-  display: grid;
-  grid-template-columns: 1.1fr 0.9fr;
+  display: flex;
+  flex-direction: column;
   align-items: center;
-  gap: 3rem;
+  text-align: center;
 }
 
 /* ── Coluna do texto ─────────────────────────────────── */
 .hero-copy {
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
-  text-align: left;
+  align-items: center;
+  text-align: center;
 }
 
 .home-hero-badge {
@@ -114,13 +69,13 @@
   width: 7px;
   height: 7px;
   border-radius: 50%;
-  background: var(--gold);
-  box-shadow: 0 0 0 3px rgba(236, 208, 111, 0.35);
+  background: var(--ink);
+  box-shadow: 0 0 0 3px rgba(10, 10, 10, 0.18);
   animation: heroPulse 2.4s ease-in-out infinite;
 }
 @keyframes heroPulse {
-  0%, 100% { box-shadow: 0 0 0 3px rgba(236, 208, 111, 0.35); }
-  50% { box-shadow: 0 0 0 6px rgba(236, 208, 111, 0.08); }
+  0%, 100% { box-shadow: 0 0 0 3px rgba(10, 10, 10, 0.18); }
+  50% { box-shadow: 0 0 0 6px rgba(10, 10, 10, 0.05); }
 }
 
 .home-hero-title {
@@ -131,22 +86,22 @@
   letter-spacing: -0.035em;
   color: #0a0a0a;
   margin: 0 0 22px;
-  max-width: 14ch;
+  max-width: 16ch;
   text-wrap: balance;
   animation: fadeInUp 0.55s var(--ease-out) 0.06s both;
 }
-/* Palavra em destaque: texto preto sobre marcador dourado */
+/* Palavra em destaque: texto preto sobre marcador branco */
 .home-hero-accent {
   color: #0a0a0a;
-  background: linear-gradient(transparent 60%, var(--gold) 60% 92%, transparent 92%);
+  background: linear-gradient(transparent 60%, #fff 60% 92%, transparent 92%);
   padding: 0 0.06em;
 }
 
 .home-hero-lead {
   font-size: clamp(1.02rem, 1.3vw, 1.15rem);
   line-height: 1.55;
-  color: var(--text-secondary);
-  max-width: 36ch;
+  color: #4a3d12;
+  max-width: 42ch;
   margin: 0 0 32px;
   text-wrap: pretty;
   animation: fadeInUp 0.55s var(--ease-out) 0.12s both;
@@ -156,6 +111,7 @@
 .hero-actions {
   display: flex;
   align-items: center;
+  justify-content: center;
   gap: 16px;
   flex-wrap: wrap;
   animation: fadeInUp 0.55s var(--ease-out) 0.2s both;
@@ -197,7 +153,7 @@
   box-shadow: 0 18px 38px -14px rgba(10, 10, 10, 0.75);
 }
 
-/* Link de texto secundário com sublinhado dourado */
+/* Link de texto secundário com sublinhado escuro */
 .hero-textlink {
   display: inline-flex;
   align-items: center;
@@ -207,7 +163,7 @@
   color: var(--text);
   text-decoration: none;
   padding: 4px 2px;
-  border-bottom: 2px solid var(--gold);
+  border-bottom: 2px solid var(--ink);
   transition: color var(--transition), opacity var(--transition);
 }
 .hero-textlink:hover { opacity: 0.7; }
@@ -216,12 +172,13 @@
 .hero-facts {
   display: flex;
   align-items: center;
+  justify-content: center;
   gap: 14px;
   flex-wrap: wrap;
   margin-top: 34px;
   font-size: 0.82rem;
   font-weight: 600;
-  color: var(--text-secondary);
+  color: #4a3d12;
   animation: fadeInUp 0.55s var(--ease-out) 0.28s both;
 }
 .hero-facts span { white-space: nowrap; }
@@ -229,220 +186,8 @@
   width: 5px;
   height: 5px;
   border-radius: 50%;
-  background: var(--gold);
+  background: var(--ink);
   display: inline-block;
-}
-
-/* ── Telemóvel com o mockup do site ──────────────────── */
-.hero-phone {
-  position: relative;
-  z-index: 2;
-  justify-self: center;
-  width: 268px;
-  height: 552px;
-  border-radius: 44px;
-  background: #0a0a0a;
-  padding: 12px;
-  box-shadow:
-    0 60px 100px -34px rgba(10, 10, 10, 0.5),
-    0 0 0 1px rgba(255, 255, 255, 0.08) inset;
-  transform: perspective(1600px) rotateY(-15deg) rotateX(4deg);
-  animation: heroFloat 6s ease-in-out infinite;
-}
-@keyframes heroFloat {
-  0%, 100% { transform: perspective(1600px) rotateY(-15deg) rotateX(4deg) translateY(0); }
-  50% { transform: perspective(1600px) rotateY(-15deg) rotateX(4deg) translateY(-12px); }
-}
-.hero-phone-notch {
-  position: absolute;
-  top: 12px;
-  left: 50%;
-  transform: translateX(-50%);
-  width: 96px;
-  height: 22px;
-  background: #0a0a0a;
-  border-radius: 0 0 14px 14px;
-  z-index: 3;
-}
-.hero-phone-screen {
-  position: relative;
-  width: 100%;
-  height: 100%;
-  border-radius: 34px;
-  overflow: hidden;
-  background: #f7f7f5;
-  display: flex;
-  flex-direction: column;
-}
-
-/* Mini-navbar do site (preta, alto contraste) */
-.ps-bar {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 16px 15px 12px;
-  background: #0a0a0a;
-}
-.ps-logo {
-  font-family: var(--font-display);
-  font-size: 0.82rem;
-  font-weight: 700;
-  letter-spacing: -0.02em;
-  color: #fff;
-}
-.ps-burger {
-  display: flex;
-  flex-direction: column;
-  gap: 2.5px;
-}
-.ps-burger i {
-  width: 15px;
-  height: 2px;
-  border-radius: 2px;
-  background: var(--gold);
-}
-
-/* Mini-hero do site (dourado) */
-.ps-hero {
-  padding: 14px 15px 16px;
-  background: linear-gradient(180deg, #f6e6a8 0%, var(--gold) 100%);
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-.ps-tag {
-  font-size: 0.56rem;
-  font-weight: 800;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  color: #6b5310;
-}
-.ps-title {
-  font-family: var(--font-display);
-  font-size: 0.94rem;
-  font-weight: 700;
-  line-height: 1.15;
-  color: #0a0a0a;
-}
-.ps-cta {
-  align-self: flex-start;
-  margin-top: 4px;
-  font-size: 0.64rem;
-  font-weight: 700;
-  color: #fff;
-  background: #0a0a0a;
-  padding: 6px 14px;
-  border-radius: var(--radius-full);
-}
-
-/* Mini-mapa do site */
-.ps-map {
-  position: relative;
-  flex: 1;
-  background: linear-gradient(180deg, #efefec 0%, #e6e6e2 55%, #f3ecd6 100%);
-  overflow: hidden;
-}
-.ps-grid {
-  position: absolute;
-  inset: 0;
-  background-image:
-    linear-gradient(rgba(10, 10, 10, 0.05) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(10, 10, 10, 0.05) 1px, transparent 1px);
-  background-size: 30px 30px;
-}
-.ps-map::before {
-  content: '';
-  position: absolute;
-  left: -20%;
-  right: -20%;
-  top: 58%;
-  height: 40px;
-  background: rgba(255, 255, 255, 0.6);
-  transform: rotate(-10deg);
-}
-.ps-pin {
-  position: absolute;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 26px;
-  height: 26px;
-  border-radius: 50% 50% 50% 2px;
-  color: #0a0a0a;
-  transform: rotate(-45deg);
-  box-shadow: 0 6px 14px -3px rgba(10, 10, 10, 0.4);
-}
-.ps-pin svg { transform: rotate(45deg); }
-.ps-pin-a { top: 20%; left: 22%; background: var(--gold); animation: pinPop 3.4s ease-in-out infinite; }
-.ps-pin-b { top: 34%; left: 60%; background: #0a0a0a; color: var(--gold); animation: pinPop 3.4s ease-in-out 0.5s infinite; }
-.ps-pin-c { top: 16%; left: 70%; background: var(--gold); animation: pinPop 3.4s ease-in-out 1s infinite; }
-@keyframes pinPop {
-  0%, 100% { transform: rotate(-45deg) translateY(0); }
-  50% { transform: rotate(-45deg) translateY(-5px); }
-}
-.ps-me {
-  position: absolute;
-  bottom: 22%;
-  left: 40%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 28px;
-  height: 28px;
-  border-radius: 50%;
-  background: #0a0a0a;
-  color: var(--gold);
-  border: 3px solid #fff;
-  box-shadow: 0 0 0 5px rgba(10, 10, 10, 0.12);
-}
-
-/* Cartão de vendedor no fundo do ecrã */
-.ps-card {
-  display: flex;
-  align-items: center;
-  gap: 9px;
-  margin: 10px;
-  padding: 10px 12px;
-  background: #fff;
-  border-radius: 16px;
-  box-shadow: 0 10px 24px -10px rgba(10, 10, 10, 0.35);
-}
-.ps-card-emoji {
-  font-size: 1.25rem;
-  width: 34px;
-  height: 34px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: 11px;
-  background: var(--surface-warm);
-  flex-shrink: 0;
-}
-.ps-card-body {
-  display: flex;
-  flex-direction: column;
-  min-width: 0;
-  flex: 1;
-}
-.ps-card-body strong {
-  font-size: 0.76rem;
-  font-weight: 700;
-  color: #0a0a0a;
-}
-.ps-card-body span {
-  font-size: 0.64rem;
-  color: var(--text-secondary);
-}
-.ps-card-go {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 26px;
-  height: 26px;
-  border-radius: 50%;
-  background: #0a0a0a;
-  color: var(--gold);
-  flex-shrink: 0;
 }
 
 @keyframes fadeInUp {
@@ -456,30 +201,8 @@
     padding: calc(var(--navbar-h) + 28px) 1.25rem 3rem;
     min-height: auto;
   }
-  .home-hero-inner {
-    grid-template-columns: 1fr;
-    gap: 2.5rem;
-    justify-items: center;
-  }
-  .hero-copy {
-    align-items: center;
-    text-align: center;
-    order: 1;
-  }
   .home-hero-title { max-width: 18ch; }
   .home-hero-lead { max-width: 44ch; }
-  .hero-actions { justify-content: center; }
-  .hero-facts { justify-content: center; }
-  .hero-phone {
-    order: 2;
-    transform: none;
-    animation: heroFloatFlat 6s ease-in-out infinite;
-  }
-  @keyframes heroFloatFlat {
-    0%, 100% { transform: translateY(0); }
-    50% { transform: translateY(-10px); }
-  }
-  .hero-rays, .hero-sun { left: 50%; top: 60%; }
 }
 
 @media (max-width: 768px) {
@@ -493,9 +216,6 @@
     padding: calc(var(--navbar-h) + 24px) 1.1rem 2.5rem;
   }
   .home-hero-title { font-size: clamp(2.2rem, 10vw, 3rem); }
-  .hero-phone { width: 240px; height: 494px; }
-  .hero-rays { width: 460px; height: 460px; }
-  .hero-sun { width: 340px; height: 340px; }
   .hero-pill { width: 100%; }
   .hero-actions { width: 100%; }
 }

--- a/sunny_sales_web/src/pages/Home.jsx
+++ b/sunny_sales_web/src/pages/Home.jsx
@@ -1,23 +1,19 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { FiMapPin, FiArrowRight, FiNavigation } from 'react-icons/fi';
+import { FiMapPin, FiArrowRight } from 'react-icons/fi';
 import './Home.css';
 
 // (em português) Página inicial / landing da Sunny Sales.
-// Um único ecrã (hero): à esquerda o texto e o botão "Explorar Mapa";
-// à direita o mockup do site dentro de um telemóvel, com um brilho de sol
-// por trás. Sem secções adicionais — apenas o hero. O header e o rodapé
-// são geridos em App.jsx.
+// Um único ecrã (hero) sobre fundo amarelo, com todo o conteúdo
+// centrado: o texto e o botão "Explorar Mapa". Sem secções
+// adicionais — apenas o hero. O header e o rodapé são geridos
+// em App.jsx.
 export default function Home() {
   return (
     <div className="home">
       <section className="home-hero">
-        {/* Fundo: raios de sol + brilho quente por trás do telemóvel */}
-        <span className="hero-rays" aria-hidden="true" />
-        <span className="hero-sun" aria-hidden="true" />
-
         <div className="home-hero-inner">
-          {/* ── Coluna do texto ─────────────────────────────── */}
+          {/* ── Conteúdo centrado ───────────────────────────── */}
           <div className="hero-copy">
             <span className="home-hero-badge">
               <span className="home-hero-badge-dot" aria-hidden="true" />
@@ -51,37 +47,6 @@ export default function Home() {
               <span>Praias de Portugal</span>
               <i aria-hidden="true" />
               <span>Sem instalar app</span>
-            </div>
-          </div>
-
-          {/* ── Coluna do telemóvel (mockup do site) ────────── */}
-          <div className="hero-phone" aria-hidden="true">
-            <span className="hero-phone-notch" />
-            <div className="hero-phone-screen">
-              <div className="ps-bar">
-                <span className="ps-logo">Sunny Sales</span>
-                <span className="ps-burger"><i /><i /><i /></span>
-              </div>
-              <div className="ps-hero">
-                <span className="ps-tag">Praia · tempo real</span>
-                <strong className="ps-title">Vendedores perto de ti</strong>
-                <span className="ps-cta">Ver no Mapa</span>
-              </div>
-              <div className="ps-map">
-                <span className="ps-grid" />
-                <span className="ps-pin ps-pin-a"><FiMapPin size={11} /></span>
-                <span className="ps-pin ps-pin-b"><FiMapPin size={11} /></span>
-                <span className="ps-pin ps-pin-c"><FiMapPin size={11} /></span>
-                <span className="ps-me"><FiNavigation size={10} /></span>
-              </div>
-              <div className="ps-card">
-                <span className="ps-card-emoji">🍦</span>
-                <div className="ps-card-body">
-                  <strong>Gelados do Zé</strong>
-                  <span>a 120 m · aberto</span>
-                </div>
-                <span className="ps-card-go"><FiArrowRight size={12} /></span>
-              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
Redesigned the Home page hero section from a two-column layout with phone mockup to a centered, single-column design on the brand's yellow background. This simplifies the landing page while maintaining visual hierarchy and engagement through refined typography and interactions.

## Key Changes

**Layout & Structure**
- Changed hero from two-column grid (text + phone mockup) to centered flex column layout
- Removed phone mockup component and all associated styling (`.hero-phone`, `.ps-*` classes)
- Removed decorative sun rays and glow effects (`.hero-rays`, `.hero-sun` animations)
- Reduced max-width from 1180px to 720px for tighter content focus

**Visual Design**
- Changed hero background from white with subtle gold gradient to solid brand yellow (`var(--gold)`)
- Updated page background to yellow throughout (in `index.css`)
- Changed accent highlight on hero title from gold to white
- Updated badge dot and accent colors from gold to dark ink (`var(--ink)`)
- Adjusted text colors for yellow background: lead text and facts now use darker brown (`#4a3d12`)
- Updated text link underline from gold to dark ink

**Content Alignment**
- Centered all hero content: badge, title, lead text, actions, and facts
- Changed hero copy from left-aligned to center-aligned
- Added `justify-content: center` to action buttons and facts sections
- Adjusted text wrapping and max-widths for centered layout

**Responsive Updates**
- Simplified tablet breakpoint by removing phone mockup repositioning logic
- Removed decorative element repositioning for smaller screens
- Maintained responsive typography scaling

## Implementation Details
- Removed unused icon import (`FiNavigation`) from Home.jsx
- Cleaned up extensive phone mockup HTML and CSS (200+ lines removed)
- Preserved all animation keyframes for fade-in effects
- Maintained accessibility attributes on remaining decorative elements

https://claude.ai/code/session_01RtEkfmHHFjMdcKyqA23nzx