### PR TITLE
Volta aos tiles CARTO Voyager nos mapas Leaflet

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,12 +39,3 @@ STRIPE_PRICE_ID_MENSAL=
 # Se não definido, os ficheiros são guardados localmente.
 SUPABASE_URL=
 SUPABASE_SERVICE_ROLE_KEY=
-
-# --- Mapas (frontend: sunny_sales_web e mobile) ---
-# OPCIONAL: chave da API do MapTiler para o estilo de mapa "Topo" original.
-# Obtém-se gratuitamente em https://cloud.maptiler.com/account/keys/
-# Define-a no ambiente de BUILD do frontend (ex.: Railway) ou num ficheiro
-# `.env` dentro de `sunny_sales_web/` e de `mobile/`.
-# Sem chave, os mapas usam um estilo topográfico gratuito e sem registo
-# (Esri World Topo), com cores semelhantes.
-VITE_MAPTILER_KEY=

--- a/mobile/src/config.js
+++ b/mobile/src/config.js
@@ -7,27 +7,13 @@ export function mediaUrl(path) {
   return `${BASE_URL.replace(/\/$/, '')}/${path}`;
 }
 
-// (em português) Chave da API do MapTiler, definida em build pela variável
-// `VITE_MAPTILER_KEY` (obtém-se gratuitamente em https://cloud.maptiler.com/account/keys/).
-export const MAPTILER_KEY = import.meta.env.VITE_MAPTILER_KEY || '';
-
-// Estilo do MapTiler usado nos mapas da aplicação.
-export const MAPTILER_STYLE = 'topo-v2';
-
-// Configuração partilhada da camada de tiles (sempre Leaflet; só muda a
-// origem das imagens): com chave usa o estilo "Topo" do MapTiler; sem chave
-// usa o mapa topográfico da Esri, gratuito e sem registo, com cores
-// semelhantes. Usar como `<TileLayer {...TILE_LAYER} />`.
-export const TILE_LAYER = MAPTILER_KEY
-  ? {
-      url: `https://api.maptiler.com/maps/${MAPTILER_STYLE}/256/{z}/{x}/{y}{r}.png?key=${MAPTILER_KEY}`,
-      attribution:
-        '&copy; <a href="https://www.maptiler.com/copyright/">MapTiler</a> &copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap contributors</a>',
-      maxZoom: 19,
-    }
-  : {
-      url: 'https://server.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer/tile/{z}/{y}/{x}',
-      attribution:
-        'Tiles &copy; Esri &mdash; Esri, TomTom, Garmin, FAO, NOAA, USGS, &copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap contributors</a>, and the GIS User Community',
-      maxZoom: 19,
-    };
+// (em português) Configuração partilhada da camada de tiles dos mapas
+// Leaflet: estilo Voyager da CARTO, gratuito e sem chave de API.
+// Usar como `<TileLayer {...TILE_LAYER} />`.
+export const TILE_LAYER = {
+  url: 'https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png',
+  attribution:
+    '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>',
+  subdomains: 'abcd',
+  maxZoom: 19,
+};

--- a/sunny_sales_web/src/config.js
+++ b/sunny_sales_web/src/config.js
@@ -12,27 +12,13 @@ export function mediaUrl(path) {
   return `${BASE_URL.replace(/\/$/, '')}/${path}`;
 }
 
-// (em português) Chave da API do MapTiler, definida em build pela variável
-// `VITE_MAPTILER_KEY` (obtém-se gratuitamente em https://cloud.maptiler.com/account/keys/).
-export const MAPTILER_KEY = import.meta.env.VITE_MAPTILER_KEY || '';
-
-// Estilo do MapTiler usado nos mapas da aplicação.
-export const MAPTILER_STYLE = 'topo-v2';
-
-// Configuração partilhada da camada de tiles (sempre Leaflet; só muda a
-// origem das imagens): com chave usa o estilo "Topo" do MapTiler; sem chave
-// usa o mapa topográfico da Esri, gratuito e sem registo, com cores
-// semelhantes. Usar como `<TileLayer {...TILE_LAYER} />`.
-export const TILE_LAYER = MAPTILER_KEY
-  ? {
-      url: `https://api.maptiler.com/maps/${MAPTILER_STYLE}/256/{z}/{x}/{y}{r}.png?key=${MAPTILER_KEY}`,
-      attribution:
-        '&copy; <a href="https://www.maptiler.com/copyright/">MapTiler</a> &copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap contributors</a>',
-      maxZoom: 19,
-    }
-  : {
-      url: 'https://server.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer/tile/{z}/{y}/{x}',
-      attribution:
-        'Tiles &copy; Esri &mdash; Esri, TomTom, Garmin, FAO, NOAA, USGS, &copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap contributors</a>, and the GIS User Community',
-      maxZoom: 19,
-    };
+// (em português) Configuração partilhada da camada de tiles dos mapas
+// Leaflet: estilo Voyager da CARTO, gratuito e sem chave de API.
+// Usar como `<TileLayer {...TILE_LAYER} />`.
+export const TILE_LAYER = {
+  url: 'https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png',
+  attribution:
+    '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>',
+  subdomains: 'abcd',
+  maxZoom: 19,
+};


### PR DESCRIPTION
Remove o estilo topográfico (MapTiler Topo / Esri World Topo) introduzido
no PR #615: o TILE_LAYER partilhado da web e do mobile volta ao estilo
Voyager da CARTO, gratuito e sem chave de API. A variável
VITE_MAPTILER_KEY deixa de existir e sai do .env.example.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01SJmAA8daFXT9Gv2ykMCCfJ