### PR TITLE
Implementar cores dos trajetos no mapa de detalhe de rota

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1241,6 +1241,7 @@ def list_routes(
                 "end_time": r.end_time.isoformat() if r.end_time else None,
                 "distance_m": r.distance_m,
                 "points": json.loads(r.points or "[]"),
+                "pin_color": r.vendor.pin_color,
             }
         )
     return result

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -104,6 +104,7 @@ class RouteOut(BaseModel):
     end_time: Optional[str]
     distance_m: float
     points: list[RoutePoint]
+    pin_color: Optional[str] = None
 
     # Configuração para permitir criação a partir de objetos ORM
     model_config = ConfigDict(from_attributes=True)

--- a/sunny_sales_web/src/pages/RouteDetail.jsx
+++ b/sunny_sales_web/src/pages/RouteDetail.jsx
@@ -49,7 +49,7 @@ export default function RouteDetail() {
               subdomains="abcd"
               maxZoom={19}
             />
-            <Polyline positions={polyline} color="var(--blue)" weight={4} />
+            <Polyline positions={polyline} color={route.pin_color || "var(--blue)"} weight={4} />
           </MapContainer>
         </div>
 


### PR DESCRIPTION
- Adicionar campo `pin_color` ao schema RouteOut
- Incluir cor do vendedor na resposta da API de trajetos
- Usar cor personalizada do vendedor ao renderizar polyline no mapa
- Fallback para azul se cor não estiver disponível

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UfBvor3svHG5fB12QugkaG