### PR TITLE
Corrige localização no mapa: Permissions-Policy bloqueava a geolocalização

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -215,7 +215,7 @@ async def add_security_headers(request: Request, call_next):
     response.headers["Strict-Transport-Security"] = "max-age=31536000; includeSubDomains"
     response.headers["Content-Security-Policy"] = "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline' fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' fonts.gstatic.com; connect-src 'self' https:"
     response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
-    response.headers["Permissions-Policy"] = "geolocation=(), microphone=(), camera=()"
+    response.headers["Permissions-Policy"] = "geolocation=(self), microphone=(), camera=()"
     return response
 
 # Endpoint de verificação de funcionamento da API

--- a/sunny_sales_web/src/components/LocateButton.jsx
+++ b/sunny_sales_web/src/components/LocateButton.jsx
@@ -15,15 +15,22 @@ export default function LocateButton({ type = 'user', data = null, onLocationFou
     } else {
       setLocating(true);
       const onFound = (e) => {
+        map.off('locationerror', onError);
         setLocating(false);
         const { lat, lng } = e.latlng;
         if (onLocationFound) onLocationFound({ lat, lng });
         map.setView([lat, lng], 18, { animate: false });
       };
 
-      const onError = () => {
+      const onError = (e) => {
+        map.off('locationfound', onFound);
         setLocating(false);
-        alert('Não foi possível obter a sua localização.');
+        // code 1 = PERMISSION_DENIED (bloqueado pelo utilizador ou pelo navegador)
+        if (e && e.code === 1) {
+          alert('O acesso à localização está bloqueado. Permita a localização nas definições do navegador e tente novamente.');
+        } else {
+          alert('Não foi possível obter a sua localização. Tente novamente.');
+        }
       };
 
       map.once('locationfound', onFound);


### PR DESCRIPTION
O middleware de security headers enviava "Permissions-Policy:
geolocation=()" em todas as respostas, incluindo o index.html do site.
A lista vazia proíbe a geolocalização para todas as origens (até a
própria), pelo que o browser rejeitava navigator.geolocation sem sequer
mostrar o pedido de permissão: sem ponto azul, filtro de distância
inoperante, meteo sem posição, partilha de localização dos vendedores
bloqueada e o botão de localização a falhar sempre com alerta.

Passa a "geolocation=(self)", que permite geolocalização na própria
origem e continua a negá-la a iframes de terceiros.

No LocateButton, os handlers once de locationfound/locationerror
passam a remover-se mutuamente (evitava alertas duplicados em cliques
seguintes) e o alerta distingue permissão negada de falha temporária.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UfuJtu9yKE9coLr25iG9H4