### PR TITLE
Corrige carregamento do mapa: repõe caminho rastertiles/voyager da CARTO

### DIFF
--- a/mobile/src/pages/HomePage.jsx
+++ b/mobile/src/pages/HomePage.jsx
@@ -217,7 +217,7 @@ export default function HomePage() {
                 ref={mapRef}
               >
                 <TileLayer
-                  url="https://{s}.basemaps.cartocdn.com/voyager/{z}/{x}/{y}.png"
+                  url="https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png"
                   attribution="&copy; <a href='https://base.org'>base</a> contributors"
                 />
 

--- a/mobile/src/pages/MainScreen.jsx
+++ b/mobile/src/pages/MainScreen.jsx
@@ -257,7 +257,7 @@ export default function MainScreen({ auth, onLogout, onUserUpdate }) {
         {position ? (
           <MapContainer center={position} zoom={16} className="map-container" zoomControl={false}>
             <TileLayer
-              url="https://{s}.basemaps.cartocdn.com/voyager/{z}/{x}/{y}.png"
+              url="https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png"
               attribution="&copy; <a href='https://base.org'>base</a> contributors &copy; <a href='https://carto.com/attributions'>CARTO</a>"
             />
             <AnimatedMarker position={position} icon={vendorIcon} />

--- a/mobile/src/pages/MapTab.jsx
+++ b/mobile/src/pages/MapTab.jsx
@@ -209,7 +209,7 @@ export default function MapTab({ auth, onChangePage, onLogout, onUserUpdate }) {
         {position ? (
           <MapContainer center={position} zoom={16} className="map-container" zoomControl={false}>
             <TileLayer
-              url="https://{s}.basemaps.cartocdn.com/voyager/{z}/{x}/{y}.png"
+              url="https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png"
               attribution="&copy; <a href='https://base.org'>base</a> contributors &copy; <a href='https://carto.com/attributions'>CARTO</a>"
             />
             <AnimatedMarker position={position} icon={vendorIcon} />

--- a/sunny_sales_web/src/App.jsx
+++ b/sunny_sales_web/src/App.jsx
@@ -4,6 +4,7 @@ import {
   Route,
   Link,
   NavLink,
+  Navigate,
   useLocation,
 } from 'react-router-dom';
 import { FiUser, FiMenu, FiX } from 'react-icons/fi';
@@ -268,6 +269,9 @@ function AppLayout() {
         <Suspense fallback={<PageLoader />}>
         <Routes>
           <Route path="/" element={<Home />} />
+          {/* O mapa completo vive na página inicial; /map continua a existir
+              como redirect para não deixar links antigos num beco sem saída. */}
+          <Route path="/map" element={<Navigate to="/" replace />} />
           <Route path="/about" element={<About />} />
           <Route path="/sobre-projeto" element={<SobreProjeto />} />
           <Route path="/sustentabilidade" element={<Sustentabilidade />} />

--- a/sunny_sales_web/src/components/HomeMapPreview.jsx
+++ b/sunny_sales_web/src/components/HomeMapPreview.jsx
@@ -19,7 +19,7 @@ function getVendorPinHtml(color) {
   return `<div class="vendor-pin-marker" style="--pin-color: ${safeColor};"></div>`;
 }
 
-function MapContent({ vendors, onMapClick }) {
+function MapContent({ vendors }) {
   const map = useMap();
 
   useEffect(() => {
@@ -44,7 +44,7 @@ function MapContent({ vendors, onMapClick }) {
   return (
     <>
       <TileLayer
-        url="https://{s}.basemaps.cartocdn.com/voyager/{z}/{x}/{y}.png"
+        url="https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png"
         attribution="&copy; <a href='https://base.org'>base</a> contributors &copy; <a href='https://carto.com/attributions'>CARTO</a>"
         subdomains="abcd"
         maxZoom={19}

--- a/sunny_sales_web/src/pages/Home.jsx
+++ b/sunny_sales_web/src/pages/Home.jsx
@@ -589,7 +589,7 @@ export default function Home() {
               <MapZoomA11y />
               <MapBearingController targetBearingRef={targetBearingRef} />
               <TileLayer
-                url="https://{s}.basemaps.cartocdn.com/voyager/{z}/{x}/{y}.png"
+                url="https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png"
                 attribution="&copy; <a href='https://base.org'>base</a> contributors &copy; <a href='https://carto.com/attributions'>CARTO</a>"
                 subdomains="abcd"
                 maxZoom={19}

--- a/sunny_sales_web/src/pages/ModernMapLayout.jsx
+++ b/sunny_sales_web/src/pages/ModernMapLayout.jsx
@@ -606,7 +606,7 @@ export default function ModernMapLayout() {
             <MapZoomA11y />
             <MapBearingController targetBearingRef={targetBearingRef} />
             <TileLayer
-              url="https://{s}.basemaps.cartocdn.com/voyager/{z}/{x}/{y}.png"
+              url="https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png"
               attribution="&copy; <a href='https://base.org'>base</a> contributors &copy; <a href='https://carto.com/attributions'>CARTO</a>"
               subdomains="abcd"
               maxZoom={19}

--- a/sunny_sales_web/src/pages/RouteDetail.jsx
+++ b/sunny_sales_web/src/pages/RouteDetail.jsx
@@ -44,7 +44,7 @@ export default function RouteDetail() {
         <div className="rd-map">
           <MapContainer center={initial} zoom={15} style={{ width: '100%', height: '100%' }}>
             <TileLayer
-              url="https://{s}.basemaps.cartocdn.com/voyager/{z}/{x}/{y}.png"
+              url="https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png"
               attribution="&copy; <a href='https://base.org'>base</a> contributors &copy; <a href='https://carto.com/attributions'>CARTO</a>"
               subdomains="abcd"
               maxZoom={19}


### PR DESCRIPTION
O URL dos tiles usava "voyager/" sem o prefixo "rastertiles/", um caminho
que não existe no CDN da CARTO — todos os pedidos devolviam 404 e o mapa
ficava em branco em todas as páginas (web e mobile). O commit 44279e6
tinha "corrigido" no sentido inverso, removendo o prefixo correto do
mobile em vez de o acrescentar ao web.

- Repõe o template canónico https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png
  nas 7 páginas com mapa (inclui {r} para tiles retina)
- Adiciona redirect /map → / para os links antigos não caírem no 404
  (o mapa completo vive agora na página inicial)
- Remove prop não usada em HomeMapPreview (lint limpo)

Validado com teste Playwright: os 32 pedidos de tiles vão todos para
/rastertiles/voyager/, os tiles renderizam e o skeleton desaparece via
evento load do TileLayer.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01K7KNVz7WS4rPNQZ2VK9stt