### PR TITLE
Implement fullscreen map preview on homepage

### DIFF
--- a/sunny_sales_web/src/components/HomeMapPreview.css
+++ b/sunny_sales_web/src/components/HomeMapPreview.css
@@ -1,0 +1,155 @@
+.home-map-preview {
+  position: relative;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.home-map-container {
+  position: relative;
+  width: 100%;
+  height: clamp(300px, 50vh, 500px);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  cursor: pointer;
+  box-shadow: var(--shadow-md);
+  background: var(--surface);
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.home-map-container:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-lg);
+}
+
+.home-map {
+  width: 100%;
+  height: 100%;
+  z-index: 1;
+}
+
+.home-map-loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  background: var(--surface-alt);
+}
+
+.loading-spinner {
+  width: 40px;
+  height: 40px;
+  border: 3px solid var(--border);
+  border-top-color: var(--accent);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+.home-map-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(135deg, rgba(0, 0, 0, 0.3), transparent);
+  z-index: 2;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
+.home-map-container:hover .home-map-overlay {
+  opacity: 1;
+}
+
+.home-map-cta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: var(--accent);
+  color: var(--on-accent);
+  padding: 12px 20px;
+  border-radius: var(--radius-full);
+  font-weight: 600;
+  font-size: 0.9375rem;
+  box-shadow: var(--shadow-md);
+  animation: bounceIn 0.4s ease-out;
+}
+
+@keyframes bounceIn {
+  0% {
+    opacity: 0;
+    transform: scale(0.8);
+  }
+  100% {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+.home-map-section {
+  text-align: center;
+  padding: 1.5rem 1rem;
+}
+
+.home-map-text {
+  margin: 0;
+}
+
+.home-map-subtitle {
+  font-size: clamp(0.875rem, 2vw, 1.0625rem);
+  font-weight: 500;
+  color: var(--text-secondary);
+  margin: 0;
+  letter-spacing: 0.05em;
+}
+
+.vendor-marker-icon {
+  filter: drop-shadow(0 2px 4px rgba(0, 0, 0, 0.2));
+}
+
+.vendor-pin-marker {
+  width: 100%;
+  height: 100%;
+  background: var(--pin-color, #00A98F);
+  border: 2px solid white;
+  border-radius: 50%;
+  box-shadow: 0 0 0 3px rgba(0, 169, 143, 0.1);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+@media (max-width: 768px) {
+  .home-map-container {
+    height: clamp(250px, 45vh, 400px);
+  }
+
+  .home-map-cta {
+    font-size: 0.875rem;
+    padding: 10px 16px;
+  }
+}
+
+@media (max-width: 480px) {
+  .home-map-container {
+    height: clamp(200px, 40vh, 300px);
+    border-radius: var(--radius-md);
+  }
+
+  .home-map-section {
+    padding: 1rem 0.5rem;
+  }
+
+  .home-map-subtitle {
+    font-size: 0.8125rem;
+  }
+}

--- a/sunny_sales_web/src/components/HomeMapPreview.jsx
+++ b/sunny_sales_web/src/components/HomeMapPreview.jsx
@@ -1,0 +1,134 @@
+import React, { useState, useEffect } from 'react';
+import { MapContainer, TileLayer, Marker, useMap } from 'react-leaflet';
+import L from 'leaflet';
+import 'leaflet/dist/leaflet.css';
+import axios from 'axios';
+import { BASE_URL } from '../config';
+import { useNavigate } from 'react-router-dom';
+import { FiArrowUpRight } from 'react-icons/fi';
+import './HomeMapPreview.css';
+
+function escapeHtml(str) {
+  return String(str ?? '').replace(/[&<>"']/g, (c) => ({
+    '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;',
+  }[c]));
+}
+
+function getVendorPinHtml(color) {
+  const safeColor = escapeHtml(color);
+  return `<div class="vendor-pin-marker" style="--pin-color: ${safeColor};"></div>`;
+}
+
+function MapContent({ vendors, onMapClick }) {
+  const map = useMap();
+
+  useEffect(() => {
+    if (vendors.length > 0) {
+      const group = new L.FeatureGroup(
+        vendors.map(v => {
+          const icon = L.divIcon({
+            html: getVendorPinHtml(v.brand_color || '#00A98F'),
+            className: 'vendor-marker-icon',
+            iconSize: [28, 28],
+            iconAnchor: [14, 14],
+          });
+          return L.marker([v.current_lat, v.current_lng], { icon });
+        })
+      );
+      if (group.getLayers().length > 0) {
+        map.fitBounds(group.getBounds(), { padding: [40, 40], maxZoom: 15 });
+      }
+    }
+  }, [vendors, map]);
+
+  return (
+    <>
+      <TileLayer
+        url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+        attribution='&copy; OpenStreetMap contributors'
+      />
+      {vendors.map(v => {
+        const icon = L.divIcon({
+          html: getVendorPinHtml(v.brand_color || '#00A98F'),
+          className: 'vendor-marker-icon',
+          iconSize: [28, 28],
+          iconAnchor: [14, 14],
+        });
+        return (
+          <Marker
+            key={v.id}
+            position={[v.current_lat, v.current_lng]}
+            icon={icon}
+          />
+        );
+      })}
+    </>
+  );
+}
+
+export default function HomeMapPreview() {
+  const [vendors, setVendors] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    axios
+      .get(`${BASE_URL}/vendors`)
+      .then(res => {
+        const filtered = res.data.filter(v => v.current_lat && v.current_lng);
+        setVendors(filtered);
+      })
+      .catch(() => {
+        setVendors([]);
+      })
+      .finally(() => setLoading(false));
+  }, []);
+
+  const defaultCenter = [40.2, -8.4];
+  const defaultZoom = 7;
+
+  const handleMapClick = () => {
+    navigate('/map');
+  };
+
+  return (
+    <div className="home-map-preview">
+      <div className="home-map-container" onClick={handleMapClick}>
+        {loading ? (
+          <div className="home-map-loading">
+            <div className="loading-spinner"></div>
+          </div>
+        ) : (
+          <>
+            <MapContainer
+              center={defaultCenter}
+              zoom={defaultZoom}
+              className="home-map"
+              zoomControl={false}
+              scrollWheelZoom={false}
+              doubleClickZoom={false}
+              dragging={false}
+              touchZoom={false}
+              keyboard={false}
+            >
+              <MapContent vendors={vendors} onMapClick={handleMapClick} />
+            </MapContainer>
+            <div className="home-map-overlay">
+              <div className="home-map-cta">
+                <span>Explorar Mapa Completo</span>
+                <FiArrowUpRight size={18} />
+              </div>
+            </div>
+          </>
+        )}
+      </div>
+      <div className="home-map-section">
+        <div className="home-map-text">
+          <p className="home-map-subtitle">
+            Tempo real • Sem instalar • Banhistas grátis
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/sunny_sales_web/src/pages/Home.css
+++ b/sunny_sales_web/src/pages/Home.css
@@ -30,68 +30,14 @@
   justify-content: center;
 }
 
-.home-hero-inner {
-  position: relative;
-  z-index: 1;
+.home-hero-map {
+  background: linear-gradient(135deg, rgba(0, 0, 0, 0.02), rgba(0, 0, 0, 0.04));
+}
+
+.home-hero-map > * {
   width: 100%;
   max-width: 1120px;
   margin: 0 auto;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  text-align: center;
-  background: linear-gradient(135deg, rgba(0, 0, 0, 0.7), rgba(0, 0, 0, 0.65));
-  padding: 40px 30px;
-  border-radius: 12px;
-  color: #ffffff;
-}
-
-/* Eyebrow: linha pequena teal com tracking largo por cima do título */
-.home-hero-eyebrow {
-  font-size: clamp(0.8125rem, 1.4vw, 1rem);
-  font-weight: 600;
-  letter-spacing: 0.34em;
-  text-indent: 0.34em; /* compensa o tracking para centrar oticamente */
-  text-transform: uppercase;
-  color: #ffffff;
-  margin-bottom: clamp(14px, 2.5vw, 26px);
-  animation: heroRise 0.7s var(--ease-out) both;
-}
-
-/* Título gigante em caixa alta, petróleo escuro sobre branco */
-.home-hero-title {
-  margin: 0;
-  font-family: var(--font-display);
-  font-size: clamp(3.1rem, 11vw, 9.5rem);
-  font-weight: 800;
-  line-height: 0.98;
-  letter-spacing: 0.01em;
-  text-transform: uppercase;
-  color: #ffffff;
-  white-space: nowrap;
-  animation: heroRise 0.7s 0.08s var(--ease-out) both;
-}
-
-.home-hero-lead {
-  max-width: 560px;
-  margin: clamp(18px, 3vw, 30px) 0 0;
-  font-size: var(--fs-lead);
-  line-height: 1.6;
-  font-weight: 400;
-  color: rgba(255, 255, 255, 0.9);
-  text-wrap: pretty;
-  text-align: justify;
-  animation: heroRise 0.7s 0.16s var(--ease-out) both;
-}
-
-.hero-actions {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  flex-wrap: wrap;
-  gap: 14px;
-  margin-top: clamp(26px, 4vw, 40px);
-  animation: heroRise 0.7s 0.24s var(--ease-out) both;
 }
 
 /* ── Botões (formato pílula) ── */
@@ -147,35 +93,10 @@
   padding: 0 34px;
 }
 
-/* Indicador de scroll discreto no fundo do hero */
-.home-hero-scroll {
-  position: absolute;
-  bottom: calc(var(--footer-h) + 18px);
-  left: 50%;
-  color: var(--text-muted);
-  line-height: 0;
-  animation: scrollNudge 2.2s ease-in-out infinite;
-}
-
-@keyframes heroRise {
-  from { opacity: 0; transform: translateY(18px); }
-  to   { opacity: 1; transform: translateY(0); }
-}
-
-@keyframes scrollNudge {
-  0%, 100% { transform: translate(-50%, 0); opacity: 0.85; }
-  50%      { transform: translate(-50%, 7px); opacity: 0.5; }
-}
-
 @media (prefers-reduced-motion: reduce) {
-  .home-hero-eyebrow,
-  .home-hero-title,
-  .home-hero-lead,
-  .hero-actions,
-  .home-hero-scroll {
-    animation: none;
+  * {
+    animation: none !important;
   }
-  .home-hero-scroll { transform: translateX(-50%); }
 }
 
 /* ═══════════════ SECÇÕES ═══════════════ */
@@ -266,30 +187,29 @@
 }
 
 @media (max-width: 768px) {
-  .home-hero { margin-top: calc(-1 * (var(--navbar-h) + 8px)); }
+  .home-hero {
+    margin-top: calc(-1 * (var(--navbar-h) + 8px));
+    padding-left: 1rem;
+    padding-right: 1rem;
+  }
 }
 
 @media (max-width: 640px) {
-  .home-hero { padding-left: 1.1rem; padding-right: 1.1rem; }
-  .hero-actions { width: 100%; flex-direction: column; }
-  .hero-pill { width: 100%; }
-
-  .home-hero-eyebrow {
-    letter-spacing: 0.22em;
-    text-indent: 0.22em;
-  }
-
-  /* Em ecrãs estreitos o título quebra em duas linhas grandes
-     ("SUNNY / SALES") em vez de encolher numa linha só */
-  .home-hero-title {
-    white-space: normal;
-    text-wrap: balance;
-    font-size: clamp(3.2rem, 15.5vw, 4.6rem);
-    line-height: 0.96;
+  .home-hero {
+    padding-left: 1.1rem;
+    padding-right: 1.1rem;
+    min-height: auto;
+    padding-top: calc(var(--navbar-h) + 20px);
+    padding-bottom: 40px;
   }
 }
 
 @media (max-width: 480px) {
   .home-stats { grid-template-columns: 1fr; gap: 12px; }
   .home-stat { padding: 22px 18px; }
+
+  .home-hero {
+    padding-left: 0.75rem;
+    padding-right: 0.75rem;
+  }
 }

--- a/sunny_sales_web/src/pages/Home.jsx
+++ b/sunny_sales_web/src/pages/Home.jsx
@@ -3,8 +3,8 @@ import { Link } from 'react-router-dom';
 import {
   FiMapPin,
   FiArrowRight,
-  FiChevronDown,
 } from 'react-icons/fi';
+import HomeMapPreview from '../components/HomeMapPreview';
 import './Home.css';
 
 // (em português) Página inicial / landing da Sunny Sales.
@@ -16,38 +16,9 @@ import './Home.css';
 export default function Home() {
   return (
     <div className="home">
-      {/* ══════════════ HERO ══════════════ */}
-      <section className="home-hero">
-        <div className="home-hero-inner">
-          <span className="home-hero-eyebrow">
-            Vendedores de praia em tempo real
-          </span>
-
-          <h1 className="home-hero-title">
-            Sunny Sales
-          </h1>
-
-          <p className="home-hero-lead">
-            Gelados, bebidas e bolas de Berlim a poucos passos da tua
-            toalha — descobre quem está a vender na tua praia, sem
-            instalar nada.
-          </p>
-
-          <div className="hero-actions">
-            <Link to="/map" className="hero-pill hero-pill-primary">
-              <FiMapPin size={18} />
-              Explorar Mapa
-            </Link>
-            <Link to="/como-funciona" className="hero-pill hero-pill-ghost">
-              Como funciona
-              <FiArrowRight size={16} />
-            </Link>
-          </div>
-        </div>
-
-        <div className="home-hero-scroll" aria-hidden="true">
-          <FiChevronDown size={22} />
-        </div>
+      {/* ══════════════ HERO COM MAPA ══════════════ */}
+      <section className="home-hero home-hero-map">
+        <HomeMapPreview />
       </section>
 
       {/* ══════════════ STATS — caixas brancas ══════════════ */}


### PR DESCRIPTION
Replace hero text section with interactive map preview that expands to fullscreen. The homepage now displays a miniature map with vendor locations that opens the complete map interface when clicked. Includes smooth animations, responsive design, and loading states.

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Acs3xgpnWeS7T3vscS8xzR