### PR TITLE
Add CORS support for Capacitor mobile app origins

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -201,6 +201,17 @@ else:
         "https://sstester-production.up.railway.app",
     ]
 
+# (em português) Origens da app móvel (Capacitor).
+# No Android, com androidScheme 'https', a WebView serve a app a partir de
+# https://localhost; no iOS a origem é capacitor://localhost. Sem estas
+# origens na lista de CORS, o browser bloqueia as respostas do backend e o
+# fetch falha com "Failed to fetch" no ecrã inicial. São sempre adicionadas
+# (mesmo quando ALLOWED_ORIGINS está definido) para a app móvel funcionar em
+# qualquer configuração de deploy.
+for _mobile_origin in ("https://localhost", "capacitor://localhost", "http://localhost"):
+    if _mobile_origin not in origins:
+        origins.append(_mobile_origin)
+
 app.add_middleware(
     CORSMiddleware,
     allow_origins=origins,

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -768,3 +768,37 @@ def test_subscription_expires_when_validity_passes(client):
     assert resp.status_code == 403
     assert resp.json()["detail"] == "Subscription inactive"
 
+
+def test_cors_allows_capacitor_mobile_origin(client):
+    """A app móvel (Capacitor) faz fetch a partir da origem https://localhost.
+
+    Sem essa origem na lista de CORS, a WebView do Android bloqueia a resposta
+    e o ecrã inicial mostra "Failed to fetch". Este teste garante que a origem
+    da app móvel é aceite tanto num pedido simples como no preflight.
+    """
+    # Pedido simples (GET) — cenário exato do ecrã inicial a carregar /vendors.
+    resp = client.get("/vendors/", headers={"Origin": "https://localhost"})
+    assert resp.status_code == 200
+    assert resp.headers.get("access-control-allow-origin") == "https://localhost"
+
+    # Preflight (OPTIONS) para um pedido autenticado a partir da app móvel.
+    resp = client.options(
+        "/vendors/",
+        headers={
+            "Origin": "https://localhost",
+            "Access-Control-Request-Method": "GET",
+            "Access-Control-Request-Headers": "authorization",
+        },
+    )
+    assert resp.status_code == 200
+    assert resp.headers.get("access-control-allow-origin") == "https://localhost"
+
+
+def test_cors_rejects_unknown_origin(client):
+    """Origens não autorizadas continuam sem receber cabeçalhos de CORS."""
+    resp = client.get(
+        "/vendors/", headers={"Origin": "https://malicious.example.com"}
+    )
+    assert resp.status_code == 200
+    assert "access-control-allow-origin" not in resp.headers
+


### PR DESCRIPTION
## Summary
This PR adds CORS (Cross-Origin Resource Sharing) support for the Capacitor mobile application by allowing requests from mobile origins (`https://localhost`, `capacitor://localhost`, and `http://localhost`) to be processed by the backend.

## Changes Made
- **backend/app/main.py**: Added mobile app origins to the CORS allowed origins list. These origins are always included regardless of the `ALLOWED_ORIGINS` configuration to ensure the mobile app functions correctly across all deployment environments.
- **tests/test_main.py**: Added two new test cases:
  - `test_cors_allows_capacitor_mobile_origin`: Verifies that both simple GET requests and CORS preflight OPTIONS requests from `https://localhost` receive proper CORS headers
  - `test_cors_rejects_unknown_origin`: Confirms that unauthorized origins do not receive CORS headers

## Implementation Details
The mobile origins are added to the CORS middleware configuration in a way that ensures they are always present in the allowed origins list. This is necessary because:
- On Android with `androidScheme: 'https'`, the Capacitor WebView serves the app from `https://localhost`
- On iOS, the origin is `capacitor://localhost`
- Without these origins in the CORS allowlist, the browser blocks responses and requests fail with "Failed to fetch" errors on the mobile app's initial screen

The implementation includes both simple request handling (GET) and preflight request handling (OPTIONS with Access-Control-Request-* headers).

https://claude.ai/code/session_01TP8pdG6r1CJcxGSVfUF9u4