### PR TITLE
Fix map tile loading issue by correcting CARTO tile layer URL

### DIFF
--- a/mobile/src/pages/HomePage.jsx
+++ b/mobile/src/pages/HomePage.jsx
@@ -217,7 +217,7 @@ export default function HomePage() {
                 ref={mapRef}
               >
                 <TileLayer
-                  url="https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}.png"
+                  url="https://{s}.basemaps.cartocdn.com/voyager/{z}/{x}/{y}.png"
                   attribution="&copy; <a href='https://base.org'>base</a> contributors"
                 />
 

--- a/mobile/src/pages/MainScreen.jsx
+++ b/mobile/src/pages/MainScreen.jsx
@@ -257,7 +257,7 @@ export default function MainScreen({ auth, onLogout, onUserUpdate }) {
         {position ? (
           <MapContainer center={position} zoom={16} className="map-container" zoomControl={false}>
             <TileLayer
-              url="https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}.png"
+              url="https://{s}.basemaps.cartocdn.com/voyager/{z}/{x}/{y}.png"
               attribution="&copy; <a href='https://base.org'>base</a> contributors &copy; <a href='https://carto.com/attributions'>CARTO</a>"
             />
             <AnimatedMarker position={position} icon={vendorIcon} />

--- a/mobile/src/pages/MapTab.jsx
+++ b/mobile/src/pages/MapTab.jsx
@@ -209,7 +209,7 @@ export default function MapTab({ auth, onChangePage, onLogout, onUserUpdate }) {
         {position ? (
           <MapContainer center={position} zoom={16} className="map-container" zoomControl={false}>
             <TileLayer
-              url="https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}.png"
+              url="https://{s}.basemaps.cartocdn.com/voyager/{z}/{x}/{y}.png"
               attribution="&copy; <a href='https://base.org'>base</a> contributors &copy; <a href='https://carto.com/attributions'>CARTO</a>"
             />
             <AnimatedMarker position={position} icon={vendorIcon} />


### PR DESCRIPTION
Remove incorrect '/rastertiles/' path from CARTO basemaps URL that was causing 404 errors and preventing map tiles from loading in mobile app.

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TLitS7DT3ag8HmpajhekFG