### PR TITLE
Update vendor API endpoint and field mappings

### DIFF
--- a/mobile/src/pages/HomePage.jsx
+++ b/mobile/src/pages/HomePage.jsx
@@ -52,7 +52,7 @@ export default function HomePage() {
     const loadVendors = async () => {
       try {
         setLoading(true);
-        const response = await fetch(`${BASE_URL}/vendors/public`);
+        const response = await fetch(`${BASE_URL}/vendors`);
         if (!response.ok) throw new Error('Erro ao carregar vendedores');
         const data = await response.json();
         setVendors(data);
@@ -232,10 +232,10 @@ export default function HomePage() {
 
                 {/* Vendor markers */}
                 {filteredVendors.map((vendor) => (
-                  vendor.lat && vendor.lng && (
+                  vendor.current_lat && vendor.current_lng && (
                     <Marker
                       key={vendor.id}
-                      position={[vendor.lat, vendor.lng]}
+                      position={[vendor.current_lat, vendor.current_lng]}
                       icon={L.divIcon({
                         className: '',
                         html: getVendorLocationHtml(vendor.pin_color),
@@ -249,7 +249,7 @@ export default function HomePage() {
                       <Popup>
                         <div className="vendor-popup">
                           <h4>{vendor.name}</h4>
-                          <p>{vendor.business_type || 'Vendedor'}</p>
+                          <p>{vendor.product || 'Vendedor'}</p>
                         </div>
                       </Popup>
                     </Marker>
@@ -307,7 +307,7 @@ export default function HomePage() {
                   </div>
                   <div className="vendor-info">
                     <h4>{vendor.name}</h4>
-                    <p className="vendor-type">{vendor.business_type || 'Vendedor'}</p>
+                    <p className="vendor-type">{vendor.product || 'Vendedor'}</p>
                     <p className="vendor-status">
                       <span className="status-dot online" />
                       Online agora


### PR DESCRIPTION
## Summary
Updated the HomePage component to use the correct vendor API endpoint and align field mappings with the backend schema changes.

## Key Changes
- Changed vendor API endpoint from `/vendors/public` to `/vendors`
- Updated vendor location coordinates from `lat`/`lng` to `current_lat`/`current_lng` fields
- Updated vendor type display from `business_type` to `product` field in both map popups and vendor list

## Implementation Details
These changes reflect updates to the backend API schema:
- The vendor endpoint no longer requires the `/public` suffix
- Location coordinates are now stored as `current_lat` and `current_lng` (likely to support tracking current vs. registered location)
- The vendor classification field has been renamed from `business_type` to `product`

All vendor display logic (map markers and list items) has been updated to use the new field names consistently.

https://claude.ai/code/session_01L3NZoxstsQUW1aZ7t6FCUB