### PR TITLE
Style adjustments: brand color update, yellow weather card, justified text, and hero background

### DIFF
--- a/sunny_sales_web/src/components/WeatherCard.css
+++ b/sunny_sales_web/src/components/WeatherCard.css
@@ -2,7 +2,7 @@
   width: 100%;
   border-radius: var(--radius-lg, 16px);
   overflow: hidden;
-  background: var(--surface, #ffffff);
+  background: #ffd700;
   color: var(--text, #0f0f0f);
   border: 1px solid var(--border, #ececec);
   box-shadow: var(--shadow-md, 0 8px 30px rgba(0, 0, 0, 0.04));

--- a/sunny_sales_web/src/components/WelcomeCard.css
+++ b/sunny_sales_web/src/components/WelcomeCard.css
@@ -60,6 +60,7 @@
   margin: 0;
   font-size: 0.9rem;
   color: var(--text-secondary);
+  text-align: justify;
 }
 
 .welcome-steps {

--- a/sunny_sales_web/src/index.css
+++ b/sunny_sales_web/src/index.css
@@ -65,51 +65,51 @@
 
 :root {
   /* ── Acento = teal (verde-água da marca) ── */
-  --accent: #2b7c6d;
-  --accent-hover: #236457;
-  --accent-soft: rgba(43, 124, 109, 0.12);
+  --accent: #199fb1;
+  --accent-hover: #1485a0;
+  --accent-soft: rgba(25, 159, 177, 0.12);
   /* Ícones/realces "de acento" sobre fundo claro */
-  --accent-text: #2b7c6d;
+  --accent-text: #199fb1;
   /* Texto sobre superfícies teal (botões, badges, blocos) */
   --on-accent: #ffffff;
 
   /* ── Cor primária (alias do acento, compatibilidade) ── */
-  --primary: #2b7c6d;
-  --primary-hover: #236457;
-  --primary-dark: #1e5a4f;
-  --primary-bright: #3aa08d;
-  --primary-light: rgba(43, 124, 109, 0.1);
-  --primary-light-solid: #e6f1ee;
+  --primary: #199fb1;
+  --primary-hover: #1485a0;
+  --primary-dark: #10708f;
+  --primary-bright: #22b3c9;
+  --primary-light: rgba(25, 159, 177, 0.1);
+  --primary-light-solid: #e0f4f7;
 
   /* ── Ação primária (CTAs sólidos) ── */
-  --secondary: #2b7c6d;
-  --secondary-hover: #236457;
-  --secondary-light: rgba(43, 124, 109, 0.12);
+  --secondary: #199fb1;
+  --secondary-hover: #1485a0;
+  --secondary-light: rgba(25, 159, 177, 0.12);
 
   /* Tons legados de amarelo — remapeados para teal */
-  --gold: #2b7c6d;
-  --gold-strong: #1e5a4f;
-  --amber: #2b7c6d;
-  --amber-strong: #1e5a4f;
-  --coral: #2b7c6d;
+  --gold: #199fb1;
+  --gold-strong: #10708f;
+  --amber: #199fb1;
+  --amber-strong: #10708f;
+  --coral: #199fb1;
 
   /* ── Aliases de azul/teal (links funcionais, mapa) ── */
-  --blue: #1d6a5c;
-  --blue-hover: #14574b;
-  --teal: #1d6a5c;
-  --teal-strong: #14574b;
-  --teal-light: rgba(43, 124, 109, 0.12);
-  --sky: #1d6a5c;
+  --blue: #1078a0;
+  --blue-hover: #0d5d8a;
+  --teal: #1078a0;
+  --teal-strong: #0d5d8a;
+  --teal-light: rgba(25, 159, 177, 0.12);
+  --sky: #1078a0;
 
   /* ── "Ink" (botões sólidos de navegação → teal) ── */
-  --ink: #2b7c6d;
-  --ink-hover: #236457;
+  --ink: #199fb1;
+  --ink-hover: #1485a0;
   /* Texto escuro para fundos claros */
   --ink-on-light: #1b2c33;
   /* ── Painéis institucionais (agora teal escuro) ── */
-  --navy: #1e5a4f;
-  --navy-light: #236457;
-  --navy-border: rgba(30, 90, 79, 0.2);
+  --navy: #10708f;
+  --navy-light: #1485a0;
+  --navy-border: rgba(25, 159, 177, 0.2);
 
   /* ── Superfícies: fundo branco e cartões claros ── */
   --bg-deep: #f1f5f4;
@@ -141,12 +141,12 @@
   --danger: #b91c1c;
 
   /* ── Gradientes legados — achatados para teal ── */
-  --grad-sun: linear-gradient(135deg, #2b7c6d, #2b7c6d);
-  --grad-gold: linear-gradient(135deg, #2b7c6d, #2b7c6d);
-  --grad-sea: linear-gradient(135deg, #2b7c6d, #1e5a4f);
-  --grad-dusk: linear-gradient(135deg, #2b7c6d, #2b7c6d);
+  --grad-sun: linear-gradient(135deg, #199fb1, #199fb1);
+  --grad-gold: linear-gradient(135deg, #199fb1, #199fb1);
+  --grad-sea: linear-gradient(135deg, #199fb1, #10708f);
+  --grad-dusk: linear-gradient(135deg, #199fb1, #199fb1);
   /* Blocos de destaque: gradiente teal (texto branco por cima) */
-  --grad-dark: linear-gradient(155deg, #2b7c6d 0%, #1e5a4f 100%);
+  --grad-dark: linear-gradient(155deg, #199fb1 0%, #10708f 100%);
 
   /* ── Sombras (suaves, tema claro) ── */
   --shadow-xs: 0 1px 2px rgba(20, 45, 52, 0.06);
@@ -155,10 +155,10 @@
   --shadow-lg: 0 2px 8px rgba(20, 45, 52, 0.06), 0 18px 44px rgba(20, 45, 52, 0.14);
   --shadow-warm: var(--shadow-sm);
   --shadow-warm-lg: var(--shadow-md);
-  --shadow-primary: 0 10px 24px -12px rgba(43, 124, 109, 0.45);
-  --shadow-ink: 0 10px 24px -12px rgba(43, 124, 109, 0.45);
-  --shadow-gold: 0 10px 24px -12px rgba(43, 124, 109, 0.45);
-  --shadow-accent: 0 12px 28px -12px rgba(43, 124, 109, 0.5);
+  --shadow-primary: 0 10px 24px -12px rgba(25, 159, 177, 0.45);
+  --shadow-ink: 0 10px 24px -12px rgba(25, 159, 177, 0.45);
+  --shadow-gold: 0 10px 24px -12px rgba(25, 159, 177, 0.45);
+  --shadow-accent: 0 12px 28px -12px rgba(25, 159, 177, 0.5);
 
   /* ── Raios (contidos; botões em pílula) ── */
   --radius-xs: 8px;
@@ -191,7 +191,7 @@
   --section-pad: clamp(4rem, 8vw, 7rem);
 
   /* ── Foco visível (teclado): teal escuro, ≥3:1 sobre branco ── */
-  --focus-ring: #1d6a5c;
+  --focus-ring: #1078a0;
 
   /* ── Movimento (200ms, ease-out, nada mais) ── */
   --transition: 0.2s cubic-bezier(0, 0, 0.2, 1);
@@ -970,9 +970,9 @@ h2 {
   to { background-position: 200% center; }
 }
 @keyframes pinPulse {
-  0% { box-shadow: 0 0 0 0 rgba(43, 124, 109, 0.4); }
-  70% { box-shadow: 0 0 0 14px rgba(43, 124, 109, 0); }
-  100% { box-shadow: 0 0 0 0 rgba(43, 124, 109, 0); }
+  0% { box-shadow: 0 0 0 0 rgba(25, 159, 177, 0.4); }
+  70% { box-shadow: 0 0 0 14px rgba(25, 159, 177, 0); }
+  100% { box-shadow: 0 0 0 0 rgba(25, 159, 177, 0); }
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -1274,6 +1274,7 @@ h2 {
 .page-list-item-desc {
   font-size: 0.8125rem;
   color: var(--text-secondary);
+  text-align: justify;
 }
 
 .page-list-item-badge {
@@ -1402,6 +1403,7 @@ h2 {
 .route-info-value {
   color: var(--text);
   font-weight: 500;
+  text-align: justify;
 }
 
 @media (max-width: 480px) {

--- a/sunny_sales_web/src/pages/Home.css
+++ b/sunny_sales_web/src/pages/Home.css
@@ -40,6 +40,10 @@
   flex-direction: column;
   align-items: center;
   text-align: center;
+  background: linear-gradient(135deg, rgba(0, 0, 0, 0.7), rgba(0, 0, 0, 0.65));
+  padding: 40px 30px;
+  border-radius: 12px;
+  color: #ffffff;
 }
 
 /* Eyebrow: linha pequena teal com tracking largo por cima do título */
@@ -49,7 +53,7 @@
   letter-spacing: 0.34em;
   text-indent: 0.34em; /* compensa o tracking para centrar oticamente */
   text-transform: uppercase;
-  color: var(--primary);
+  color: #ffffff;
   margin-bottom: clamp(14px, 2.5vw, 26px);
   animation: heroRise 0.7s var(--ease-out) both;
 }
@@ -63,7 +67,7 @@
   line-height: 0.98;
   letter-spacing: 0.01em;
   text-transform: uppercase;
-  color: var(--text);
+  color: #ffffff;
   white-space: nowrap;
   animation: heroRise 0.7s 0.08s var(--ease-out) both;
 }
@@ -74,8 +78,9 @@
   font-size: var(--fs-lead);
   line-height: 1.6;
   font-weight: 400;
-  color: var(--text-secondary);
+  color: rgba(255, 255, 255, 0.9);
   text-wrap: pretty;
+  text-align: justify;
   animation: heroRise 0.7s 0.16s var(--ease-out) both;
 }
 
@@ -195,7 +200,7 @@
   background: var(--surface);
   border: 1px solid var(--border);
   color: var(--text);
-  text-align: center;
+  text-align: justify;
   border-radius: var(--radius-lg);
   padding: 28px 20px;
   box-shadow: var(--shadow-sm);


### PR DESCRIPTION
- Replace green (#2b7c6d) with #199fb1 throughout design system
- Add yellow background (#ffd700) to weather card
- Apply text-align: justify to card text elements
- Style hero section with dark background overlay and white text
- Update all gradient colors and shadows for new color scheme

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FAUFrE1B6JPMmWxnn53VAZ