### PR TITLE
Switch map tiles from CARTO to MapTiler with custom style

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ ss_TESTER/
 | Backend | FastAPI, SQLAlchemy, PostgreSQL / SQLite, JWT, bcrypt, Stripe, WebSocket |
 | Web frontend | React 19, Vite, React Router, Leaflet + react-leaflet, Recharts, Axios |
 | Mobile | Capacitor 7 (Android), React 18, Vite, Leaflet, @capacitor/geolocation |
-| Mapas | Leaflet com tiles CARTO, leaflet-rotate (bússola), Haversine (distâncias) |
+| Mapas | Leaflet com estilo personalizado MapTiler (web) e tiles CARTO (mobile), leaflet-rotate (bússola), Haversine (distâncias) |
 | Pagamentos | Stripe Checkout + Webhooks, semanas pagas com recibos |
 | Autenticação | JWT Bearer tokens, gestão de sessões multi-dispositivo |
 | Tempo real | WebSocket `/ws/locations` para atualizações de posição |

--- a/sunny_sales_web/src/config.js
+++ b/sunny_sales_web/src/config.js
@@ -13,12 +13,18 @@ export function mediaUrl(path) {
 }
 
 // (em português) Configuração partilhada da camada de tiles dos mapas
-// Leaflet: estilo Voyager da CARTO, gratuito e sem chave de API.
-// Usar como `<TileLayer {...TILE_LAYER} />`.
+// Leaflet: estilo personalizado criado no MapTiler (raster tiles 256px,
+// com suporte retina via `{r}`). A chave e o ID do mapa podem ser
+// substituídos pelas variáveis de ambiente `VITE_MAPTILER_KEY` e
+// `VITE_MAPTILER_MAP_ID`. Usar como `<TileLayer {...TILE_LAYER} />`.
+const MAPTILER_KEY = import.meta.env.VITE_MAPTILER_KEY || 'Ru4jRsFJoXg3TmEsFaOC';
+const MAPTILER_MAP_ID =
+  import.meta.env.VITE_MAPTILER_MAP_ID || '019f805d-3125-7863-9a77-ab58ad966b58';
+
 export const TILE_LAYER = {
-  url: 'https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png',
+  url: `https://api.maptiler.com/maps/${MAPTILER_MAP_ID}/256/{z}/{x}/{y}{r}.png?key=${MAPTILER_KEY}`,
   attribution:
-    '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>',
-  subdomains: 'abcd',
+    '&copy; <a href="https://www.maptiler.com/copyright/">MapTiler</a> &copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
   maxZoom: 19,
+  crossOrigin: true,
 };


### PR DESCRIPTION
## Summary
Migrated the web application's map tile provider from CARTO's free Voyager style to a custom MapTiler style, while maintaining support for environment-based configuration.

## Key Changes
- **Tile Provider Migration**: Replaced CARTO basemaps with MapTiler API endpoints
- **Custom Map Style**: Now uses a personalized map style created in MapTiler (256px raster tiles with retina support via `{r}`)
- **Environment Configuration**: Added support for `VITE_MAPTILER_KEY` and `VITE_MAPTILER_MAP_ID` environment variables with sensible defaults
- **Attribution Updates**: Updated map attribution to credit MapTiler and OpenStreetMap contributors
- **CORS Support**: Added `crossOrigin: true` to tile layer configuration
- **Removed Subdomains**: Removed the `subdomains` property as MapTiler doesn't require subdomain distribution
- **Documentation**: Updated README to reflect the new MapTiler tiles for web while noting CARTO tiles remain for mobile

## Implementation Details
- MapTiler credentials are configurable via environment variables, allowing different keys/maps per deployment
- Default credentials are provided as fallback values
- The tile URL structure follows MapTiler's API format: `https://api.maptiler.com/maps/{mapId}/256/{z}/{x}/{y}{r}.png?key={key}`
- Mobile implementation continues to use CARTO tiles (no changes to mobile configuration)

https://claude.ai/code/session_01AjWyD7bnv9sZwJ1nZFs1iP