### PR TITLE
Switch map tiles from MapTiler to CARTO Voyager

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ ss_TESTER/
 | Backend | FastAPI, SQLAlchemy, PostgreSQL / SQLite, JWT, bcrypt, Stripe, WebSocket |
 | Web frontend | React 19, Vite, React Router, Leaflet + react-leaflet, Recharts, Axios |
 | Mobile | Capacitor 7 (Android), React 18, Vite, Leaflet, @capacitor/geolocation |
-| Mapas | Leaflet com estilo personalizado MapTiler (web) e tiles CARTO (mobile), leaflet-rotate (bússola), Haversine (distâncias) |
+| Mapas | Leaflet com tiles CARTO, leaflet-rotate (bússola), Haversine (distâncias) |
 | Pagamentos | Stripe Checkout + Webhooks, semanas pagas com recibos |
 | Autenticação | JWT Bearer tokens, gestão de sessões multi-dispositivo |
 | Tempo real | WebSocket `/ws/locations` para atualizações de posição |

--- a/sunny_sales_web/src/config.js
+++ b/sunny_sales_web/src/config.js
@@ -13,18 +13,12 @@ export function mediaUrl(path) {
 }
 
 // (em português) Configuração partilhada da camada de tiles dos mapas
-// Leaflet: estilo personalizado criado no MapTiler (raster tiles 256px,
-// com suporte retina via `{r}`). A chave e o ID do mapa podem ser
-// substituídos pelas variáveis de ambiente `VITE_MAPTILER_KEY` e
-// `VITE_MAPTILER_MAP_ID`. Usar como `<TileLayer {...TILE_LAYER} />`.
-const MAPTILER_KEY = import.meta.env.VITE_MAPTILER_KEY || 'Ru4jRsFJoXg3TmEsFaOC';
-const MAPTILER_MAP_ID =
-  import.meta.env.VITE_MAPTILER_MAP_ID || '019f805d-3125-7863-9a77-ab58ad966b58';
-
+// Leaflet: estilo Voyager da CARTO, gratuito e sem chave de API.
+// Usar como `<TileLayer {...TILE_LAYER} />`.
 export const TILE_LAYER = {
-  url: `https://api.maptiler.com/maps/${MAPTILER_MAP_ID}/256/{z}/{x}/{y}{r}.png?key=${MAPTILER_KEY}`,
+  url: 'https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png',
   attribution:
-    '&copy; <a href="https://www.maptiler.com/copyright/">MapTiler</a> &copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+    '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>',
+  subdomains: 'abcd',
   maxZoom: 19,
-  crossOrigin: true,
 };


### PR DESCRIPTION
## Summary
Replaced the MapTiler tile layer with CARTO's free Voyager tiles across the web frontend, eliminating the need for API keys and simplifying map configuration.

## Key Changes
- **Tile provider migration**: Changed from MapTiler's custom raster tiles to CARTO's Voyager basemap
  - Removed `VITE_MAPTILER_KEY` and `VITE_MAPTILER_MAP_ID` environment variables
  - Updated tile URL from MapTiler API endpoint to CARTO's CDN (`basemaps.cartocdn.com`)
  - Added `subdomains: 'abcd'` for load balancing across CARTO's tile servers
  - Removed `crossOrigin: true` (no longer needed with CARTO)

- **Attribution updates**: Updated map attribution to properly credit both OpenStreetMap and CARTO

- **Documentation**: Updated README to reflect unified use of CARTO tiles across both web and mobile platforms

## Benefits
- Eliminates dependency on MapTiler API keys and configuration
- Reduces environment variable complexity
- Uses a free, open-source tile provider (CARTO Voyager)
- Simplifies deployment and development setup
- Maintains consistent map styling across web and mobile platforms

https://claude.ai/code/session_01UUXvyS6zxRbN4MPudcN8r9