### PR TITLE
Update map tiles to CartoDB Voyager with blue water

### DIFF
--- a/sunny_sales_web/src/components/HomeMapPreview.jsx
+++ b/sunny_sales_web/src/components/HomeMapPreview.jsx
@@ -44,7 +44,7 @@ function MapContent({ vendors, onMapClick }) {
   return (
     <>
       <TileLayer
-        url="https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png"
+        url="https://{s}.basemaps.cartocdn.com/voyager/{z}/{x}/{y}.png"
         attribution="&copy; <a href='https://base.org'>base</a> contributors &copy; <a href='https://carto.com/attributions'>CARTO</a>"
         subdomains="abcd"
         maxZoom={19}

--- a/sunny_sales_web/src/pages/Home.jsx
+++ b/sunny_sales_web/src/pages/Home.jsx
@@ -589,7 +589,7 @@ export default function Home() {
               <MapZoomA11y />
               <MapBearingController targetBearingRef={targetBearingRef} />
               <TileLayer
-                url="https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png"
+                url="https://{s}.basemaps.cartocdn.com/voyager/{z}/{x}/{y}.png"
                 attribution="&copy; <a href='https://base.org'>base</a> contributors &copy; <a href='https://carto.com/attributions'>CARTO</a>"
                 subdomains="abcd"
                 maxZoom={19}

--- a/sunny_sales_web/src/pages/ModernMapLayout.jsx
+++ b/sunny_sales_web/src/pages/ModernMapLayout.jsx
@@ -606,7 +606,7 @@ export default function ModernMapLayout() {
             <MapZoomA11y />
             <MapBearingController targetBearingRef={targetBearingRef} />
             <TileLayer
-              url="https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png"
+              url="https://{s}.basemaps.cartocdn.com/voyager/{z}/{x}/{y}.png"
               attribution="&copy; <a href='https://base.org'>base</a> contributors &copy; <a href='https://carto.com/attributions'>CARTO</a>"
               subdomains="abcd"
               maxZoom={19}

--- a/sunny_sales_web/src/pages/RouteDetail.jsx
+++ b/sunny_sales_web/src/pages/RouteDetail.jsx
@@ -44,7 +44,7 @@ export default function RouteDetail() {
         <div className="rd-map">
           <MapContainer center={initial} zoom={15} style={{ width: '100%', height: '100%' }}>
             <TileLayer
-              url="https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png"
+              url="https://{s}.basemaps.cartocdn.com/voyager/{z}/{x}/{y}.png"
               attribution="&copy; <a href='https://base.org'>base</a> contributors &copy; <a href='https://carto.com/attributions'>CARTO</a>"
               subdomains="abcd"
               maxZoom={19}


### PR DESCRIPTION
Replace gray light_all style with vibrant Voyager style featuring blue water
across all map components for better visual appeal.

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Qhtd74croSVPXnWuHv4D2a