### PR TITLE
Tornar mapa da página inicial consistente com a página do mapa

### DIFF
--- a/sunny_sales_web/src/components/HomeMapPreview.jsx
+++ b/sunny_sales_web/src/components/HomeMapPreview.jsx
@@ -27,10 +27,10 @@ function MapContent({ vendors, onMapClick }) {
       const group = new L.FeatureGroup(
         vendors.map(v => {
           const icon = L.divIcon({
-            html: getVendorPinHtml(v.brand_color || '#00A98F'),
+            html: getVendorPinHtml(v.pin_color || '#7B61FF'),
             className: 'vendor-marker-icon',
-            iconSize: [28, 28],
-            iconAnchor: [14, 14],
+            iconSize: [30, 37],
+            iconAnchor: [15, 36],
           });
           return L.marker([v.current_lat, v.current_lng], { icon });
         })
@@ -44,15 +44,17 @@ function MapContent({ vendors, onMapClick }) {
   return (
     <>
       <TileLayer
-        url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
-        attribution='&copy; OpenStreetMap contributors'
+        url="https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png"
+        attribution="&copy; <a href='https://openstreetmap.org'>OpenStreetMap</a> contributors &copy; <a href='https://carto.com/attributions'>CARTO</a>"
+        subdomains="abcd"
+        maxZoom={19}
       />
       {vendors.map(v => {
         const icon = L.divIcon({
-          html: getVendorPinHtml(v.brand_color || '#00A98F'),
+          html: getVendorPinHtml(v.pin_color || '#7B61FF'),
           className: 'vendor-marker-icon',
-          iconSize: [28, 28],
-          iconAnchor: [14, 14],
+          iconSize: [30, 37],
+          iconAnchor: [15, 36],
         });
         return (
           <Marker


### PR DESCRIPTION
- Usar o mesmo tile layer CartoDB (light_all) em vez de OpenStreetMap
- Usar pin_color com default #7B61FF em vez de brand_color com #00A98F
- Ajustar tamanho dos pins para [30, 37] e anchor para [15, 36] para corresponder ao ModernMapLayout

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KJHQcXkb9TF3cz1ubVvrQf