### PR TITLE
Rebrand to Dark Sport/Premium theme with red-orange accent

### DIFF
--- a/sunny_sales_web/DESIGN_SYSTEM.md
+++ b/sunny_sales_web/DESIGN_SYSTEM.md
@@ -1,4 +1,4 @@
-# Sunny Sales — Design System
+# Sunny Sales — Design System "Dark Sport / Premium"
 
 Tokens centralizados em [`src/index.css`](src/index.css) (`:root`). Este documento
 descreve **como usar cada token**. Nenhuma página deve introduzir cores, tamanhos
@@ -8,40 +8,44 @@ de fonte ou sombras fora desta lista.
 
 | Token | Valor | Uso |
 |---|---|---|
-| `--primary` | `#0e7f94` (teal do logótipo) | Acentos de marca: ícones, links, números de passos, estados ativos, foco. AA (4.69:1) sobre branco. |
-| `--primary-dark` | `#0a5464` | Texto teal sobre fundos teal claros (`--primary-light-solid`). |
-| `--primary-bright` | `#18a8c0` | Teal vivo do logótipo — **apenas decorativo** (pontos, ilustrações), nunca texto. |
-| `--primary-light` / `--primary-light-solid` | teal a 8% / `#e9f4f6` | Fundos suaves de chips e ícones. |
-| `--secondary` | `#f5b301` (amarelo) | **Ação primária** — CTA "Explorar Mapa", submissão de formulários, plano em destaque — e micro-indicadores (pontos, badges). Texto sobre amarelo: sempre `--ink` (10.3:1). |
-| `--ink` | `#0f0f0f` | Texto principal e **ações de navegação secundárias** (botão do header, botões utilitários). |
-| `--navy` | `#0d2b39` (azul-marinho) | Fundo de **blocos institucionais de contraste** (painel "Para Vendedores", banners finais). Texto branco: 14.8:1. |
-| `--text-secondary` | `#6b7280` | Texto de apoio. 4.83:1 sobre branco (AA). |
-| `--text-muted` | `#71717a` | Legendas e metadados. 4.83:1 sobre branco (AA). |
-| `--border` / `--border-strong` | `#ececec` / `#e2e2e2` | Bordas de 1px; a forte só em hover/inputs. |
-| `--success` / `--warning` / `--error` | verdes/âmbar/vermelho | Apenas estados funcionais (validação, avisos). |
+| `--bg` | `#10151c` (azul-petróleo/carvão) | Fundo principal do site (body, navbar). |
+| `--bg-deep` / `--bg-raised` | `#0b0f15` / `#1a212b` | Extremos dos gradientes subtis do hero e de secções de destaque. |
+| `--surface` / `--surface-alt` | `#1a212b` / `#232d3a` | Fundo de cards e painéis; o alt para chips, ícones e hovers. |
+| `--accent` / `--secondary` | `#ef4136` (vermelho-alaranjado) | **Ação primária** — CTAs sólidos ("Explorar Mapa", submissões, plano em destaque) — e detalhes: sublinhado do item de menu ativo, ícones, badges, pontos. Texto sobre o acento: sempre `#fff`. |
+| `--accent-hover` | `#d63527` | Hover (leve escurecimento) dos botões de acento. |
+| `--accent-text` / `--primary-dark` | `#ff8d84` | Texto/ícones de acento sobre fundo escuro (AA). |
+| `--primary` | alias de `--accent` | Compatibilidade: ícones, links, estados ativos, foco. |
+| `--ink` | alias de `--accent` | Compatibilidade: botões sólidos legados ficam no acento. Para texto escuro sobre fundos claros residuais usar `--ink-on-light` (`#151b22`). |
+| `--navy` | `#151d27` | Painéis escuros institucionais (ligeiramente mais claros que o fundo). |
+| `--text` | `#f5f5f5` | Títulos e texto principal sobre fundo escuro. |
+| `--text-secondary` | `#c9ced6` | Parágrafos de apoio. |
+| `--text-muted` | `#98a2ae` | Legendas e metadados. |
+| `--border` / `--border-strong` | `#262f3a` / `#364253` | Bordas de 1px sobre escuro; a forte em hover/inputs/outlines. |
+| `--blue` / `--teal` / `--sky` | `#5cc0d4` | Apenas funcional: links utilitários e "a tua posição" no mapa. |
+| `--success` / `--warning` / `--error` | verdes/âmbar/vermelho claros | Apenas estados funcionais (validação, avisos), com fundos rgba translúcidos. |
 
-**Regra de ouro:** amarelo = "faz isto agora"; preto = "navega/ferramenta";
-teal = identidade e acentos; navy = secção escura institucional. Se um ecrã
-tiver dois botões amarelos lado a lado, um deles está errado.
+**Regra de ouro:** vermelho-alaranjado = "faz isto agora" + detalhes de marca;
+branco/quase-branco = texto e outlines; os fundos são sempre tons escuros de
+azul-petróleo/carvão com gradientes subtis (`--grad-dark`). Se um ecrã tiver
+dois botões sólidos de acento lado a lado, um deles está errado.
 
 ## 2. Tipografia
 
-Família única: **Inter** (pesos 400–700 + 650 para títulos hero).
+Família única: **Inter** (variável 100–900, self-hosted).
 
 | Token | Tamanho | Uso |
 |---|---|---|
-| `--fs-display` | 40→58px | H1 do hero da Home (peso 650) |
-| `--fs-h1` | 32→44px | H1 do hero das páginas internas (peso 650) |
-| `--fs-h2` | 28→32px | Títulos de secção (peso 600) |
-| `--fs-h3` | 20→24px | Subtítulos e cabeçalhos de card (peso 600) |
-| `--fs-lead` | 17→20px | Parágrafo de apoio sob um título (cor `--text-secondary`) |
-| `--fs-body` | 16px | Corpo |
+| `--fs-display` | 48→64px | H1 do hero da Home (peso **800**, tracking -0.03em) |
+| `--fs-h1` | 32→44px | H1 do hero das páginas internas (peso 800) |
+| `--fs-h2` | 28→32px | Títulos de secção (peso 700) |
+| `--fs-h3` | 20→24px | Subtítulos e cabeçalhos de card (peso 600–700) |
+| `--fs-lead` | 17→20px | Parágrafo de apoio sob um título (cor `--text-secondary`, peso 400) |
+| `--fs-body` | 16px | Corpo (peso 400) |
 | `--fs-body-sm` | 15px | Corpo compacto (cards, listas) |
 | `--fs-caption` | 13px | Legendas, labels, eyebrows uppercase |
 
-Hierarquia dos heroes internos: título `--fs-h1` 650 + lead `--fs-lead`
-`--text-secondary` + chips `--fs-caption`. Igual em Sobre o Projeto, Praia
-Sustentável, Planos, Como Funciona, FAQs e Contacto.
+Menu de navegação: itens em **UPPERCASE**, 0.78rem, peso 600, tracking `0.08em`;
+item ativo com sublinhado fino de 2px em `--accent`.
 
 ## 3. Espaçamento, raios e sombras
 
@@ -49,37 +53,41 @@ Sustentável, Planos, Como Funciona, FAQs e Contacto.
   `--space-lg` 24 · `--space-xl` 32 · `--space-2xl` 48.
 - Ritmo vertical de secções da Home: `--section-pad` (`clamp(4rem, 8vw, 7rem)`)
   aplicado como padding-top de todas as secções.
-- Raios: `--radius-sm` 10 · `--radius-md` 12 (botões/inputs) · `--radius-lg` 16
-  (cards) · `--radius-2xl` 20 (heroes) · `--radius-full` (pills).
-- Sombras: `--shadow-xs`→`--shadow-lg`, quase impercetíveis; hover de card =
-  `--shadow-md` + `translateY(-2px)`.
+- Raios: `--radius-sm` 10 · `--radius-md` 12 (inputs) · `--radius-lg` 16
+  (cards) · `--radius-2xl` 20 (heroes) · **`--radius-btn` = `--radius-full`
+  (todos os botões são pílulas)**.
+- Sombras: `--shadow-xs`→`--shadow-lg` (profundas, rgba(0,0,0,0.3+));
+  `--shadow-accent` para CTAs de acento em destaque.
 
 ## 4. Componentes partilhados (classes CSS)
 
 | Componente | Classes | Onde vive |
 |---|---|---|
-| Botões | `.hero-pill` (base) + `.hero-pill-primary` (amarelo) / `.hero-pill-ghost` (outline) · `.nav-cta` (preto, header) | `Home.css` / `index.css` |
-| Hero card interno | `.info-hero.info-hero--media` + `.info-hero-content/-title/-lead/-media` | `InfoPage.css` |
+| Botões | `.hero-pill` (base pílula) + `.hero-pill-primary` (acento sólido, texto branco) / `.hero-pill-ghost` (outline branco/transparente) · `.nav-cta` (pílula de acento, header) | `Home.css` / `index.css` |
+| Hero card interno | `.info-hero.info-hero--media` + `.info-hero-content/-title/-lead/-media` (gradiente escuro a separar texto/foto) | `InfoPage.css` |
 | Badges/Chips | `.info-badge` (+ `.info-badge-sky`) | `InfoPage.css` |
 | Cards de conteúdo | `.info-card`, `.info-cards` (grelha) | `InfoPage.css` |
 | Accordion (FAQs) | `.faq-item` (`<details>`) + `.faq-q`/`.faq-a` | `FAQ.css` |
-| Tabs segmentadas | `.faq-tabs` + `.faq-tab` | `FAQ.css` |
-| Timeline numerada | `.info-timeline` | `InfoPage.css` |
-| Banner escuro | `.info-banner` (navy) + `.info-banner-btn` (amarelo) | `InfoPage.css` |
-| Inputs | `.contacto-input/-label/-error` (Contacto) · `.vd-form-input` (dashboard) | páginas respetivas |
+| Tabs segmentadas | `.faq-tabs` + `.faq-tab` (ativa com traço de acento) | `FAQ.css` |
+| Timeline numerada | `.info-timeline` (números em acento) | `InfoPage.css` |
+| Banner escuro | `.info-banner` (`--grad-dark`) + `.info-banner-btn` (pílula de acento) | `InfoPage.css` |
+| Inputs | `.contacto-input/-label/-error` (Contacto) · `.vd-form-input` (dashboard) — fundos `--surface-alt`, texto claro | páginas respetivas |
 | Toggle | `.vendor-switch` | `VendorDashboard.css` |
 | StatCard | `.vd-stat-card` (+ `.vd-skeleton` no loading) | `VendorDashboard.css` |
 
 As imagens hero das páginas internas usam todas o mesmo tratamento:
-grelha `1.05fr/0.95fr`, `min-height: 320px`, `object-fit: cover`, overlay
-branco suave à esquerda e fonte Unsplash com `auto=format` (WebP/AVIF).
+grelha `1.05fr/0.95fr`, `min-height: 320px`, `object-fit: cover`, gradiente
+escuro suave à esquerda (transição para o card) e fonte Unsplash com
+`auto=format` (WebP/AVIF).
 
 ## 5. Acessibilidade
 
-- Foco visível: `outline: 2px solid var(--focus-ring)` (+2px offset) em todos
-  os elementos interativos.
+- Foco visível: `outline: 2px solid var(--focus-ring)` (`#ff8d84`, +2px offset)
+  em todos os elementos interativos.
 - Alvos de toque ≥44×44px em mobile.
-- Contraste mínimo AA garantido pelos tokens de texto — não usar cinzentos
-  mais claros do que `--text-muted` para texto informativo.
+- Contraste mínimo AA garantido pelos tokens de texto sobre os fundos escuros —
+  não usar cinzentos mais escuros do que `--text-muted` para texto informativo.
 - Ícones sem texto visível têm sempre `aria-label`; decorativos usam
   `aria-hidden="true"`.
+- `color-scheme: dark` ativo — controlos nativos (selects, scrollbars)
+  rendem em modo escuro.

--- a/sunny_sales_web/index.html
+++ b/sunny_sales_web/index.html
@@ -5,7 +5,7 @@
     <link rel="icon" type="image/png" href="/logosite.png" />
     <link rel="apple-touch-icon" href="/logosite.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="theme-color" content="#fcfcfc" />
+    <meta name="theme-color" content="#10151c" />
     <meta name="description" content="Sunny Sales — encontra vendedores ambulantes na praia em tempo real. Bolas de Berlim, gelados e acessórios de praia perto de ti." />
 
     <!-- Open Graph / partilha social -->

--- a/sunny_sales_web/src/components/ImageCropper.css
+++ b/sunny_sales_web/src/components/ImageCropper.css
@@ -14,7 +14,7 @@
 }
 
 .cropper-box {
-  background: #fff;
+  background: var(--surface);
   padding: 10px;
   display: flex;
   flex-direction: column;

--- a/sunny_sales_web/src/components/WelcomeCard.css
+++ b/sunny_sales_web/src/components/WelcomeCard.css
@@ -16,13 +16,13 @@
 }
 
 .welcome-card {
-  background: #fff;
+  background: var(--surface);
   border: 1px solid var(--border);
   border-radius: 16px;
   padding: 32px 28px 28px;
   max-width: 400px;
   width: 100%;
-  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.12);
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
   animation: welcomeSlideUp 0.25s ease-out;
 }
 
@@ -52,7 +52,7 @@
   margin: 0 0 6px;
   font-size: 1.35rem;
   font-weight: 700;
-  color: var(--navy);
+  color: var(--text);
   line-height: 1.2;
 }
 
@@ -99,7 +99,7 @@
 .welcome-steps li strong {
   font-size: 0.88rem;
   font-weight: 600;
-  color: var(--navy);
+  color: var(--text);
 }
 
 .welcome-steps li span {
@@ -112,9 +112,9 @@
   width: 100%;
   padding: 14px;
   border: none;
-  border-radius: 12px;
+  border-radius: var(--radius-btn);
   background: var(--secondary);
-  color: var(--ink);
+  color: #fff;
   font-size: 0.95rem;
   font-weight: 600;
   cursor: pointer;

--- a/sunny_sales_web/src/index.css
+++ b/sunny_sales_web/src/index.css
@@ -23,25 +23,26 @@
 }
 
 /* ════════════════════════════════════════════════════════
-   Sunny Sales — Design System
+   Sunny Sales — Design System "Dark Sport / Premium"
 
    PALETA (regras de uso):
-   · --primary (teal do logótipo) — cor de marca para acentos,
-     ícones, links, estados ativos e pequenos destaques.
-     Nunca é fundo de grandes áreas.
-   · --secondary (amarelo/dourado) — exclusivo de AÇÕES
-     PRIMÁRIAS (CTA "Explorar Mapa", submissões, "Escolher
-     plano" em destaque) e micro-indicadores (pontos, badge).
-   · --ink (quase-preto) — ações de navegação secundárias
-     (botão do header, botões utilitários) e texto principal.
-   · --navy (azul-marinho) — fundo de blocos institucionais
-     de contraste (painel "Para Vendedores", banners escuros).
-   · Cinzentos --text-secondary/--text-muted/--border —
-     hierarquia de texto e separadores. Todos os pares
-     texto/fundo cumprem WCAG AA (≥4.5:1 em texto normal).
+   · Fundos escuros — azul-petróleo/carvão (--bg #10151c) com
+     gradientes subtis até --bg-raised (#1a212b) em heroes e
+     secções de destaque. --surface/--surface-alt para cards.
+   · --secondary / --accent (vermelho-alaranjado #ef4136) —
+     AÇÕES PRIMÁRIAS (CTAs, submissões), sublinhado do item
+     de menu ativo, ícones, badges e pequenos detalhes.
+     Texto sobre o acento: sempre branco (#fff).
+   · --primary é alias do acento (ícones, links, estados
+     ativos) para compatibilidade com os componentes.
+   · Texto: --text (#f5f5f5) para títulos/corpo sobre escuro;
+     --text-secondary (#c9ced6) para parágrafos de apoio.
+     Sobre fundos claros residuais usar --ink-on-light.
+   · --navy — painéis escuros institucionais (ligeiramente
+     mais claros que o fundo, com borda subtil).
 
    TIPOGRAFIA (escala única, aplicada em todo o site):
-   · --fs-display  40→58px  Hero da Home (peso 650)
+   · --fs-display  48→64px  Hero da Home (peso 800)
    · --fs-h1       32→44px  Título hero das páginas internas
    · --fs-h2       28→32px  Títulos de secção
    · --fs-h3       20→24px  Subtítulos / cabeçalhos de card
@@ -49,94 +50,109 @@
    · --fs-body     16px     Corpo
    · --fs-body-sm  15px     Corpo compacto (cards, listas)
    · --fs-caption  13px     Legendas, labels, eyebrows
+   · Menu de navegação: uppercase com tracking 0.08em.
+
+   BOTÕES: formato pílula (--radius-btn). Primário sólido
+   vermelho-alaranjado com texto branco; secundário outline
+   branco/transparente; hover com leve escurecimento.
    ════════════════════════════════════════════════════════ */
 
 :root {
-  /* ── Cor primária de marca: teal do logótipo ──
-     #0e7f94 garante AA (4.69:1) para texto/ícones sobre branco;
-     #18a8c0 (bright) é só decorativo, nunca texto. */
-  --primary: #0e7f94;
-  --primary-hover: #0c7286;
-  --primary-dark: #0a5464;
-  --primary-bright: #18a8c0;
-  --primary-light: rgba(14, 127, 148, 0.08);
-  --primary-light-solid: #e9f4f6;
+  /* ── Acento vermelho-alaranjado (CTA e destaques) ── */
+  --accent: #ef4136;
+  --accent-hover: #d63527;
+  --accent-soft: rgba(239, 65, 54, 0.16);
+  /* Tom claro do acento — texto/ícones de acento sobre fundo escuro */
+  --accent-text: #ff8d84;
 
-  /* ── Amarelo da marca (ações primárias e micro-indicadores) ── */
-  --secondary: #f5b301;
-  --secondary-hover: #e8a800;
-  --secondary-light: rgba(245, 179, 1, 0.16);
+  /* ── Cor primária (alias do acento, compatibilidade) ── */
+  --primary: #ef4136;
+  --primary-hover: #d63527;
+  --primary-dark: #ff8d84;
+  --primary-bright: #ff6f61;
+  --primary-light: rgba(239, 65, 54, 0.12);
+  --primary-light-solid: #271e23;
 
-  /* Tons de amarelo — compatibilidade */
-  --gold: #f5b301;
-  --gold-strong: #8a6600;
-  --amber: #f5b301;
-  --amber-strong: #8a6600;
-  --coral: #f5b301;
+  /* ── Ação primária (CTAs sólidos) ── */
+  --secondary: #ef4136;
+  --secondary-hover: #d63527;
+  --secondary-light: rgba(239, 65, 54, 0.18);
 
-  /* ── Aliases de azul/teal (links, mapa, estados ativos) ── */
-  --blue: #0e7f94;
-  --blue-hover: #0a5464;
-  --teal: #0e7f94;
-  --teal-strong: #0a5464;
-  --teal-light: rgba(14, 127, 148, 0.08);
-  --sky: #18a8c0;
+  /* Tons legados de amarelo — remapeados para o acento */
+  --gold: #ef4136;
+  --gold-strong: #ffb3ab;
+  --amber: #ef4136;
+  --amber-strong: #ffb3ab;
+  --coral: #ef4136;
 
-  /* ── "Ink" (texto e botões de navegação secundária) ── */
-  --ink: #0f0f0f;
-  --ink-hover: #262626;
-  /* ── Azul-marinho (blocos escuros institucionais) ── */
-  --navy: #0d2b39;
-  --navy-light: #12374a;
-  --navy-border: rgba(255, 255, 255, 0.14);
+  /* ── Aliases de azul/teal (links funcionais, mapa) ── */
+  --blue: #5cc0d4;
+  --blue-hover: #86d3e2;
+  --teal: #5cc0d4;
+  --teal-strong: #86d3e2;
+  --teal-light: rgba(92, 192, 212, 0.12);
+  --sky: #5cc0d4;
 
-  /* ── Superfícies ── */
-  --bg: #fcfcfc;
-  --surface: #ffffff;
-  --surface-alt: #f6f6f6;
-  --surface-warm: #fafafa;
+  /* ── "Ink" (botões sólidos de navegação → acento) ── */
+  --ink: #ef4136;
+  --ink-hover: #d63527;
+  /* Texto escuro para eventuais fundos claros residuais */
+  --ink-on-light: #151b22;
+  /* ── Painéis escuros institucionais ── */
+  --navy: #151d27;
+  --navy-light: #1c2531;
+  --navy-border: rgba(255, 255, 255, 0.12);
 
-  /* ── Texto (todos AA sobre --surface/--bg) ── */
-  --text: #0f0f0f;
-  --text-secondary: #6b7280;  /* 4.83:1 sobre branco */
-  --text-muted: #71717a;      /* 4.83:1 sobre branco */
+  /* ── Superfícies (tons escuros de azul-petróleo/carvão) ── */
+  --bg-deep: #0b0f15;
+  --bg: #10151c;
+  --bg-raised: #1a212b;
+  --surface: #1a212b;
+  --surface-alt: #232d3a;
+  --surface-warm: #1a212b;
 
-  /* ── Bordas (muito subtis) ── */
-  --border: #ececec;
-  --border-strong: #e2e2e2;
+  /* ── Texto (todos AA sobre --bg/--surface) ── */
+  --text: #f5f5f5;
+  --text-secondary: #c9ced6;
+  --text-muted: #98a2ae;
+
+  /* ── Bordas (subtis sobre escuro) ── */
+  --border: #262f3a;
+  --border-strong: #364253;
 
   /* ── Cores semânticas (só em contexto funcional) ── */
-  --success: #16a34a;
-  --success-bg: #f0fdf4;
-  --success-border: #bbf7d0;
-  --warning: #b45309;
-  --warning-bg: #fffbeb;
-  --warning-border: #fde68a;
-  --error: #dc2626;
-  --error-bg: #fef2f2;
-  --error-border: #fecaca;
-  --danger: #dc2626;
+  --success: #4ade80;
+  --success-bg: rgba(74, 222, 128, 0.1);
+  --success-border: rgba(74, 222, 128, 0.35);
+  --warning: #fbbf24;
+  --warning-bg: rgba(251, 191, 36, 0.12);
+  --warning-border: rgba(251, 191, 36, 0.35);
+  --error: #f87171;
+  --error-bg: rgba(248, 113, 113, 0.12);
+  --error-border: rgba(248, 113, 113, 0.4);
+  --danger: #f87171;
 
-  /* ── Gradientes legados — achatados para cores planas ── */
-  --grad-sun: linear-gradient(135deg, #f5b301, #f5b301);
-  --grad-gold: linear-gradient(135deg, #f5b301, #f5b301);
-  --grad-sea: linear-gradient(135deg, #0e7f94, #0e7f94);
-  --grad-dusk: linear-gradient(135deg, #f5b301, #f5b301);
-  /* Painéis escuros: azul-marinho institucional */
-  --grad-dark: linear-gradient(180deg, #12374a 0%, #0d2b39 100%);
+  /* ── Gradientes legados — achatados para o acento ── */
+  --grad-sun: linear-gradient(135deg, #ef4136, #ef4136);
+  --grad-gold: linear-gradient(135deg, #ef4136, #ef4136);
+  --grad-sea: linear-gradient(135deg, #5cc0d4, #5cc0d4);
+  --grad-dusk: linear-gradient(135deg, #ef4136, #ef4136);
+  /* Painéis escuros: gradiente subtil entre dois tons do fundo */
+  --grad-dark: linear-gradient(155deg, #1a212b 0%, #10151c 100%);
 
-  /* ── Sombras (quase impercetíveis) ── */
-  --shadow-xs: 0 1px 2px rgba(0, 0, 0, 0.03);
-  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.03), 0 2px 8px rgba(0, 0, 0, 0.03);
-  --shadow-md: 0 8px 30px rgba(0, 0, 0, 0.04);
-  --shadow-lg: 0 2px 8px rgba(0, 0, 0, 0.03), 0 8px 30px rgba(0, 0, 0, 0.06);
+  /* ── Sombras (profundas, para fundo escuro) ── */
+  --shadow-xs: 0 1px 2px rgba(0, 0, 0, 0.3);
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.3), 0 2px 8px rgba(0, 0, 0, 0.25);
+  --shadow-md: 0 8px 30px rgba(0, 0, 0, 0.35);
+  --shadow-lg: 0 2px 8px rgba(0, 0, 0, 0.3), 0 12px 36px rgba(0, 0, 0, 0.45);
   --shadow-warm: var(--shadow-sm);
   --shadow-warm-lg: var(--shadow-md);
-  --shadow-primary: 0 8px 24px -12px rgba(14, 127, 148, 0.35);
-  --shadow-ink: 0 8px 24px -12px rgba(15, 15, 15, 0.28);
-  --shadow-gold: 0 8px 24px -12px rgba(245, 179, 1, 0.35);
+  --shadow-primary: 0 8px 24px -12px rgba(239, 65, 54, 0.45);
+  --shadow-ink: 0 8px 24px -12px rgba(239, 65, 54, 0.45);
+  --shadow-gold: 0 8px 24px -12px rgba(239, 65, 54, 0.45);
+  --shadow-accent: 0 10px 28px -12px rgba(239, 65, 54, 0.55);
 
-  /* ── Raios (contidos, nunca exagerados) ── */
+  /* ── Raios (contidos; botões em pílula) ── */
   --radius-xs: 8px;
   --radius-sm: 10px;
   --radius-md: 12px;
@@ -144,9 +160,11 @@
   --radius-xl: 16px;
   --radius-2xl: 20px;
   --radius-full: 9999px;
+  /* Botões: formato pílula em todo o site */
+  --radius-btn: var(--radius-full);
 
   /* ── Escala tipográfica ── */
-  --fs-display: clamp(2.5rem, 4.4vw, 3.625rem);
+  --fs-display: clamp(3rem, 5.2vw, 4rem);
   --fs-h1: clamp(2rem, 3.6vw, 2.75rem);
   --fs-h2: clamp(1.75rem, 3vw, 2rem);
   --fs-h3: clamp(1.25rem, 2vw, 1.5rem);
@@ -164,8 +182,8 @@
   --space-2xl: 48px;
   --section-pad: clamp(4rem, 8vw, 7rem);
 
-  /* ── Foco visível (teclado): teal, ≥3:1 sobre fundos claros ── */
-  --focus-ring: #0c7286;
+  /* ── Foco visível (teclado): acento claro, ≥3:1 sobre escuro ── */
+  --focus-ring: #ff8d84;
 
   /* ── Movimento (200ms, ease-out, nada mais) ── */
   --transition: 0.2s cubic-bezier(0, 0, 0.2, 1);
@@ -186,6 +204,8 @@
   font-family: 'Inter', system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
   font-feature-settings: 'cv02', 'cv03', 'cv04', 'cv11';
   color: var(--text);
+  /* Controlos nativos (inputs, scrollbars) em modo escuro */
+  color-scheme: dark;
 }
 
 *, *::before, *::after { box-sizing: border-box; }
@@ -209,7 +229,7 @@ body {
 }
 
 ::selection {
-  background: var(--navy);
+  background: var(--accent);
   color: #fff;
 }
 
@@ -282,12 +302,13 @@ body {
   display: flex;
   align-items: center;
   padding: 0 28px;
-  background: var(--surface);
+  background: var(--bg);
   border-bottom: 1px solid var(--border);
   box-shadow: none;
   z-index: 1100;
   gap: 16px;
-  transition: border-color var(--transition), height var(--transition-slow);
+  transition: border-color var(--transition), height var(--transition-slow),
+    background var(--transition);
 }
 
 /* Ao rolar: encolhe ligeiramente. Sem blur nem sombras. */
@@ -297,10 +318,10 @@ body {
 }
 .navbar--scrolled .nav-logo-img { height: 30px; }
 
-/* No topo da página inicial o header funde-se com o hero branco:
-   apenas desaparece a linha inferior. */
+/* No topo da página inicial o header é transparente sobre o hero escuro:
+   funde-se com o gradiente e só ganha fundo ao rolar. */
 .navbar.navbar--home {
-  background: var(--surface);
+  background: transparent;
   border-bottom-color: transparent;
   box-shadow: none;
 }
@@ -348,8 +369,11 @@ body {
   position: relative;
   color: var(--text-secondary);
   text-decoration: none;
-  font-size: 0.875rem;
-  font-weight: 500;
+  /* Itens de menu em maiúsculas com leve tracking (estilo sport/premium) */
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
   padding: 8px 12px;
   border-radius: var(--radius-sm);
   background: transparent;
@@ -371,9 +395,16 @@ body {
   color: var(--text);
   font-weight: 600;
 }
-/* Sem traço decorativo: o estado ativo é apenas texto mais escuro. */
+/* Item ativo: sublinhado fino vermelho-alaranjado */
 .nav-link.active::after {
-  display: none;
+  content: '';
+  position: absolute;
+  left: 12px;
+  right: 12px;
+  bottom: 1px;
+  height: 2px;
+  border-radius: 2px;
+  background: var(--accent);
 }
 
 .nav-link-icon {
@@ -415,7 +446,7 @@ body {
   outline-offset: 2px;
 }
 
-/* Botão principal do header: preto, texto branco, raio 12px */
+/* Botão principal do header: pílula vermelho-alaranjada, texto branco */
 .nav-cta {
   display: inline-flex;
   align-items: center;
@@ -423,17 +454,17 @@ body {
   text-decoration: none;
   color: #fff;
   font-size: 0.85rem;
-  font-weight: 500;
+  font-weight: 600;
   white-space: nowrap;
-  padding: 9px 16px;
+  padding: 9px 18px;
   margin-left: 6px;
-  border-radius: var(--radius-md);
-  background: var(--ink);
+  border-radius: var(--radius-btn);
+  background: var(--accent);
   box-shadow: none;
   transition: background var(--transition);
 }
 .nav-cta:hover {
-  background: var(--ink-hover);
+  background: var(--accent-hover);
   transform: none;
   box-shadow: none;
 }
@@ -476,7 +507,7 @@ body {
   display: none;
   position: fixed;
   inset: 0;
-  background: rgba(15, 15, 15, 0.32);
+  background: rgba(4, 6, 9, 0.6);
   backdrop-filter: blur(2px);
   z-index: 1040;
   opacity: 0;
@@ -507,11 +538,11 @@ body {
 /* ── Buttons ─────────────────────────────────────────── */
 
 button {
-  --btn-bg: var(--ink);
+  --btn-bg: var(--accent);
   --btn-color: #fff;
   box-sizing: border-box;
   border: none;
-  border-radius: var(--radius-md);
+  border-radius: var(--radius-btn);
   background: var(--btn-bg);
   color: var(--btn-color);
   font-family: 'Inter', system-ui, sans-serif;
@@ -531,8 +562,11 @@ button {
   -webkit-tap-highlight-color: transparent;
 }
 
-button:hover:not(:disabled) {
-  background: var(--ink-hover);
+/* :where(:enabled) contribui especificidade zero — (0,1,1) no total —
+   para que os hovers específicos dos componentes
+   (.menu-toggle:hover, .filter-*:hover, …) ganhem sempre. */
+button:where(:enabled):hover {
+  background: var(--accent-hover);
   filter: none;
   transform: none;
   box-shadow: none;
@@ -555,7 +589,7 @@ button:disabled {
 }
 
 .black-button {
-  background: var(--ink);
+  background: var(--accent);
   color: #fff;
 }
 
@@ -677,9 +711,9 @@ button:disabled {
 .form input:focus,
 .form select:focus,
 .input:focus {
-  border-color: var(--text);
+  border-color: var(--text-muted);
   background: var(--surface);
-  box-shadow: 0 0 0 3px rgba(15, 15, 15, 0.06);
+  box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.07);
 }
 
 .form input::placeholder {
@@ -690,10 +724,10 @@ button:disabled {
 .form-btn {
   width: 100%;
   padding: 13px 22px;
-  background: var(--ink);
+  background: var(--accent);
   color: #fff;
   border: none;
-  border-radius: var(--radius-md);
+  border-radius: var(--radius-btn);
   font-family: 'Inter', system-ui, sans-serif;
   font-size: 0.95rem;
   font-weight: 500;
@@ -704,7 +738,7 @@ button:disabled {
 
 .form .submit:hover:not(:disabled),
 .form-btn:hover:not(:disabled) {
-  background: var(--ink-hover);
+  background: var(--accent-hover);
   box-shadow: none;
   transform: none;
   filter: none;
@@ -754,7 +788,7 @@ button:disabled {
 .apple-login-button,
 .google-login-button {
   padding: 12px 16px;
-  border-radius: var(--radius-md);
+  border-radius: var(--radius-btn);
   cursor: pointer;
   display: flex;
   justify-content: center;
@@ -768,12 +802,12 @@ button:disabled {
 }
 
 .apple-login-button {
-  background: var(--ink);
+  background: var(--accent);
   color: #fff;
   border: none;
 }
 .apple-login-button:hover {
-  background: var(--ink-hover);
+  background: var(--accent-hover);
 }
 
 .google-login-button {
@@ -791,7 +825,7 @@ button:disabled {
 /* ── Toggle ──────────────────────────────────────────── */
 
 input[type='checkbox'] {
-  accent-color: var(--ink);
+  accent-color: var(--accent);
 }
 
 .theme-checkbox {
@@ -800,7 +834,7 @@ input[type='checkbox'] {
   appearance: none;
   width: 4em;
   height: 2em;
-  background: linear-gradient(to right, #e5e5e5 50%, var(--ink) 50%) no-repeat;
+  background: linear-gradient(to right, #3a4553 50%, var(--accent) 50%) no-repeat;
   background-size: 205%;
   background-position: 0;
   transition: 0.3s;
@@ -841,23 +875,23 @@ main {
 h2 {
   font-family: var(--font-display);
   font-size: var(--fs-h2);
-  font-weight: 600;
+  font-weight: 700;
   letter-spacing: -0.02em;
   margin-bottom: 1rem;
 }
 
 .btn-top {
-  background: var(--ink);
+  background: var(--accent);
   color: #fff;
   padding: 9px 20px;
-  border-radius: var(--radius-md);
+  border-radius: var(--radius-btn);
   text-decoration: none;
   font-weight: 500;
   font-size: 0.88rem;
   transition: background var(--transition);
 }
 .btn-top:hover {
-  background: var(--ink-hover);
+  background: var(--accent-hover);
   transform: none;
   box-shadow: none;
 }
@@ -880,15 +914,6 @@ h2 {
 /* ════════════════════════════════════════════════════════
    Utilitários de movimento & marca
    ════════════════════════════════════════════════════════ */
-
-/* Destaque de marca em texto (usado sobre painéis escuros) */
-.grad-text {
-  background: var(--grad-sun);
-  -webkit-background-clip: text;
-  background-clip: text;
-  -webkit-text-fill-color: transparent;
-  color: transparent;
-}
 
 /* Revelação ao rolar: subtil e rápida. O JS (useScrollReveal) adiciona
    .reveal-init (esconde) e .in quando o elemento fica visível. */
@@ -928,9 +953,9 @@ h2 {
   to { background-position: 200% center; }
 }
 @keyframes pinPulse {
-  0% { box-shadow: 0 0 0 0 rgba(15, 15, 15, 0.35); }
-  70% { box-shadow: 0 0 0 14px rgba(15, 15, 15, 0); }
-  100% { box-shadow: 0 0 0 0 rgba(15, 15, 15, 0); }
+  0% { box-shadow: 0 0 0 0 rgba(239, 65, 54, 0.4); }
+  70% { box-shadow: 0 0 0 14px rgba(239, 65, 54, 0); }
+  100% { box-shadow: 0 0 0 0 rgba(239, 65, 54, 0); }
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -991,7 +1016,7 @@ h2 {
 
   .nav-link {
     padding: 12px 16px;
-    font-size: 1rem;
+    font-size: 0.9rem;
     border-radius: var(--radius-md);
     min-height: 48px;
     display: flex;
@@ -1004,9 +1029,12 @@ h2 {
     background: var(--surface-alt);
   }
 
+  /* No menu móvel o item ativo usa um traço de acento à esquerda
+     (em vez do sublinhado fino usado no desktop). */
   .nav-link.active {
     color: var(--text);
     background: var(--surface-alt);
+    box-shadow: inset 3px 0 0 var(--accent);
   }
 
   .nav-link.active::after {
@@ -1259,7 +1287,7 @@ h2 {
   color: var(--text);
   text-decoration: none;
   padding: 7px 14px;
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-btn);
   border: 1px solid var(--border-strong);
   white-space: nowrap;
   transition: background var(--transition), color var(--transition),
@@ -1267,8 +1295,8 @@ h2 {
   flex-shrink: 0;
 }
 .page-link-btn:hover {
-  background: var(--ink);
-  border-color: var(--ink);
+  background: var(--accent);
+  border-color: var(--accent);
   color: #fff;
 }
 
@@ -1278,7 +1306,7 @@ h2 {
   color: var(--error);
   background: transparent;
   border: 1px solid var(--error-border);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-btn);
   padding: 7px 14px;
   white-space: nowrap;
   cursor: pointer;

--- a/sunny_sales_web/src/pages/Contacto.css
+++ b/sunny_sales_web/src/pages/Contacto.css
@@ -64,9 +64,9 @@
 }
 
 .contacto-input:focus {
-  border-color: var(--text);
+  border-color: var(--text-muted);
   background: var(--surface);
-  box-shadow: 0 0 0 3px rgba(15, 15, 15, 0.06);
+  box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.07);
 }
 
 .contacto-select {
@@ -114,20 +114,20 @@
 }
 
 /* ── Submit button ─────────────────────────────────────── */
-/* Submeter o formulário é a ação primária da página → amarelo
-   (ver DESIGN_SYSTEM.md · paleta). */
+/* Submeter o formulário é a ação primária da página → acento
+   vermelho-alaranjado (ver DESIGN_SYSTEM.md · paleta). */
 .contacto-btn {
   display: inline-flex;
   align-items: center;
   justify-content: center;
   gap: 8px;
   background: var(--secondary);
-  color: var(--ink);
+  color: #fff;
   font-weight: 600;
   font-size: 0.95rem;
   padding: 12px 28px;
   border: none;
-  border-radius: var(--radius-md);
+  border-radius: var(--radius-btn);
   cursor: pointer;
   transition: background var(--transition);
   align-self: flex-start;
@@ -161,8 +161,8 @@
   content: '';
   width: 14px;
   height: 14px;
-  border: 2px solid rgba(15, 15, 15, 0.3);
-  border-top-color: var(--ink);
+  border: 2px solid rgba(255, 255, 255, 0.35);
+  border-top-color: #fff;
   border-radius: 50%;
   animation: contacto-spin 0.7s linear infinite;
 }

--- a/sunny_sales_web/src/pages/FAQ.css
+++ b/sunny_sales_web/src/pages/FAQ.css
@@ -38,7 +38,7 @@
 }
 
 .faq-tab:hover:not(.active) {
-  color: var(--navy);
+  color: var(--text);
   filter: none;
 }
 
@@ -49,8 +49,8 @@
 
 .faq-tab.active {
   background: var(--surface);
-  color: var(--navy);
-  box-shadow: var(--shadow-sm);
+  color: var(--text);
+  box-shadow: inset 0 -2px 0 var(--accent), var(--shadow-sm);
 }
 
 .faq-list {

--- a/sunny_sales_web/src/pages/Home.css
+++ b/sunny_sales_web/src/pages/Home.css
@@ -1,8 +1,9 @@
 /* ══════════════════════════════════════════════════════════
-   Sunny Sales — Landing "Premium Minimal"
-   Quase monocromática sobre branco. Muito espaço, hierarquia
-   perfeita, cards de um único sistema, amarelo apenas no CTA
-   e em pequenos indicadores. Silenciosa e intemporal.
+   Sunny Sales — Landing "Dark Sport / Premium"
+   Fundo azul-petróleo/carvão muito escuro com gradientes
+   subtis e uma leve diagonal a separar o lado do texto do
+   lado do visual. Título grande e bold à esquerda, CTAs em
+   pílula (sólido vermelho-alaranjado + outline) lado a lado.
    ══════════════════════════════════════════════════════════ */
 
 .home {
@@ -19,11 +20,32 @@
   margin-left: calc(50% - 50vw);
   margin-top: calc(-1 * (var(--navbar-h) + 16px));
   padding: calc(var(--navbar-h) + 48px) 1.5rem 0;
-  background: var(--surface);
+  /* Gradiente subtil entre dois tons escuros + diagonal que separa o
+     lado do texto (mais escuro) do lado do visual (ligeiramente mais claro) */
+  background:
+    linear-gradient(116deg, transparent 0%, transparent 52%, rgba(255, 255, 255, 0.025) 52.15%),
+    linear-gradient(135deg, var(--bg-deep) 0%, var(--bg) 55%, var(--bg-raised) 100%);
   border-bottom: 1px solid var(--border);
+  overflow: hidden;
+}
+
+/* Brilho de acento muito ténue no canto do visual */
+.home-hero::after {
+  content: '';
+  position: absolute;
+  top: -220px;
+  right: -180px;
+  width: 560px;
+  height: 560px;
+  border-radius: 50%;
+  background: radial-gradient(circle, var(--accent-soft), transparent 68%);
+  opacity: 0.5;
+  pointer-events: none;
 }
 
 .home-hero-inner {
+  position: relative;
+  z-index: 1;
   width: 100%;
   max-width: 1120px;
   margin: 0 auto;
@@ -48,7 +70,7 @@
   font-size: 0.8125rem;
   font-weight: 500;
   color: var(--text-secondary);
-  background: var(--surface);
+  background: rgba(255, 255, 255, 0.04);
   border: 1px solid var(--border);
   border-radius: var(--radius-full);
   padding: 6px 14px;
@@ -64,11 +86,9 @@
 .home-hero-title {
   font-family: var(--font-display);
   font-size: var(--fs-display);
-  /* Peso 650 (Inter suporta pesos intermédios) para reforçar o contraste
-     entre o H1 e o parágrafo de apoio. */
-  font-weight: 650;
-  line-height: 1.06;
-  letter-spacing: -0.035em;
+  font-weight: 800;
+  line-height: 1.04;
+  letter-spacing: -0.03em;
   color: var(--text);
   margin: 0 0 24px;
   max-width: 17ch;
@@ -78,17 +98,17 @@
   position: relative;
   white-space: nowrap;
 }
-/* Realce amarelo mínimo sob a palavra-chave — o único detalhe de cor */
+/* Sublinhado vermelho-alaranjado sob a palavra-chave — detalhe de acento */
 .home-hero-accent::after {
   content: '';
   position: absolute;
   left: 0;
   right: 0;
-  bottom: 0.06em;
-  height: 0.14em;
+  bottom: 0.04em;
+  height: 0.1em;
   z-index: -1;
   border-radius: 2px;
-  background: var(--secondary-light);
+  background: var(--secondary);
 }
 
 .home-hero-lead {
@@ -104,7 +124,7 @@
 .hero-actions {
   display: flex;
   align-items: center;
-  gap: 20px;
+  gap: 14px;
   flex-wrap: wrap;
 }
 
@@ -124,7 +144,7 @@
   gap: 6px;
   white-space: nowrap;
 }
-.hero-facts span svg { color: var(--text-muted); }
+.hero-facts span svg { color: var(--secondary); }
 .hero-facts i {
   width: 3px;
   height: 3px;
@@ -133,68 +153,60 @@
   display: inline-block;
 }
 
-/* ── Botões ── */
+/* ── Botões (formato pílula) ── */
 .hero-pill {
   display: inline-flex;
   align-items: center;
   justify-content: center;
   gap: 8px;
   font-size: 0.9375rem;
-  font-weight: 500;
+  font-weight: 600;
   height: 48px;
-  padding: 0 24px;
-  border-radius: var(--radius-md);
+  padding: 0 28px;
+  border-radius: var(--radius-full);
   text-decoration: none;
   cursor: pointer;
   color: var(--text);
-  background: var(--surface);
+  background: transparent;
   border: 1px solid var(--border-strong);
   transition: background var(--transition), color var(--transition),
-    border-color var(--transition), box-shadow var(--transition);
+    border-color var(--transition), box-shadow var(--transition),
+    opacity var(--transition);
   white-space: nowrap;
 }
-.hero-pill:hover { background: var(--surface-alt); }
+.hero-pill:hover { background: rgba(255, 255, 255, 0.06); }
 .hero-pill:active { opacity: 0.9; }
 .hero-pill:focus-visible {
   outline: 2px solid var(--focus-ring);
   outline-offset: 3px;
 }
-/* CTA principal — o único elemento amarelo de peso na página */
+/* CTA principal — pílula sólida vermelho-alaranjada com texto branco */
 .hero-pill-primary {
   background: var(--secondary);
-  color: var(--ink);
+  color: #fff;
   border-color: transparent;
-  box-shadow: none;
+  box-shadow: var(--shadow-accent);
 }
 .hero-pill-primary:hover {
   background: var(--secondary-hover);
-  box-shadow: var(--shadow-sm);
+  box-shadow: var(--shadow-accent);
 }
 .hero-pill-lg {
   font-size: 1rem;
-  padding: 0 30px;
+  padding: 0 32px;
 }
+/* Botão secundário — contorno branco/transparente com texto branco */
 .hero-pill-ghost {
   background: transparent;
   color: var(--text);
-  border-color: var(--border-strong);
+  border-color: rgba(255, 255, 255, 0.28);
 }
-.hero-pill-ghost:hover { background: var(--surface-alt); }
-
-.hero-textlink {
-  display: inline-flex;
-  align-items: center;
-  gap: 7px;
-  font-size: 0.9375rem;
-  font-weight: 500;
-  color: var(--text);
-  text-decoration: none;
-  padding: 4px 2px;
-  transition: gap var(--transition), color var(--transition);
+.hero-pill-ghost:hover {
+  background: rgba(255, 255, 255, 0.07);
+  border-color: rgba(255, 255, 255, 0.45);
 }
-.hero-textlink:hover { gap: 10px; color: var(--text-secondary); }
 
-/* ── Mapa (mock estático em card de dashboard) ── */
+/* ── Mapa (mock estático em card escuro) ── */
 .hero-visual {
   display: flex;
   align-items: center;
@@ -207,13 +219,13 @@
   aspect-ratio: 5 / 4.4;
   border-radius: var(--radius-lg);
   overflow: hidden;
-  border: 1px solid var(--border);
-  box-shadow: var(--shadow-md);
-  /* Superfície neutra com grelha ténue — aspeto de dashboard */
-  background-color: #f7f8f8;
+  border: 1px solid var(--border-strong);
+  box-shadow: var(--shadow-lg);
+  /* Superfície escura com grelha ténue — aspeto de painel técnico */
+  background-color: var(--bg-raised);
   background-image:
-    linear-gradient(to right, rgba(15, 15, 15, 0.028) 1px, transparent 1px),
-    linear-gradient(to bottom, rgba(15, 15, 15, 0.028) 1px, transparent 1px);
+    linear-gradient(to right, rgba(255, 255, 255, 0.035) 1px, transparent 1px),
+    linear-gradient(to bottom, rgba(255, 255, 255, 0.035) 1px, transparent 1px);
   background-size: 32px 32px;
 }
 /* Linha de costa abstrata, quase impercetível */
@@ -224,7 +236,7 @@
   right: -10%;
   top: 52%;
   height: 1px;
-  background: var(--border-strong);
+  background: rgba(255, 255, 255, 0.16);
   transform: rotate(-8deg);
 }
 .hero-map-live {
@@ -235,13 +247,13 @@
   display: inline-flex;
   align-items: center;
   gap: 7px;
-  background: var(--surface);
+  background: rgba(16, 21, 28, 0.88);
   color: var(--text);
   font-size: 0.75rem;
   font-weight: 500;
   padding: 7px 12px;
-  border-radius: var(--radius-sm);
-  border: 1px solid var(--border);
+  border-radius: var(--radius-full);
+  border: 1px solid var(--border-strong);
   box-shadow: var(--shadow-sm);
 }
 .hero-map-live-dot {
@@ -250,20 +262,20 @@
   border-radius: 50%;
   background: var(--secondary);
 }
-/* Pins minimalistas: pontos monocromáticos com anel branco */
+/* Pins: pontos vermelho-alaranjados com anel escuro, estilo hotspot */
 .hero-pin {
   position: absolute;
   width: 14px;
   height: 14px;
   margin: -7px 0 0 -7px;
   border-radius: 50%;
-  background: var(--ink);
-  border: 3px solid #fff;
-  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.18);
+  background: var(--secondary);
+  border: 3px solid rgba(255, 255, 255, 0.92);
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.45);
   z-index: 2;
 }
 .hero-pin--accent {
-  background: var(--secondary);
+  box-shadow: 0 0 0 6px var(--accent-soft), 0 1px 6px rgba(0, 0, 0, 0.45);
 }
 .hero-me {
   position: absolute;
@@ -272,50 +284,18 @@
   margin: -7px 0 0 -7px;
   border-radius: 50%;
   background: var(--blue);
-  border: 3px solid #fff;
-  box-shadow: 0 1px 4px rgba(37, 99, 235, 0.35);
+  border: 3px solid rgba(255, 255, 255, 0.92);
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.45);
   z-index: 2;
 }
 
 /* ═══════════════ SECÇÕES ═══════════════ */
-/* Ritmo vertical único entre todas as secções (stats, passos, features,
-   categorias, CTAs) — ver token --section-pad. */
+/* Ritmo vertical único entre as secções (stats e CTA final) —
+   ver token --section-pad. */
 .home-section {
   max-width: 1120px;
   margin: 0 auto;
   padding: var(--section-pad) 1rem 0;
-}
-
-.home-head {
-  text-align: center;
-  margin-bottom: clamp(2.5rem, 5vw, 4rem);
-}
-.home-eyebrow {
-  display: inline-block;
-  font-size: 0.8125rem;
-  font-weight: 500;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: var(--text-muted);
-  margin-bottom: 16px;
-}
-.home-title {
-  font-family: var(--font-display);
-  font-size: clamp(1.75rem, 3.4vw, 2.5rem);
-  font-weight: 600;
-  letter-spacing: -0.03em;
-  color: var(--text);
-  margin: 0 auto;
-  max-width: 24ch;
-  line-height: 1.1;
-  text-wrap: balance;
-}
-.home-sub {
-  margin: 16px auto 0;
-  max-width: 52ch;
-  color: var(--text-secondary);
-  font-size: 1.0625rem;
-  line-height: 1.6;
 }
 
 /* ── Stats ── */
@@ -339,7 +319,7 @@
   display: block;
   font-family: var(--font-display);
   font-size: 1.375rem;
-  font-weight: 600;
+  font-weight: 700;
   color: var(--text);
   letter-spacing: -0.02em;
   line-height: 1.1;
@@ -351,195 +331,49 @@
   color: var(--text-secondary);
 }
 
-/* ── Steps ── */
-.home-steps {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 16px;
-}
-.step-card {
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-lg);
-  padding: 32px 28px;
-  transition: box-shadow var(--transition), transform var(--transition),
-    border-color var(--transition);
-}
-.step-card:hover {
-  box-shadow: var(--shadow-md);
-  border-color: var(--border-strong);
-  transform: translateY(-2px);
-}
-.step-num {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 32px;
-  height: 32px;
-  border-radius: var(--radius-sm);
-  background: var(--surface-alt);
-  color: var(--text);
-  font-family: var(--font-display);
-  font-weight: 600;
-  font-size: 0.875rem;
-  margin-bottom: 20px;
-}
-.step-title {
-  font-family: var(--font-display);
-  font-size: 1.0625rem;
-  font-weight: 600;
-  letter-spacing: -0.01em;
-  color: var(--text);
-  margin: 0 0 8px;
-}
-.step-text {
-  font-size: 0.9375rem;
-  color: var(--text-secondary);
-  line-height: 1.6;
-  margin: 0;
-}
-
-/* ── Features ── */
-.home-features {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 16px;
-}
-.feature-card {
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-lg);
-  padding: 28px 26px;
-  transition: box-shadow var(--transition), transform var(--transition),
-    border-color var(--transition);
-}
-.feature-card:hover {
-  box-shadow: var(--shadow-md);
-  border-color: var(--border-strong);
-  transform: translateY(-2px);
-}
-.feature-icon {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 40px;
-  height: 40px;
-  border-radius: var(--radius-sm);
-  background: var(--surface-alt);
-  color: var(--text);
-  margin-bottom: 18px;
-}
-.feature-icon svg { stroke-width: 1.75; }
-.feature-title {
-  font-size: 0.9375rem;
-  font-weight: 600;
-  letter-spacing: -0.01em;
-  color: var(--text);
-  margin: 0 0 6px;
-}
-.feature-text {
-  font-size: 0.875rem;
-  color: var(--text-secondary);
-  line-height: 1.6;
-  margin: 0;
-}
-
-/* ── Categorias ── */
-.home-cats {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
-  gap: 10px;
-}
-.cat-chip {
-  display: flex;
-  align-items: center;
-  gap: 9px;
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-full);
-  padding: 10px 18px;
-  font-weight: 500;
-  color: var(--text);
-  transition: border-color var(--transition), box-shadow var(--transition);
-}
-.cat-chip:hover {
-  box-shadow: var(--shadow-sm);
-  border-color: var(--border-strong);
-}
-/* Pequeno indicador amarelo — o detalhe que transmite verão */
-.cat-dot {
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background: var(--secondary);
-  flex-shrink: 0;
-}
-.cat-label { font-size: 0.875rem; }
-
-/* ── CTA Vendedores (painel escuro) ── */
-.home-vendor {
-  border-radius: var(--radius-2xl);
-  background: var(--grad-dark);
-  padding: clamp(3rem, 6vw, 4.5rem);
-  box-shadow: none;
-}
-.home-vendor-body { max-width: 620px; }
-.home-eyebrow--light { color: rgba(255, 255, 255, 0.68); }
-.home-vendor-title {
-  font-family: var(--font-display);
-  font-size: clamp(1.75rem, 3.4vw, 2.5rem);
-  font-weight: 600;
-  letter-spacing: -0.03em;
-  color: #fff;
-  margin: 12px 0 16px;
-  line-height: 1.1;
-}
-.home-vendor-text {
-  /* 0.82 de opacidade sobre navy ≈ 10:1 — folga confortável acima de AA */
-  color: rgba(255, 255, 255, 0.82);
-  font-size: 1.0625rem;
-  line-height: 1.6;
-  margin: 0 0 32px;
-  max-width: 52ch;
-}
-.home-vendor-actions {
-  display: flex;
-  gap: 12px;
-  flex-wrap: wrap;
-}
-.home-vendor .hero-pill-ghost {
-  background: transparent;
-  color: #fff;
-  border-color: rgba(255, 255, 255, 0.22);
-}
-.home-vendor .hero-pill-ghost:hover {
-  background: rgba(255, 255, 255, 0.08);
-}
-
 /* ── CTA Final ── */
 .home-final {
   text-align: center;
   border-radius: var(--radius-2xl);
-  background: var(--surface);
+  background: var(--grad-dark);
   border: 1px solid var(--border);
   padding: clamp(3.5rem, 7vw, 5rem) 1.5rem;
   box-shadow: none;
+  position: relative;
+  overflow: hidden;
+}
+/* Leve brilho de acento no canto, coerente com o hero */
+.home-final::after {
+  content: '';
+  position: absolute;
+  top: -160px;
+  right: -140px;
+  width: 420px;
+  height: 420px;
+  border-radius: 50%;
+  background: radial-gradient(circle, var(--accent-soft), transparent 68%);
+  opacity: 0.45;
+  pointer-events: none;
 }
 .home-final-title {
+  position: relative;
+  z-index: 1;
   font-family: var(--font-display);
   font-size: clamp(1.75rem, 3.6vw, 2.5rem);
-  font-weight: 600;
+  font-weight: 800;
   letter-spacing: -0.03em;
   color: var(--text);
   margin: 0 0 14px;
   text-wrap: balance;
 }
 .home-final-text {
+  position: relative;
+  z-index: 1;
   color: var(--text-secondary);
   font-size: 1.0625rem;
   margin: 0 0 32px;
 }
+.home-final .hero-pill { position: relative; z-index: 1; }
 
 /* ═══════════════ RESPONSIVE ═══════════════ */
 @media (max-width: 940px) {
@@ -561,15 +395,12 @@
 
 @media (max-width: 768px) {
   .home-hero { margin-top: calc(-1 * (var(--navbar-h) + 8px)); }
-  .home-features { grid-template-columns: repeat(2, 1fr); }
-  .home-steps { grid-template-columns: 1fr; }
 }
 
 @media (max-width: 640px) {
   .home-hero { padding: calc(var(--navbar-h) + 32px) 1.1rem 0; }
   .hero-pill { width: 100%; }
   .hero-actions { width: 100%; }
-  .hero-textlink { justify-content: center; }
   .home-stats { grid-template-columns: repeat(2, 1fr); gap: 4px 0; }
   .home-stat:nth-child(2) { border-right: none; }
   .home-stat:nth-child(1), .home-stat:nth-child(2) {
@@ -577,7 +408,6 @@
     padding-bottom: 18px;
   }
   .home-stat:nth-child(3), .home-stat:nth-child(4) { padding-top: 18px; }
-  .home-features { grid-template-columns: 1fr; }
 }
 
 @media (max-width: 400px) {

--- a/sunny_sales_web/src/pages/Home.jsx
+++ b/sunny_sales_web/src/pages/Home.jsx
@@ -3,78 +3,15 @@ import { Link } from 'react-router-dom';
 import {
   FiMapPin,
   FiArrowRight,
-  FiClock,
-  FiFilter,
   FiSmartphone,
-  FiNavigation,
-  FiTrendingUp,
-  FiHeart,
   FiZap,
-  FiUsers,
 } from 'react-icons/fi';
 import './Home.css';
 
 // (em português) Página inicial / landing da Sunny Sales.
-// Versão "Premium Minimal": quase monocromática sobre branco, com o
-// amarelo reservado ao CTA principal e a pequenos indicadores e o azul
-// apenas no mapa. O header e o rodapé são geridos em App.jsx.
-
-const STEPS = [
-  {
-    title: 'Abre o mapa',
-    text: 'Sem instalar nada. Abre o mapa e vê quem está a vender perto de ti, agora mesmo.',
-  },
-  {
-    title: 'Filtra o que queres',
-    text: 'Bolas de Berlim, gelados, bebidas… filtra por produto e por distância.',
-  },
-  {
-    title: 'Recebe sem te levantares',
-    text: 'Vês o vendedor a aproximar-se em tempo real. É só acenar quando passar.',
-  },
-];
-
-const FEATURES = [
-  {
-    icon: FiClock,
-    title: 'Tempo real',
-    text: 'Posições atualizadas ao segundo via GPS. O que vês é onde eles estão.',
-  },
-  {
-    icon: FiFilter,
-    title: 'Filtros inteligentes',
-    text: 'Escolhe o produto e a distância máxima. Só te mostramos o que interessa.',
-  },
-  {
-    icon: FiNavigation,
-    title: 'Mapa que roda contigo',
-    text: 'O mapa acompanha a orientação do teu telemóvel para te guiar melhor.',
-  },
-  {
-    icon: FiSmartphone,
-    title: 'Sem instalar app',
-    text: 'Funciona direto no browser. Abre o link e está tudo pronto.',
-  },
-  {
-    icon: FiUsers,
-    title: 'Perfis de vendedor',
-    text: 'Foto, produto e stories de cada vendedor para saberes a quem compras.',
-  },
-  {
-    icon: FiHeart,
-    title: 'Praia sustentável',
-    text: 'Apoiamos o comércio local e praias mais limpas, a cada venda.',
-  },
-];
-
-const CATEGORIES = [
-  { emoji: '🍩', label: 'Bolas de Berlim' },
-  { emoji: '🍦', label: 'Gelados' },
-  { emoji: '🥤', label: 'Bebidas frescas' },
-  { emoji: '🍉', label: 'Fruta' },
-  { emoji: '🏖️', label: 'Acessórios' },
-  { emoji: '🥥', label: 'E muito mais' },
-];
+// Versão "Dark Sport/Premium": fundo azul-petróleo/carvão muito escuro,
+// tipografia bold e acento vermelho-alaranjado nos CTAs e detalhes.
+// O header e o rodapé são geridos em App.jsx.
 
 export default function Home() {
   return (
@@ -104,7 +41,7 @@ export default function Home() {
                 <FiMapPin size={18} />
                 Explorar Mapa
               </Link>
-              <Link to="/como-funciona" className="hero-textlink">
+              <Link to="/como-funciona" className="hero-pill hero-pill-ghost">
                 Como funciona
                 <FiArrowRight size={16} />
               </Link>
@@ -154,100 +91,6 @@ export default function Home() {
           <div className="home-stat">
             <span className="home-stat-num">PT</span>
             <span className="home-stat-label">Praias portuguesas</span>
-          </div>
-        </div>
-      </section>
-
-      {/* ══════════════ COMO FUNCIONA ══════════════ */}
-      <section className="home-section">
-        <header className="home-head reveal">
-          <span className="home-eyebrow">Como funciona</span>
-          <h2 className="home-title">Do teu lugar à areia, em três passos</h2>
-          <p className="home-sub">
-            Simples para os banhistas, poderoso para os vendedores.
-          </p>
-        </header>
-
-        <div className="home-steps">
-          {STEPS.map((step, i) => (
-            <article
-              key={step.title}
-              className={`step-card reveal reveal-d${i + 1}`}
-            >
-              <span className="step-num">{i + 1}</span>
-              <h3 className="step-title">{step.title}</h3>
-              <p className="step-text">{step.text}</p>
-            </article>
-          ))}
-        </div>
-      </section>
-
-      {/* ══════════════ FUNCIONALIDADES ══════════════ */}
-      <section className="home-section">
-        <header className="home-head reveal">
-          <span className="home-eyebrow">Feito para a praia</span>
-          <h2 className="home-title">Tudo o que precisas, num só mapa</h2>
-        </header>
-
-        <div className="home-features">
-          {FEATURES.map((f, i) => {
-            const Icon = f.icon;
-            return (
-              <article
-                key={f.title}
-                className={`feature-card reveal reveal-d${(i % 3) + 1}`}
-              >
-                <span className="feature-icon"><Icon size={20} /></span>
-                <h3 className="feature-title">{f.title}</h3>
-                <p className="feature-text">{f.text}</p>
-              </article>
-            );
-          })}
-        </div>
-      </section>
-
-      {/* ══════════════ CATEGORIAS ══════════════ */}
-      <section className="home-section">
-        <header className="home-head reveal">
-          <span className="home-eyebrow">O que encontras</span>
-          <h2 className="home-title">Fresquinho, a poucos passos</h2>
-        </header>
-
-        <div className="home-cats">
-          {CATEGORIES.map((c, i) => (
-            <div
-              key={c.label}
-              className={`cat-chip reveal reveal-d${(i % 5) + 1}`}
-            >
-              <span className="cat-dot" aria-hidden="true" />
-              <span className="cat-label">{c.label}</span>
-            </div>
-          ))}
-        </div>
-      </section>
-
-      {/* ══════════════ CTA VENDEDORES (escuro) ══════════════ */}
-      <section className="home-section">
-        <div className="home-vendor reveal">
-          <div className="home-vendor-body">
-            <span className="home-eyebrow home-eyebrow--light">Para vendedores</span>
-            <h2 className="home-vendor-title">
-              Coloca o teu negócio <span className="grad-text">no mapa</span>
-            </h2>
-            <p className="home-vendor-text">
-              Mais visibilidade, mais clientes, mais vendas. Ativa a tua
-              localização e fica visível para os banhistas mais próximos.
-            </p>
-            <div className="home-vendor-actions">
-              <Link to="/planos" className="hero-pill hero-pill-primary">
-                <FiTrendingUp size={18} />
-                Ver planos
-              </Link>
-              <Link to="/como-funciona" className="hero-pill hero-pill-ghost">
-                Como funciona
-                <FiArrowRight size={16} />
-              </Link>
-            </div>
           </div>
         </div>
       </section>

--- a/sunny_sales_web/src/pages/InfoPage.css
+++ b/sunny_sales_web/src/pages/InfoPage.css
@@ -42,11 +42,11 @@
    (ver DESIGN_SYSTEM.md · tipografia). */
 .info-hero-title {
   font-size: var(--fs-h1);
-  font-weight: 650;
+  font-weight: 800;
   line-height: 1.08;
   letter-spacing: -0.03em;
   margin: 0 0 18px;
-  color: var(--navy);
+  color: var(--text);
   position: relative;
   z-index: 1;
   text-wrap: balance;
@@ -64,7 +64,7 @@
 }
 
 .info-hero-lead strong {
-  color: var(--navy);
+  color: var(--text);
   font-weight: 700;
 }
 
@@ -89,8 +89,8 @@
 .info-hero-media {
   position: relative;
   min-height: 320px;
-  /* Fundo neutro azul-claro enquanto a fotografia não carrega. */
-  background: #f4f4f5;
+  /* Fundo neutro escuro enquanto a fotografia não carrega. */
+  background: var(--surface-alt);
 }
 
 .info-hero-media img {
@@ -102,12 +102,12 @@
   display: block;
 }
 
-/* Transição suave entre o conteúdo e a fotografia */
+/* Transição suave (diagonal escura) entre o conteúdo e a fotografia */
 .info-hero-media::after {
   content: '';
   position: absolute;
   inset: 0;
-  background: linear-gradient(90deg, rgba(255, 255, 255, 0.35), transparent 30%);
+  background: linear-gradient(97deg, var(--surface) 0%, rgba(26, 33, 43, 0.55) 18%, transparent 45%);
   pointer-events: none;
 }
 
@@ -303,9 +303,9 @@
 
 .info-section-title {
   font-size: var(--fs-h2);
-  font-weight: 600;
+  font-weight: 700;
   letter-spacing: -0.02em;
-  color: var(--navy);
+  color: var(--text);
   margin: 0;
   display: block;
   /* Palavras longas em PT ("Consciencialização") hifenizam em ecrãs
@@ -410,7 +410,7 @@
   font-size: 1rem;
   z-index: 1;
   flex-shrink: 0;
-  border: 2px solid #fff;
+  border: 2px solid var(--bg);
   box-shadow: var(--shadow-xs);
 }
 
@@ -520,11 +520,11 @@
   gap: 8px;
   margin-top: 16px;
   background: var(--secondary);
-  color: var(--ink);
+  color: #fff;
   font-weight: 600;
   font-size: 0.92rem;
   padding: 12px 26px;
-  border-radius: var(--radius-md);
+  border-radius: var(--radius-btn);
   text-decoration: none;
   border: none;
   cursor: pointer;
@@ -579,11 +579,11 @@
   align-items: center;
   gap: 8px;
   background: var(--secondary);
-  color: var(--ink);
+  color: #fff;
   font-weight: 600;
   font-size: 0.95rem;
   padding: 13px 28px;
-  border-radius: var(--radius-md);
+  border-radius: var(--radius-btn);
   text-decoration: none;
   border: none;
   cursor: pointer;
@@ -653,7 +653,7 @@
   }
 
   .info-hero-media::after {
-    background: linear-gradient(180deg, transparent 65%, rgba(255, 255, 255, 0.4));
+    background: linear-gradient(180deg, transparent 65%, rgba(26, 33, 43, 0.6));
   }
 }
 

--- a/sunny_sales_web/src/pages/ModernMapLayout.css
+++ b/sunny_sales_web/src/pages/ModernMapLayout.css
@@ -432,7 +432,7 @@ body {
   display: flex;
   align-items: center;
   gap: 6px;
-  background: rgba(255, 255, 255, 0.92);
+  background: rgba(16, 21, 28, 0.88);
   backdrop-filter: blur(8px);
   -webkit-backdrop-filter: blur(8px);
   border: 1px solid var(--border-strong);
@@ -1040,7 +1040,7 @@ body {
   -webkit-tap-highlight-color: transparent;
   min-height: auto;
   padding: 0;
-  color: var(--ink);
+  color: #fff;
 }
 
 .locate-btn .locate-icon,

--- a/sunny_sales_web/src/pages/NotFound.css
+++ b/sunny_sales_web/src/pages/NotFound.css
@@ -25,7 +25,7 @@
   font-size: clamp(1.4rem, 4vw, 1.9rem);
   font-weight: 700;
   letter-spacing: -0.5px;
-  color: var(--navy);
+  color: var(--text);
   margin: 0 0 10px;
 }
 
@@ -51,7 +51,7 @@
   font-size: 0.9rem;
   font-weight: 500;
   padding: 11px 24px;
-  border-radius: var(--radius-md);
+  border-radius: var(--radius-btn);
   transition: background var(--transition), transform var(--transition),
     box-shadow var(--transition), border-color var(--transition),
     color var(--transition);
@@ -71,7 +71,7 @@
 .notfound-btn-ghost {
   color: var(--text);
   border: 1px solid var(--border-strong);
-  background: var(--surface);
+  background: transparent;
 }
 .notfound-btn-ghost:hover {
   border-color: var(--text-muted);

--- a/sunny_sales_web/src/pages/PlanosVendedores.css
+++ b/sunny_sales_web/src/pages/PlanosVendedores.css
@@ -66,8 +66,8 @@
 .pv-pricing-title {
   display: block;
   font-size: clamp(1.4rem, 3.5vw, 1.9rem);
-  font-weight: 600;
-  color: var(--navy);
+  font-weight: 700;
+  color: var(--text);
   margin: 0 0 12px;
   letter-spacing: -0.025em;
 }
@@ -122,7 +122,7 @@
   border-color: var(--secondary);
   transform: translateY(-8px);
   box-shadow: 0 0 0 4px var(--secondary-light), var(--shadow-lg),
-    0 16px 40px -18px rgba(245, 179, 1, 0.45);
+    0 16px 40px -18px rgba(239, 65, 54, 0.45);
 }
 
 .pv-plan-badge {
@@ -131,7 +131,7 @@
   left: 50%;
   transform: translateX(-50%);
   background: var(--secondary);
-  color: var(--ink);
+  color: #fff;
   font-size: 0.75rem;
   font-weight: 600;
   padding: 6px 16px;
@@ -169,14 +169,14 @@
 .pv-plan-currency {
   font-size: 1.2rem;
   font-weight: 700;
-  color: var(--navy);
+  color: var(--text);
   align-self: flex-start;
   margin-top: 8px;
 }
 .pv-plan-amount {
   font-size: 3.2rem;
-  font-weight: 600;
-  color: var(--navy);
+  font-weight: 700;
+  color: var(--text);
   letter-spacing: -0.04em;
 }
 .pv-plan-period {
@@ -247,15 +247,15 @@
   width: 100%;
   text-align: center;
   padding: 13px 20px;
-  border-radius: var(--radius-md);
+  border-radius: var(--radius-btn);
   font-size: 0.92rem;
   font-weight: 600;
   font-family: inherit;
   text-decoration: none;
   cursor: pointer;
   border: 1px solid var(--border-strong);
-  color: var(--navy);
-  background: var(--surface);
+  color: var(--text);
+  background: transparent;
   transition: background var(--transition), color var(--transition),
     border-color var(--transition), transform var(--transition),
     box-shadow var(--transition);
@@ -268,17 +268,17 @@
   box-shadow: none;
   filter: none;
 }
-/* Ação primária da página = amarelo (ver DESIGN_SYSTEM.md · paleta) */
+/* Ação primária da página = acento vermelho-alaranjado */
 .pv-plan-cta--highlight {
   background: var(--secondary);
   border-color: var(--secondary);
-  color: var(--ink);
-  box-shadow: var(--shadow-sm);
+  color: #fff;
+  box-shadow: var(--shadow-accent);
 }
 .pv-plan-cta--highlight:hover {
   background: var(--secondary-hover);
   border-color: var(--secondary-hover);
-  color: var(--ink);
+  color: #fff;
 }
 
 /* ── Compare note ──────────────────────────────────────── */
@@ -351,18 +351,18 @@
   align-items: center;
   gap: 8px;
   padding: 13px 28px;
-  border-radius: var(--radius-md);
+  border-radius: var(--radius-btn);
   font-size: 0.95rem;
-  font-weight: 500;
+  font-weight: 600;
   text-decoration: none;
   transition: background var(--transition);
 }
 .pv-cta-btn--primary {
-  background: #fff;
-  color: var(--navy);
+  background: var(--accent);
+  color: #fff;
 }
 .pv-cta-btn--primary:hover {
-  background: #f4f4f4;
+  background: var(--accent-hover);
   transform: none;
   box-shadow: none;
 }

--- a/sunny_sales_web/src/pages/VendorDashboard.css
+++ b/sunny_sales_web/src/pages/VendorDashboard.css
@@ -633,10 +633,10 @@
   color: var(--text-secondary);
 }
 
-/* Ação primária do painel = amarelo (ver DESIGN_SYSTEM.md · paleta) */
+/* Ação primária do painel = acento vermelho-alaranjado */
 .vd-cta-btn {
   background: var(--secondary);
-  color: var(--ink);
+  color: #fff;
   border: none;
   border-radius: var(--radius-md);
   padding: 8px 20px;
@@ -852,7 +852,7 @@
   background: linear-gradient(
     90deg,
     var(--surface-alt) 25%,
-    #efefef 37%,
+    rgba(255, 255, 255, 0.08) 37%,
     var(--surface-alt) 63%
   );
   background-size: 400% 100%;
@@ -1183,16 +1183,16 @@
   margin-top: 4px;
 }
 
-/* Guardar = ação primária → amarelo com texto ink (10.3:1) */
+/* Guardar = ação primária → acento com texto branco */
 .vd-form-save {
   flex: 1;
   background: var(--secondary);
   border: none;
-  border-radius: var(--radius-md);
+  border-radius: var(--radius-btn);
   padding: 11px 24px;
   font-size: 0.875rem;
   font-weight: 600;
-  color: var(--ink);
+  color: #fff;
   cursor: pointer;
   min-height: auto;
   box-shadow: none;

--- a/sunny_sales_web/src/pages/VendorLogin.css
+++ b/sunny_sales_web/src/pages/VendorLogin.css
@@ -67,10 +67,10 @@
 .auth-secondary-btn {
   width: 100%;
   padding: 12px 22px;
-  background: var(--surface);
-  color: var(--navy);
+  background: transparent;
+  color: var(--text);
   border: 1px solid var(--border-strong);
-  border-radius: var(--radius-md);
+  border-radius: var(--radius-btn);
   font-size: 0.95rem;
   font-weight: 600;
   min-height: 48px;
@@ -82,7 +82,7 @@
 .auth-secondary-btn:hover:not(:disabled) {
   border-color: var(--primary);
   color: var(--primary-dark);
-  background: var(--surface);
+  background: rgba(255, 255, 255, 0.04);
   box-shadow: var(--shadow-sm);
   filter: none;
 }

--- a/sunny_sales_web/src/pages/VendorPage.css
+++ b/sunny_sales_web/src/pages/VendorPage.css
@@ -130,12 +130,12 @@
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  background: var(--ink);
+  background: var(--accent);
   color: white;
   font-weight: 500;
   font-size: 0.95rem;
   padding: 12px 24px;
-  border-radius: var(--radius-md);
+  border-radius: var(--radius-btn);
   border: none;
   cursor: pointer;
   transition: background var(--transition);


### PR DESCRIPTION
## Summary
Complete visual rebrand of Sunny Sales from a minimal light theme ("Premium Minimal") to a dark sport/premium aesthetic. The design system shifts from a light background with teal and yellow accents to a dark blue-petrol/charcoal foundation with red-orange (#ef4136) as the primary action color.

## Key Changes

### Design System & Color Palette
- **Background**: Changed from light (`#fcfcfc`) to dark blue-petrol/charcoal (`#10151c` as `--bg`, with `--bg-deep` and `--bg-raised` variants)
- **Primary Action Color**: Replaced yellow (`#f5b301`) with red-orange (`#ef4136`) for all CTAs, badges, and accent details
- **Text Colors**: Inverted from dark-on-light to light-on-dark (`--text: #f5f5f5`, `--text-secondary: #c9ced6`)
- **Accent Details**: Red-orange now used for active menu underlines, button highlights, and micro-indicators (previously yellow)
- **Semantic Colors**: Updated success/warning/error to light variants suitable for dark backgrounds

### Home Page Hero Section
- Added dark gradient background with subtle diagonal separator between text and visual areas
- Implemented radial accent glow effect in top-right corner (`--accent-soft`)
- Increased title font-weight from 650 to 800 and adjusted line-height for bolder appearance
- Changed accent underline from yellow to red-orange with adjusted thickness
- Converted button styles to pill format (`--radius-full`) with updated hover states
- Updated map card background from light neutral to dark (`--bg-raised`) with inverted grid pattern
- Changed pin colors to red-orange with updated shadows for dark theme

### Navigation & Header
- Header background now transparent on home page, fading to dark on scroll
- Menu items converted to uppercase with letter-spacing (0.08em) for sport/premium feel
- Active menu indicator changed from hidden to visible red-orange underline
- CTA button in header now uses red-orange pill format instead of black

### Removed Sections
- Removed "How it Works" (steps), "Features", "Categories", and "For Vendors" sections from home page
- Simplified home page to focus on hero, stats, and final CTA

### Button & Form Styling
- All primary buttons now use red-orange background with white text
- Secondary buttons use transparent background with white outline
- Form inputs updated with dark-appropriate focus states
- Button border-radius standardized to `--radius-btn` (pill format)

### Supporting Pages
- Updated PlanosVendedores, InfoPage, Contacto, VendorDashboard, VendorLogin, FAQ, NotFound, and other pages to use dark theme
- Adjusted text colors, backgrounds, and borders throughout for dark mode compatibility
- Updated shadows to be more pronounced for dark backgrounds

### Typography & Spacing
- Display font-size increased from `clamp(2.5rem, 4.4vw, 3.625rem)` to `clamp(3rem, 5.2vw, 4rem)`
- Font weights increased across headings (600→700-800) for bolder appearance
- Menu items now use 600 weight with uppercase transformation

## Implementation Details
- All color tokens centralized in `:root` CSS variables for consistency
- Dark theme applied via `color-scheme: dark` on html element for native control styling
- Gradient backgrounds use subtle variations of dark tones rather than stark contrasts
- Accent glow effects use `radial-gradient` with `--accent-soft` for cohesive visual language
- Shadow system updated with higher opacity values suitable for dark backgrounds
- Focus ring color changed to light accent (`#ff8d84`) for visibility on dark backgrounds

https://claude.ai/code/session_01QDpyTabvEnRt3s7SW1v3ZT