### PR TITLE
Botão de localização centra de imediato na posição já conhecida

### DIFF
--- a/sunny_sales_web/src/components/LocateButton.jsx
+++ b/sunny_sales_web/src/components/LocateButton.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { useMap } from 'react-leaflet';
 
-export default function LocateButton({ type = 'user', data = null, onLocationFound, onClick, disabled = false }) {
+export default function LocateButton({ type = 'user', data = null, currentPos = null, onLocationFound, onClick, disabled = false }) {
   const map = useMap();
   const [locating, setLocating] = useState(false);
 
@@ -12,6 +12,13 @@ export default function LocateButton({ type = 'user', data = null, onLocationFou
       if (data && data.current_lat && data.current_lng) {
         map.setView([data.current_lat, data.current_lng], 18, { animate: false });
       }
+    } else if (currentPos && currentPos.lat != null && currentPos.lng != null) {
+      // Já temos a posição do watchPosition (o ponto azul no mapa): centra já,
+      // sem esperar por um novo fix de GPS — em telemóveis um pedido de alta
+      // precisão com maximumAge: 0 pode demorar vários segundos ou expirar,
+      // deixando o botão aparentemente morto.
+      if (onLocationFound) onLocationFound({ lat: currentPos.lat, lng: currentPos.lng });
+      map.setView([currentPos.lat, currentPos.lng], 18, { animate: false });
     } else {
       setLocating(true);
       const onFound = (e) => {

--- a/sunny_sales_web/src/pages/Home.jsx
+++ b/sunny_sales_web/src/pages/Home.jsx
@@ -643,6 +643,7 @@ export default function Home() {
                     setIsAutoFollowing={setIsAutoFollowing}
                   />
                   <LocateButton
+                    currentPos={clientPos}
                     onLocationFound={(pos) => {
                       setClientPos(pos);
                       setIsAutoFollowing(true);

--- a/sunny_sales_web/src/pages/ModernMapLayout.jsx
+++ b/sunny_sales_web/src/pages/ModernMapLayout.jsx
@@ -660,6 +660,7 @@ export default function ModernMapLayout() {
                   setIsAutoFollowing={setIsAutoFollowing}
                 />
                 <LocateButton
+                  currentPos={clientPos}
                   onLocationFound={(pos) => {
                     setClientPos(pos);
                     setIsAutoFollowing(true);


### PR DESCRIPTION
O botão "Localizar-me" pedia sempre um fix de GPS novo via map.locate()
(alta precisão, maximumAge: 0) e só centrava o mapa quando esse fix
chegasse. Em telemóveis esse pedido demora vários segundos ou expira
(timeout de 10s), pelo que o clique parecia não fazer nada: o mapa não
se movia e, como o auto-follow só era reativado no locationfound, nem
as posições seguintes do watchPosition voltavam a centrar o mapa.

A app já conhece a posição do utilizador — o watchPosition alimenta o
ponto azul desenhado no mapa. O botão passa a receber essa posição
(currentPos) e centra imediatamente nela, reativando o auto-follow para
que as atualizações seguintes continuem a seguir o utilizador (mesmo
comportamento com o mapa rodado pela bússola, verificado com Playwright).

Sem posição conhecida (primeira visita, permissão ainda não concedida)
mantém-se o fluxo atual: spinner + map.locate(), que despoleta o pedido
de permissão do browser e mostra o alerta adequado em caso de recusa.

O botão do vendedor (setView direto para o pin) já funcionava, incluindo
com rotação ativa, e fica inalterado.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011FoiuVaAAX4x8x1DL4jF61