### PR TITLE
Adicionar componente visual de mapa da praia com elementos coloridos

### DIFF
--- a/sunny_sales_web/src/App.jsx
+++ b/sunny_sales_web/src/App.jsx
@@ -48,6 +48,7 @@ const PrivacyPolicy = lazy(() => import('./pages/PrivacyPolicy'));
 const TermsAndConditions = lazy(() => import('./pages/TermsAndConditions'));
 const LegalNotice = lazy(() => import('./pages/LegalNotice'));
 const CookiesPolicy = lazy(() => import('./pages/CookiesPolicy'));
+const BeachVisualization = lazy(() => import('./pages/BeachVisualization'));
 const NotFound = lazy(() => import('./pages/NotFound'));
 
 // Rotas sem botão de voltar global: página inicial (tem UI própria),
@@ -270,6 +271,7 @@ function AppLayout() {
           <Route path="/about" element={<About />} />
           <Route path="/sobre-projeto" element={<SobreProjeto />} />
           <Route path="/sustentabilidade" element={<Sustentabilidade />} />
+          <Route path="/beach-visuals" element={<BeachVisualization />} />
           <Route path="/settings" element={<AccountSettings />} />
           <Route path="/login" element={<VendorLogin />} />
           <Route path="/vendor-login" element={<VendorLogin />} />

--- a/sunny_sales_web/src/components/BeachMapVisuals.css
+++ b/sunny_sales_web/src/components/BeachMapVisuals.css
@@ -1,0 +1,27 @@
+.beach-map-visuals {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  padding: 20px 0;
+  background: linear-gradient(180deg, #f5f5f5 0%, #efefef 100%);
+}
+
+.beach-canvas {
+  max-width: 100%;
+  height: auto;
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  display: block;
+}
+
+@media (max-width: 768px) {
+  .beach-map-visuals {
+    padding: 15px 0;
+  }
+
+  .beach-canvas {
+    width: 100%;
+    max-width: 600px;
+  }
+}

--- a/sunny_sales_web/src/components/BeachMapVisuals.jsx
+++ b/sunny_sales_web/src/components/BeachMapVisuals.jsx
@@ -1,0 +1,192 @@
+import React, { useEffect, useRef } from 'react';
+import './BeachMapVisuals.css';
+
+export default function BeachMapVisuals() {
+  const canvasRef = useRef(null);
+
+  useEffect(() => {
+    if (!canvasRef.current) return;
+
+    const canvas = canvasRef.current;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    const width = canvas.width;
+    const height = canvas.height;
+
+    // Cores dos elementos da praia
+    const colors = {
+      sky: '#87CEEB',
+      water: '#0066CC',
+      waterShallow: '#4DB8E8',
+      foam: '#FFFFFF',
+      sand: '#F4D03F',
+      sandDark: '#E8C547',
+      rock: '#8B7355',
+      seaweed: '#228B22',
+      sunlight: 'rgba(255, 255, 200, 0.3)',
+    };
+
+    // Limpa o canvas
+    ctx.fillStyle = colors.sky;
+    ctx.fillRect(0, 0, width, height);
+
+    // Sol
+    const sunX = width * 0.8;
+    const sunY = height * 0.2;
+    const sunRadius = 50;
+    ctx.fillStyle = '#FFD700';
+    ctx.beginPath();
+    ctx.arc(sunX, sunY, sunRadius, 0, Math.PI * 2);
+    ctx.fill();
+
+    // Raios do sol
+    ctx.strokeStyle = 'rgba(255, 215, 0, 0.4)';
+    ctx.lineWidth = 3;
+    for (let i = 0; i < 8; i++) {
+      const angle = (i / 8) * Math.PI * 2;
+      const startX = sunX + Math.cos(angle) * (sunRadius + 20);
+      const startY = sunY + Math.sin(angle) * (sunRadius + 20);
+      const endX = sunX + Math.cos(angle) * (sunRadius + 60);
+      const endY = sunY + Math.sin(angle) * (sunRadius + 60);
+      ctx.beginPath();
+      ctx.moveTo(startX, startY);
+      ctx.lineTo(endX, endY);
+      ctx.stroke();
+    }
+
+    // Gradiente de água (fundo para frente)
+    const waterGradient = ctx.createLinearGradient(0, height * 0.25, 0, height * 0.65);
+    waterGradient.addColorStop(0, colors.water);
+    waterGradient.addColorStop(0.7, colors.waterShallow);
+    waterGradient.addColorStop(1, colors.sandDark);
+
+    // Água
+    ctx.fillStyle = waterGradient;
+    ctx.fillRect(0, height * 0.25, width, height * 0.4);
+
+    // Ondas (padrão de movimento)
+    ctx.strokeStyle = colors.foam;
+    ctx.lineWidth = 2;
+    ctx.globalAlpha = 0.6;
+    for (let wave = 0; wave < 4; wave++) {
+      const waveY = height * (0.3 + wave * 0.08);
+      ctx.beginPath();
+      for (let x = 0; x <= width; x += 20) {
+        const y = waveY + Math.sin((x + wave * 30) / 30) * 8;
+        if (x === 0) ctx.moveTo(x, y);
+        else ctx.lineTo(x, y);
+      }
+      ctx.stroke();
+    }
+    ctx.globalAlpha = 1;
+
+    // Areia
+    ctx.fillStyle = colors.sand;
+    ctx.fillRect(0, height * 0.65, width, height * 0.35);
+
+    // Gradiente de areia (mais escura em baixo)
+    const sandGradient = ctx.createLinearGradient(0, height * 0.65, 0, height);
+    sandGradient.addColorStop(0, colors.sand);
+    sandGradient.addColorStop(1, colors.sandDark);
+    ctx.fillStyle = sandGradient;
+    ctx.fillRect(0, height * 0.65, width, height * 0.35);
+
+    // Padrão de areia (pontos pequenos)
+    ctx.fillStyle = 'rgba(200, 140, 0, 0.2)';
+    for (let i = 0; i < 200; i++) {
+      const x = Math.random() * width;
+      const y = height * 0.65 + Math.random() * (height * 0.35);
+      const radius = Math.random() * 2;
+      ctx.beginPath();
+      ctx.arc(x, y, radius, 0, Math.PI * 2);
+      ctx.fill();
+    }
+
+    // Espuma/Mar na fronteira
+    ctx.fillStyle = colors.foam;
+    ctx.globalAlpha = 0.8;
+    ctx.beginPath();
+    for (let x = 0; x <= width; x += 15) {
+      const y = height * 0.62 + Math.sin(x / 40) * 15;
+      if (x === 0) ctx.moveTo(x, y);
+      else ctx.lineTo(x, y);
+    }
+    ctx.lineTo(width, height * 0.62);
+    ctx.lineTo(0, height * 0.62);
+    ctx.closePath();
+    ctx.fill();
+    ctx.globalAlpha = 1;
+
+    // Algas/Vegetação no lado esquerdo
+    ctx.fillStyle = colors.seaweed;
+    ctx.globalAlpha = 0.7;
+    for (let i = 0; i < 5; i++) {
+      const startX = width * 0.1 + i * width * 0.15;
+      const startY = height * 0.6 + Math.random() * 20;
+      ctx.beginPath();
+      ctx.moveTo(startX, startY);
+      for (let step = 0; step < 5; step++) {
+        const offsetX = Math.sin(step / 3) * 20;
+        const offsetY = 30 + step * 15;
+        ctx.lineTo(startX + offsetX, startY + offsetY);
+      }
+      ctx.lineWidth = 3;
+      ctx.strokeStyle = colors.seaweed;
+      ctx.stroke();
+    }
+    ctx.globalAlpha = 1;
+
+    // Rochas/Pedras na areia
+    const rocks = [
+      { x: width * 0.2, y: height * 0.75, r: 25 },
+      { x: width * 0.5, y: height * 0.8, r: 30 },
+      { x: width * 0.8, y: height * 0.72, r: 20 },
+      { x: width * 0.35, y: height * 0.85, r: 18 },
+    ];
+
+    rocks.forEach(rock => {
+      ctx.fillStyle = colors.rock;
+      ctx.beginPath();
+      ctx.ellipse(rock.x, rock.y, rock.r, rock.r * 0.7, 0.3, 0, Math.PI * 2);
+      ctx.fill();
+
+      // Sombra nas rochas
+      ctx.fillStyle = 'rgba(0, 0, 0, 0.3)';
+      ctx.beginPath();
+      ctx.ellipse(rock.x + 5, rock.y + 8, rock.r * 0.6, rock.r * 0.3, 0.3, 0, Math.PI * 2);
+      ctx.fill();
+    });
+
+    // Guarda-sol (representado por triângulo)
+    const umbrellaX = width * 0.7;
+    const umbrellaY = height * 0.7;
+    ctx.fillStyle = '#FF6B6B';
+    ctx.beginPath();
+    ctx.moveTo(umbrellaX, umbrellaY - 40);
+    ctx.lineTo(umbrellaX - 35, umbrellaY + 20);
+    ctx.lineTo(umbrellaX + 35, umbrellaY + 20);
+    ctx.closePath();
+    ctx.fill();
+
+    // Haste do guarda-sol
+    ctx.strokeStyle = '#8B4513';
+    ctx.lineWidth = 4;
+    ctx.beginPath();
+    ctx.moveTo(umbrellaX, umbrellaY + 20);
+    ctx.lineTo(umbrellaX, umbrellaY + 60);
+    ctx.stroke();
+
+  }, []);
+
+  return (
+    <div className="beach-map-visuals">
+      <canvas
+        ref={canvasRef}
+        width={800}
+        height={600}
+        className="beach-canvas"
+      />
+    </div>
+  );
+}

--- a/sunny_sales_web/src/pages/BeachVisualization.css
+++ b/sunny_sales_web/src/pages/BeachVisualization.css
@@ -1,0 +1,179 @@
+.beach-visualization-page {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  background: linear-gradient(135deg, #f5f7fa 0%, #c3cfe2 100%);
+}
+
+.beach-viz-header {
+  background: white;
+  border-bottom: 1px solid #e0e0e0;
+  padding: 20px;
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+}
+
+.beach-viz-back {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: #666;
+  text-decoration: none;
+  font-weight: 500;
+  transition: color 0.2s;
+}
+
+.beach-viz-back:hover {
+  color: #333;
+}
+
+.beach-viz-title {
+  font-size: 28px;
+  font-weight: 700;
+  margin: 0;
+  color: #1a1a1a;
+}
+
+.beach-viz-main {
+  flex: 1;
+  padding: 40px 20px;
+}
+
+.beach-viz-section {
+  max-width: 1000px;
+  margin: 0 auto 40px;
+  background: white;
+  border-radius: 12px;
+  padding: 40px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.1);
+}
+
+.beach-viz-content {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 40px;
+  align-items: start;
+}
+
+.beach-viz-description h2 {
+  font-size: 24px;
+  font-weight: 600;
+  margin: 0 0 16px 0;
+  color: #1a1a1a;
+}
+
+.beach-viz-description p {
+  color: #666;
+  line-height: 1.6;
+  margin: 0 0 20px 0;
+}
+
+.beach-viz-legend {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+}
+
+.beach-viz-legend li {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: #555;
+  font-size: 14px;
+}
+
+.legend-color {
+  display: inline-block;
+  width: 24px;
+  height: 24px;
+  border-radius: 4px;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+}
+
+.beach-viz-info {
+  max-width: 1000px;
+  margin: 0 auto;
+  background: white;
+  border-radius: 12px;
+  padding: 40px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.1);
+}
+
+.beach-viz-info-content h2 {
+  font-size: 24px;
+  font-weight: 600;
+  margin: 0 0 16px 0;
+  color: #1a1a1a;
+}
+
+.beach-viz-info-content p {
+  color: #666;
+  line-height: 1.6;
+  margin: 0 0 30px 0;
+}
+
+.beach-viz-elements {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+}
+
+.element-card {
+  background: #f8f9fb;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  padding: 20px;
+  transition: transform 0.2s, box-shadow 0.2s;
+}
+
+.element-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.1);
+}
+
+.element-card h3 {
+  font-size: 18px;
+  font-weight: 600;
+  margin: 0 0 10px 0;
+  color: #1a1a1a;
+}
+
+.element-card p {
+  font-size: 14px;
+  color: #666;
+  line-height: 1.5;
+  margin: 0;
+}
+
+@media (max-width: 768px) {
+  .beach-viz-header {
+    padding: 16px;
+  }
+
+  .beach-viz-title {
+    font-size: 20px;
+  }
+
+  .beach-viz-main {
+    padding: 20px 10px;
+  }
+
+  .beach-viz-section,
+  .beach-viz-info {
+    padding: 20px;
+  }
+
+  .beach-viz-content {
+    grid-template-columns: 1fr;
+    gap: 20px;
+  }
+
+  .beach-viz-elements {
+    grid-template-columns: 1fr;
+  }
+}

--- a/sunny_sales_web/src/pages/BeachVisualization.jsx
+++ b/sunny_sales_web/src/pages/BeachVisualization.jsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import BeachMapVisuals from '../components/BeachMapVisuals';
+import { FiArrowLeft } from 'react-icons/fi';
+import './BeachVisualization.css';
+
+export default function BeachVisualization() {
+  return (
+    <div className="beach-visualization-page">
+      <header className="beach-viz-header">
+        <Link to="/" className="beach-viz-back">
+          <FiArrowLeft size={20} /> Voltar
+        </Link>
+        <h1 className="beach-viz-title">Elementos da Praia</h1>
+      </header>
+
+      <main className="beach-viz-main">
+        <section className="beach-viz-section">
+          <div className="beach-viz-content">
+            <div className="beach-viz-description">
+              <h2>Visualização dos Elementos da Praia</h2>
+              <p>
+                Elementos coloridos que representam os diferentes componentes de uma praia:
+              </p>
+              <ul className="beach-viz-legend">
+                <li><span className="legend-color" style={{ backgroundColor: '#87CEEB' }} />Céu</li>
+                <li><span className="legend-color" style={{ backgroundColor: '#0066CC' }} />Água profunda</li>
+                <li><span className="legend-color" style={{ backgroundColor: '#4DB8E8' }} />Água rasa</li>
+                <li><span className="legend-color" style={{ backgroundColor: '#F4D03F' }} />Areia</li>
+                <li><span className="legend-color" style={{ backgroundColor: '#FFFFFF' }} />Espuma</li>
+                <li><span className="legend-color" style={{ backgroundColor: '#228B22' }} />Algas</li>
+                <li><span className="legend-color" style={{ backgroundColor: '#8B7355' }} />Rochas</li>
+                <li><span className="legend-color" style={{ backgroundColor: '#FF6B6B' }} />Guarda-sol</li>
+              </ul>
+            </div>
+
+            <BeachMapVisuals />
+          </div>
+        </section>
+
+        <section className="beach-viz-info">
+          <div className="beach-viz-info-content">
+            <h2>Sobre o Mapa Visual</h2>
+            <p>
+              Este componente renderiza uma visualização artística de uma praia com elementos
+              coloridos. Cada elemento possui uma cor específica para melhor identificação:
+            </p>
+            <div className="beach-viz-elements">
+              <div className="element-card">
+                <h3>🌊 Água</h3>
+                <p>Representada em azul profundo (#0066CC) que transiciona para tons mais claros
+                   conforme se aproxima da areia, representando a mudança de profundidade.</p>
+              </div>
+              <div className="element-card">
+                <h3>🏖️ Areia</h3>
+                <p>Amarela dourada (#F4D03F) com padrão de textura que simula grãos de areia.
+                   O sombreamento gradual cria profundidade visual.</p>
+              </div>
+              <div className="element-card">
+                <h3>🌊 Espuma</h3>
+                <p>Branca (#FFFFFF) formada na linha de contato entre água e areia, representando
+                   as ondas do mar chegando à praia.</p>
+              </div>
+              <div className="element-card">
+                <h3>🪨 Rochas</h3>
+                <p>Marrom (#8B7355) posicionadas estrategicamente na areia, com sombras para
+                   criar efeito tridimensional realista.</p>
+              </div>
+            </div>
+          </div>
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/sunny_sales_web/src/pages/Home.jsx
+++ b/sunny_sales_web/src/pages/Home.jsx
@@ -10,6 +10,7 @@ import LocateButton from '../components/LocateButton';
 import LocateHint from '../components/LocateHint';
 import WelcomeCard from '../components/WelcomeCard';
 import WeatherCard from '../components/WeatherCard';
+import BeachMapVisuals from '../components/BeachMapVisuals';
 import {
   FiMapPin, FiTag, FiShoppingBag,
   FiSmartphone, FiCreditCard,


### PR DESCRIPTION
Cria componente BeachMapVisuals que renderiza elementos da praia em canvas:
- Água azul (gradiente de tons)
- Areia amarela com sombreamento
- Espuma branca nas ondas
- Sol e raios de luz
- Rochas e pedras
- Guarda-sol decorativo
- Algas/vegetação

O componente desenha uma visualização estilizada da praia com cores
apropriadas para cada elemento, ideal para visualizações de interface
e marketing do projeto.

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01JsVu9xvVwDhwUR3psaseEz